### PR TITLE
Implement monitor_id support for downtime

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -86,6 +86,10 @@ func resourceDatadogDowntime() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"monitor_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -104,6 +108,9 @@ func buildDowntimeStruct(d *schema.ResourceData) *datadog.Downtime {
 	}
 	if attr, ok := d.GetOk("message"); ok {
 		dt.SetMessage(strings.TrimSpace(attr.(string)))
+	}
+	if attr, ok := d.GetOk("monitor_id"); ok {
+		dt.SetMonitorId(attr.(int))
 	}
 	if _, ok := d.GetOk("recurrence"); ok {
 		var recurrence datadog.Recurrence
@@ -194,6 +201,8 @@ func resourceDatadogDowntimeRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("disabled", dt.GetDisabled())
 	d.Set("end", dt.GetEnd())
 	d.Set("message", dt.GetMessage())
+	d.Set("monitor_id", dt.GetMonitorId())
+
 	if r, ok := dt.GetRecurrenceOk(); ok {
 		recurrence := make(map[string]interface{})
 		recurrenceList := make([]map[string]interface{}, 0, 1)
@@ -248,6 +257,9 @@ func resourceDatadogDowntimeUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	if attr, ok := d.GetOk("message"); ok {
 		dt.SetMessage(attr.(string))
+	}
+	if attr, ok := d.GetOk("monitor_id"); ok {
+		dt.SetMonitorId(attr.(int))
 	}
 
 	if _, ok := d.GetOk("recurrence"); ok {

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -197,11 +197,22 @@ func resourceDatadogDowntimeRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] downtime: %v", dt)
-	d.Set("active", dt.GetActive())
-	d.Set("disabled", dt.GetDisabled())
-	d.Set("end", dt.GetEnd())
-	d.Set("message", dt.GetMessage())
-	d.Set("monitor_id", dt.GetMonitorId())
+
+	if err := d.Set("active", dt.GetActive()); err != nil {
+		return err
+	}
+	if err := d.Set("disabled", dt.GetDisabled()); err != nil {
+		return err
+	}
+	if err := d.Set("end", dt.GetEnd()); err != nil {
+		return err
+	}
+	if err := d.Set("message", dt.GetMessage()); err != nil {
+		return err
+	}
+	if err := d.Set("monitor_id", dt.GetMonitorId()); err != nil {
+		return err
+	}
 
 	if r, ok := dt.GetRecurrenceOk(); ok {
 		recurrence := make(map[string]interface{})

--- a/datadog/resource_datadog_downtime_test.go
+++ b/datadog/resource_datadog_downtime_test.go
@@ -229,8 +229,6 @@ func TestAccDatadogDowntime_Updated(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
-					resource.TestCheckResourceAttr(
-						"datadog_downtime.foo", "monitor_id", "1234"),
 				),
 			},
 			resource.TestStep{
@@ -249,8 +247,6 @@ func TestAccDatadogDowntime_Updated(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "3"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
-					resource.TestCheckResourceAttr(
-						"datadog_downtime.foo", "monitor_id", "5678"),
 				),
 			},
 		},
@@ -332,11 +328,11 @@ resource "datadog_monitor" "downtime_monitor" {
   query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"
 
   thresholds {
-	warning = "1.0"
-	critical = "2.0"
+		warning = "1.0"
+		critical = "2.0"
 	}
 	silenced {
-		"*" : %d
+		"*" = %d
 	}
 }
 
@@ -419,7 +415,7 @@ resource "datadog_downtime" "foo" {
 	week_days = ["Sat", "Sun"]
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
 }
 `
 
@@ -435,7 +431,6 @@ resource "datadog_downtime" "foo" {
   }
 
   message = "Example Datadog downtime message."
-  monitor_id = 5678
 }
 `
 

--- a/datadog/resource_datadog_downtime_test.go
+++ b/datadog/resource_datadog_downtime_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -33,6 +34,27 @@ func TestAccDatadogDowntime_Basic(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatadogDowntime_BasicWithMonitor(t *testing.T) {
+	start := time.Now().Local().Add(time.Hour * time.Duration(3))
+	end := start.Add(time.Hour * time.Duration(1))
+
+	config := testAccCheckDatadogDowntimeConfigWithMonitor(start.Unix(), end.Unix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatadogDowntimeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogDowntimeExists("datadog_downtime.foo"),
 				),
 			},
 		},
@@ -207,6 +229,8 @@ func TestAccDatadogDowntime_Updated(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_id", "1234"),
 				),
 			},
 			resource.TestStep{
@@ -225,6 +249,8 @@ func TestAccDatadogDowntime_Updated(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "3"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_id", "5678"),
 				),
 			},
 		},
