### PR TITLE
Add metric metadata

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -25,10 +25,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"datadog_downtime":  resourceDatadogDowntime(),
-			"datadog_monitor":   resourceDatadogMonitor(),
-			"datadog_timeboard": resourceDatadogTimeboard(),
-			"datadog_user":      resourceDatadogUser(),
+			"datadog_downtime":        resourceDatadogDowntime(),
+			"datadog_metric_metadata": resourceDatadogMetricMetadata(),
+			"datadog_monitor":         resourceDatadogMonitor(),
+			"datadog_timeboard":       resourceDatadogTimeboard(),
+			"datadog_user":            resourceDatadogUser(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/datadog/resource_datadog_metric_metadata.go
+++ b/datadog/resource_datadog_metric_metadata.go
@@ -1,0 +1,161 @@
+package datadog
+
+import (
+	"fmt"
+	"strings"
+
+	datadog "gopkg.in/zorkian/go-datadog-api.v2"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDatadogMetricMetadata() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDatadogMetricMetadataCreate,
+		Read:   resourceDatadogMetricMetadataRead,
+		Update: resourceDatadogMetricMetadataUpdate,
+		Delete: resourceDatadogMetricMetadataDelete,
+		Exists: resourceDatadogMetricMetadataExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceDatadogMetricMetadataImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"metric": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"short_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"per_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"statsd_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildMetricMetadataStruct(d *schema.ResourceData) (string, *datadog.MetricMetadata) {
+	return d.Get("metric").(string), &datadog.MetricMetadata{
+		Type:           datadog.String(d.Get("type").(string)),
+		Description:    datadog.String(d.Get("description").(string)),
+		ShortName:      datadog.String(d.Get("short_name").(string)),
+		Unit:           datadog.String(d.Get("unit").(string)),
+		PerUnit:        datadog.String(d.Get("per_unit").(string)),
+		StatsdInterval: datadog.Int(d.Get("statsd_interval").(int)),
+	}
+}
+
+func resourceDatadogMetricMetadataExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+	// Exists - This is called to verify a resource still exists. It is called prior to Read,
+	// and lowers the burden of Read to be able to assume the resource exists.
+	client := meta.(*datadog.Client)
+
+	id, _ := buildMetricMetadataStruct(d)
+
+	if _, err := client.ViewMetricMetadata(id); err != nil {
+		fmt.Println("view:", err)
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func resourceDatadogMetricMetadataCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*datadog.Client)
+
+	id, m := buildMetricMetadataStruct(d)
+	_, err := client.EditMetricMetadata(id, m)
+	if err != nil {
+		fmt.Println("this si the err:", err)
+		return fmt.Errorf("error updating MetricMetadata: %s", err.Error())
+	}
+
+	d.SetId(id)
+
+	return nil
+}
+
+func resourceDatadogMetricMetadataRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*datadog.Client)
+
+	id, _ := buildMetricMetadataStruct(d)
+
+	m, err := client.ViewMetricMetadata(id)
+	if err != nil {
+		return err
+	}
+
+	d.Set("type", m.GetType())
+	d.Set("description", m.GetDescription())
+	d.Set("short_name", m.GetShortName())
+	d.Set("unit", m.GetUnit())
+	d.Set("per_unit", m.GetPerUnit())
+	d.Set("statsd_interval", m.GetStatsdInterval())
+
+	return nil
+}
+
+func resourceDatadogMetricMetadataUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*datadog.Client)
+
+	m := &datadog.MetricMetadata{}
+	id := d.Get("metric").(string)
+
+	if attr, ok := d.GetOk("type"); ok {
+		m.SetType(attr.(string))
+	}
+	if attr, ok := d.GetOk("description"); ok {
+		m.SetDescription(attr.(string))
+	}
+	if attr, ok := d.GetOk("short_name"); ok {
+		m.SetShortName(attr.(string))
+	}
+	if attr, ok := d.GetOk("unit"); ok {
+		m.SetUnit(attr.(string))
+	}
+	if attr, ok := d.GetOk("per_unit"); ok {
+		m.SetPerUnit(attr.(string))
+	}
+	if attr, ok := d.GetOk("statsd_interval"); ok {
+		m.SetStatsdInterval(attr.(int))
+	}
+
+	if _, err := client.EditMetricMetadata(id, m); err != nil {
+		return fmt.Errorf("error updating MetricMetadata: %s", err.Error())
+	}
+
+	return resourceDatadogMetricMetadataRead(d, meta)
+}
+
+func resourceDatadogMetricMetadataDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceDatadogMetricMetadataImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceDatadogMetricMetadataRead(d, meta); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/datadog/resource_datadog_metric_metadata_test.go
+++ b/datadog/resource_datadog_metric_metadata_test.go
@@ -1,0 +1,137 @@
+package datadog
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	datadog "gopkg.in/zorkian/go-datadog-api.v2"
+)
+
+func TestAccDatadogMetricMetadata_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: postEvent,
+				Config:    testAccCheckDatadogMetricMetadataConfig,
+				Check: resource.ComposeTestCheckFunc(
+					checkMetricMetadataExists("datadog_metric_metadata.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "short_name", "short name for metric_metadata foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "type", "gauge"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "description", "some description"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "unit", "byte"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "per_unit", "second"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "statsd_interval", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatadogMetricMetadata_Updated(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: postEvent,
+				Config:    testAccCheckDatadogMetricMetadataConfig,
+				Check: resource.ComposeTestCheckFunc(
+					checkMetricMetadataExists("datadog_metric_metadata.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "short_name", "short name for metric_metadata foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "type", "gauge"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "description", "some description"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "unit", "byte"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "per_unit", "second"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "statsd_interval", "1"),
+				),
+			},
+			{
+				Config: testAccCheckDatadogMetricMetadataConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					checkMetricMetadataExists("datadog_metric_metadata.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "short_name", "short name for metric_metadata foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "type", "gauge"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "description", "a different description"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "unit", "byte"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "per_unit", "second"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_metadata.foo", "statsd_interval", "1"),
+				),
+			},
+		},
+	})
+}
+
+func checkMetricMetadataExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*datadog.Client)
+		for _, r := range s.RootModule().Resources {
+			metric, ok := r.Primary.Attributes["metric"]
+			if !ok {
+				continue
+			}
+			if _, err := client.ViewMetricMetadata(metric); err != nil {
+				return fmt.Errorf("Received an error retrieving metric_metadata %s", err)
+			}
+		}
+		return nil
+	}
+}
+
+func postEvent() {
+	client := testAccProvider.Meta().(*datadog.Client)
+	metric := datadog.Metric{
+		Metric: datadog.String("foo"),
+		Points: []datadog.DataPoint{{float64(time.Now().Unix()), 1}},
+	}
+	if err := client.PostMetrics([]datadog.Metric{metric}); err != nil {
+		log.Fatalf("Failed to post `foo` metric: %s\n", err.Error())
+	}
+}
+
+const testAccCheckDatadogMetricMetadataConfig = `
+resource "datadog_metric_metadata" "foo" {
+  metric = "foo"
+  short_name = "short name for metric_metadata foo"
+  type = "gauge"
+  description = "some description"
+  unit = "byte"
+  per_unit = "second"
+  statsd_interval = "1"
+}
+`
+
+const testAccCheckDatadogMetricMetadataConfigUpdated = `
+resource "datadog_metric_metadata" "foo" {
+  metric = "foo"
+  short_name = "short name for metric_metadata foo"
+  type = "gauge"
+  description = "a different description"
+  unit = "byte"
+  per_unit = "second"
+  statsd_interval = "1"
+}
+`

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/datadog-accessors.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/datadog-accessors.go
@@ -7205,6 +7205,192 @@ func (m *Metric) SetUnit(v string) {
 	m.Unit = &v
 }
 