@@ -292,6 +318,38 @@ resource "datadog_downtime" "foo" {
   message = "Example Datadog downtime message."
 }
 `
+
+func testAccCheckDatadogDowntimeConfigWithMonitor(start int64, end int64) string {
+	//When scheduling downtime, Datadog switches the silenced property of monitor to the "end" property of downtime.
+	//If that is omitted, the plan doesn't become empty after removing the downtime.
+	return fmt.Sprintf(`
+resource "datadog_monitor" "downtime_monitor" {
+  name = "name for monitor foo"
+  type = "metric alert"
+  message = "some message Notify: @hipchat-channel"
+  escalation_message = "the situation has escalated @pagerduty"
+
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"
+
+  thresholds {
+	warning = "1.0"
+	critical = "2.0"
+	}
+	silenced {
+		"*" : %d
+	}
+}
+
+resource "datadog_downtime" "foo" {
+  scope = ["*"]
+  start = %d
+  end   = %d
+
+  message = "Example Datadog downtime message."
+  monitor_id = "${datadog_monitor.downtime_monitor.id}"
+}
+`, end, start, end)
+}
 
 const testAccCheckDatadogDowntimeConfigMultiScope = `
 resource "datadog_downtime" "foo" {
@@ -377,6 +435,7 @@ resource "datadog_downtime" "foo" {
   }
 
   message = "Example Datadog downtime message."
+  monitor_id = 5678
 }
 `
 
@@ -496,7 +555,12 @@ func TestResourceDatadogDowntimeRecurrenceWeekDaysValidation(t *testing.T) {
 }
 
 func datadogDowntimeDestroyHelper(s *terraform.State, client *datadog.Client) error {
-	for _, r := range s.RootModule().Resources {
+	for n, r := range s.RootModule().Resources {
+		fmt.Printf("Resource %s, type = %s\n", n, r.Type)
+		if r.Type != "datadog_downtime" {
+			continue
+		}
+
 		id, _ := strconv.Atoi(r.Primary.ID)
 		dt, err := client.GetDowntime(id)
 
@@ -518,6 +582,10 @@ func datadogDowntimeDestroyHelper(s *terraform.State, client *datadog.Client) er
 
 func datadogDowntimeExistsHelper(s *terraform.State, client *datadog.Client) error {
 	for _, r := range s.RootModule().Resources {
+		if r.Type != "datadog_downtime" {
+			continue
+		}
+
 		id, _ := strconv.Atoi(r.Primary.ID)
 		if _, err := client.GetDowntime(id); err != nil {
 			return fmt.Errorf("Received an error retrieving downtime %s", err)

--- a/website/docs/r/downtime.html.markdown
+++ b/website/docs/r/downtime.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
     * `until_occurrences` - (Optional) How many times the downtime will be rescheduled. `until_occurrences` and `until_date` are mutually exclusive.
     * `until_date` - (Optional) The date at which the recurrence should end as a POSIX timestamp. `until_occurrences` and `until_date` are mutually exclusive.
 * `message` - (Optional) A message to include with notifications for this downtime.
+* `monitor_id` - (Optional) Reference to which monitor this downtime is applied. When scheduling downtime for a given monitor, datadog changes `silenced` property of the monitor  to match the `end` POSIX timestamp.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is a shot at trying to implement the `monitor_id` field for downtime.
Since this is my first PR for terraform, please let me know if there are any hard mistakes, and I'll more than happy to work through them.