+// GetDescription returns the Description field if non-nil, zero value otherwise.
+func (m *MetricMetadata) GetDescription() string {
+	if m == nil || m.Description == nil {
+		return ""
+	}
+	return *m.Description
+}
+
+// GetOkDescription returns a tuple with the Description field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *MetricMetadata) GetDescriptionOk() (string, bool) {
+	if m == nil || m.Description == nil {
+		return "", false
+	}
+	return *m.Description, true
+}
+
+// HasDescription returns a boolean if a field has been set.
+func (m *MetricMetadata) HasDescription() bool {
+	if m != nil && m.Description != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetDescription allocates a new m.Description and returns the pointer to it.
+func (m *MetricMetadata) SetDescription(v string) {
+	m.Description = &v
+}
+
+// GetPerUnit returns the PerUnit field if non-nil, zero value otherwise.
+func (m *MetricMetadata) GetPerUnit() string {
+	if m == nil || m.PerUnit == nil {
+		return ""
+	}
+	return *m.PerUnit
+}
+
+// GetOkPerUnit returns a tuple with the PerUnit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *MetricMetadata) GetPerUnitOk() (string, bool) {
+	if m == nil || m.PerUnit == nil {
+		return "", false
+	}
+	return *m.PerUnit, true
+}
+
+// HasPerUnit returns a boolean if a field has been set.
+func (m *MetricMetadata) HasPerUnit() bool {
+	if m != nil && m.PerUnit != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetPerUnit allocates a new m.PerUnit and returns the pointer to it.
+func (m *MetricMetadata) SetPerUnit(v string) {
+	m.PerUnit = &v
+}
+
+// GetShortName returns the ShortName field if non-nil, zero value otherwise.
+func (m *MetricMetadata) GetShortName() string {
+	if m == nil || m.ShortName == nil {
+		return ""
+	}
+	return *m.ShortName
+}
+
+// GetOkShortName returns a tuple with the ShortName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *MetricMetadata) GetShortNameOk() (string, bool) {
+	if m == nil || m.ShortName == nil {
+		return "", false
+	}
+	return *m.ShortName, true
+}
+
+// HasShortName returns a boolean if a field has been set.
+func (m *MetricMetadata) HasShortName() bool {
+	if m != nil && m.ShortName != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetShortName allocates a new m.ShortName and returns the pointer to it.
+func (m *MetricMetadata) SetShortName(v string) {
+	m.ShortName = &v
+}
+
+// GetStatsdInterval returns the StatsdInterval field if non-nil, zero value otherwise.
+func (m *MetricMetadata) GetStatsdInterval() int {
+	if m == nil || m.StatsdInterval == nil {
+		return 0
+	}
+	return *m.StatsdInterval
+}
+
+// GetOkStatsdInterval returns a tuple with the StatsdInterval field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *MetricMetadata) GetStatsdIntervalOk() (int, bool) {
+	if m == nil || m.StatsdInterval == nil {
+		return 0, false
+	}
+	return *m.StatsdInterval, true
+}
+
+// HasStatsdInterval returns a boolean if a field has been set.
+func (m *MetricMetadata) HasStatsdInterval() bool {
+	if m != nil && m.StatsdInterval != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetStatsdInterval allocates a new m.StatsdInterval and returns the pointer to it.
+func (m *MetricMetadata) SetStatsdInterval(v int) {
+	m.StatsdInterval = &v
+}
+
+// GetType returns the Type field if non-nil, zero value otherwise.
+func (m *MetricMetadata) GetType() string {
+	if m == nil || m.Type == nil {
+		return ""
+	}
+	return *m.Type
+}
+
+// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *MetricMetadata) GetTypeOk() (string, bool) {
+	if m == nil || m.Type == nil {
+		return "", false
+	}
+	return *m.Type, true
+}
+
+// HasType returns a boolean if a field has been set.
+func (m *MetricMetadata) HasType() bool {
+	if m != nil && m.Type != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetType allocates a new m.Type and returns the pointer to it.
+func (m *MetricMetadata) SetType(v string) {
+	m.Type = &v
+}
+
+// GetUnit returns the Unit field if non-nil, zero value otherwise.
+func (m *MetricMetadata) GetUnit() string {
+	if m == nil || m.Unit == nil {
+		return ""
+	}
+	return *m.Unit
+}
+
+// GetOkUnit returns a tuple with the Unit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *MetricMetadata) GetUnitOk() (string, bool) {
+	if m == nil || m.Unit == nil {
+		return "", false
+	}
+	return *m.Unit, true
+}
+
+// HasUnit returns a boolean if a field has been set.
+func (m *MetricMetadata) HasUnit() bool {
+	if m != nil && m.Unit != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetUnit allocates a new m.Unit and returns the pointer to it.
+func (m *MetricMetadata) SetUnit(v string) {
+	m.Unit = &v
+}
+
 // GetCreator returns the Creator field if non-nil, zero value otherwise.
 func (m *Monitor) GetCreator() Creator {
 	if m == nil || m.Creator == nil {

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/metric_metadata.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/metric_metadata.go
@@ -1,0 +1,39 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2013 by authors and contributors.
+ */
+
+package datadog
+
+import "fmt"
+
+// MetricMetadata allows you to edit fields of a metric's metadata.
+type MetricMetadata struct {
+	Type           *string `json:"type,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	ShortName      *string `json:"short_name,omitempty"`
+	Unit           *string `json:"unit,omitempty"`
+	PerUnit        *string `json:"per_unit,omitempty"`
+	StatsdInterval *int    `json:"statsd_interval,omitempty"`
+}
+
+// ViewMetricMetadata allows you to get metadata about a specific metric.
+func (client *Client) ViewMetricMetadata(mn string) (*MetricMetadata, error) {
+	var out MetricMetadata
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/metrics/%s", mn), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// EditMetricMetadata edits the metadata for the given metric.
+func (client *Client) EditMetricMetadata(mn string, mm *MetricMetadata) (*MetricMetadata, error) {
+	var out MetricMetadata
+	if err := client.doJsonRequest("PUT", fmt.Sprintf("/v1/metrics/%s", mn), mm, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/series.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/series.go
@@ -8,7 +8,10 @@
 
 package datadog
 
-import "strconv"
+import (
+	"net/url"
+	"strconv"
+)
 
 // DataPoint is a tuple of [UNIX timestamp, value]. This has to use floats
 // because the value could be non-integer.
@@ -59,9 +62,14 @@ func (client *Client) PostMetrics(series []Metric) error {
 // QueryMetrics takes as input from, to (seconds from Unix Epoch) and query string and then requests
 // timeseries data for that time peried
 func (client *Client) QueryMetrics(from, to int64, query string) ([]Series, error) {
+	v := url.Values{}
+	v.Add("from", strconv.FormatInt(from, 10))
+	v.Add("to", strconv.FormatInt(to, 10))
+	v.Add("query", query)
+
 	var out reqMetrics
-	if err := client.doJsonRequest("GET", "/v1/query?from="+strconv.FormatInt(from, 10)+"&to="+strconv.FormatInt(to, 10)+"&query="+query,
-		nil, &out); err != nil {
+	err := client.doJsonRequest("GET", "/v1/query?"+v.Encode(), nil, &out)
+	if err != nil {
 		return nil, err
 	}
 	return out.Series, nil

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/snapshot.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/snapshot.go
@@ -14,19 +14,32 @@ import (
 	"time"
 )
 
-// Snapshot creates an image from a graph and returns the URL of the image.
-func (client *Client) Snapshot(query string, start, end time.Time, eventQuery string) (string, error) {
-	v := url.Values{}
-	v.Add("start", fmt.Sprintf("%d", start.Unix()))
-	v.Add("end", fmt.Sprintf("%d", end.Unix()))
-	v.Add("metric_query", query)
-	v.Add("event_query", eventQuery)
-
+func (client *Client) doSnapshotRequest(values url.Values) (string, error) {
 	out := struct {
 		SnapshotURL string `json:"snapshot_url,omitempty"`
 	}{}
-	if err := client.doJsonRequest("GET", "/v1/graph/snapshot?"+v.Encode(), nil, &out); err != nil {
+	if err := client.doJsonRequest("GET", "/v1/graph/snapshot?"+values.Encode(), nil, &out); err != nil {
 		return "", err
 	}
 	return out.SnapshotURL, nil
+}
+
+// Snapshot creates an image from a graph and returns the URL of the image.
+func (client *Client) Snapshot(query string, start, end time.Time, eventQuery string) (string, error) {
+	options := map[string]string{"metric_query": query, "event_query": eventQuery}
+
+	return client.SnapshotGeneric(options, start, end)
+}
+
+// Generic function for snapshots, use map[string]string to create url.Values() instead of pre-defined params
+func (client *Client) SnapshotGeneric(options map[string]string, start, end time.Time) (string, error) {
+	v := url.Values{}
+	v.Add("start", fmt.Sprintf("%d", start.Unix()))
+	v.Add("end", fmt.Sprintf("%d", end.Unix()))
+
+	for opt, val := range options {
+		v.Add(opt, val)
+	}
+
+	return client.doSnapshotRequest(v)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -628,10 +628,10 @@
 			"revisionTime": "2017-08-04T00:04:37Z"
 		},
 		{
-			"checksumSHA1": "WI/b3b5dn9P+yWQRHd1gOebLxbw=",
+			"checksumSHA1": "kR5VZQ/g5RdSY0JPFqLenWdUEws=",
 			"path": "gopkg.in/zorkian/go-datadog-api.v2",
-			"revision": "7069eb831c018b4c3f224e42edcad7d9ae3bbeea",
-			"revisionTime": "2017-05-15T05:26:33Z"
+			"revision": "6db99b254ab9c82020abcdc8f702f6075f438603",
+			"revisionTime": "2017-08-30T04:48:20Z"
 		},
 		{
 			"checksumSHA1": "wICWAGQfZcHD2y0dHesz9R2YSiw=",

--- a/website/docs/r/metric_metadata.html.markdown
+++ b/website/docs/r/metric_metadata.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "datadog"
+page_title: "Datadog: datadog_metric_metadata"
+sidebar_current: "docs-datadog-resource-metric_metadata"
+description: |-
+  Provides a Datadog metric metadata resource. This can be used to manage a metric's metadata.
+---
+
+# datadog_metric_metadata
+
+Provides a Datadog metric_metadata resource. This can be used to manage a metric's metadata.
+
+## Example Usage
+
+```hcl
+# Manage a Datadog metric's metadata
+resource "datadog_metric_metadata" "request_time" {
+  metric = "request.time"
+  short_name = "Request time"
+  description = "99th percentile request time in millseconds"
+  type = "gauge"
+  unit = "millisecond"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metric` - (Required) The name of the metric.
+* `description` - (Optional) A description of the metric.
+* `short_name` - (Optional) A short name of the metric.
+* `unit` - (Optional) Primary unit of the metric such as 'byte' or 'operation'.
+* `per_unit` - (Optional) 'Per' unit of the metric such as 'second' in 'bytes per second'.
+* `statsd_interval` - (Optional) If applicable, stasd flush interval in seconds for the metric.
+


### PR DESCRIPTION
- Adds a resource for [metric metadata](https://docs.datadoghq.com/api/#metrics-metadata-update).
- This would allow you to edit metric metadata, for instance, adding a description for a metric to let other people know what the metric means and its values should be, or to set the unit of a metric, and so on.
- Metric metadata are read and update only, they're created automatically when you send a metric to DD.
- [My PR for go-datadog-api dep adding support for metric metadata](https://github.com/zorkian/go-datadog-api/pull/109).