### PR TITLE
Use accessor methods; change schema types

### DIFF
--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -470,14 +470,17 @@ func buildGraphs(terraformGraphs *[]interface{}) *[]datadog.Graph {
 		if v, ok := t["include_ungrouped_hosts"]; ok {
 			d.Definition.SetIncludeUngroupedHosts(v.(bool))
 		}
-		v := t["marker"].([]interface{})
-		appendMarkers(d, &v)
+		if v, ok := t["marker"].([]interface{}); ok {
+			appendMarkers(d, &v)
+		}
 
-		v = t["events"].([]interface{})
-		appendEvents(d, &v)
+		if v, ok := t["events"].([]interface{}); ok {
+			appendEvents(d, &v)
+		}
 
-		v = t["request"].([]interface{})
-		appendRequests(d, &v)
+		if v, ok := t["request"].([]interface{}); ok {
+			appendRequests(d, &v)
+		}
 	}
 	return &datadogGraphs
 }
@@ -530,9 +533,15 @@ func resourceDatadogTimeboardUpdate(d *schema.ResourceData, meta interface{}) er
 func appendTerraformGraphRequests(datadogRequests []datadog.GraphDefinitionRequest, requests *[]map[string]interface{}) {
 	for _, datadogRequest := range datadogRequests {
 		request := map[string]interface{}{}
-		request["q"] = datadogRequest.GetQuery()
-		request["stacked"] = datadogRequest.GetStacked()
-		request["type"] = datadogRequest.GetType()
+		if v, ok := datadogRequest.GetQueryOk(); ok {
+			request["q"] = v
+		}
+		if v, ok := datadogRequest.GetStackedOk(); ok {
+			request["stacked"] = v
+		}
+		if v, ok := datadogRequest.GetTypeOk(); ok {
+			request["type"] = v
+		}
 		if v, ok := datadogRequest.GetStyleOk(); ok {
 			style := map[string]string{}
 			if v, ok := v.GetPaletteOk(); ok {
@@ -548,12 +557,21 @@ func appendTerraformGraphRequests(datadogRequests []datadog.GraphDefinitionReque
 		}
 		conditionalFormats := []map[string]interface{}{}
 		for _, cf := range datadogRequest.ConditionalFormats {
-			conditionalFormat := map[string]interface{}{
-				"palette":         cf.Palette,
-				"comparator":      cf.Comparator,
-				"custom_bg_color": cf.CustomBgColor,
-				"value":           cf.Value,
-				"custom_fg_color": cf.CustomFgColor,
+			conditionalFormat := map[string]interface{}{}
+			if v, ok := cf.GetPaletteOk(); ok {
+				conditionalFormat["palette"] = v
+			}
+			if v, ok := cf.GetComparatorOk(); ok {
+				conditionalFormat["comparator"] = v
+			}
+			if v, ok := cf.GetCustomBgColorOk(); ok {
+				conditionalFormat["custom_bg_color"] = v
+			}
+			if v, ok := cf.GetValueOk(); ok {
+				conditionalFormat["value"] = v
+			}
+			if v, ok := cf.GetCustomFgColorOk(); ok {
+				conditionalFormat["custom_fg_color"] = v
 			}
 			conditionalFormats = append(conditionalFormats, conditionalFormat)
 		}

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -452,7 +452,7 @@ func buildGraphs(terraformGraphs *[]interface{}) *[]datadog.Graph {
 		}
 
 		if v, ok := t["group"]; ok {
-			for _, g := range v.(*schema.Set).List() {
+			for _, g := range v.([]interface{}) {
 				d.Definition.Groups = append(d.Definition.Groups, g.(string))
 			}
 		}
@@ -462,7 +462,7 @@ func buildGraphs(terraformGraphs *[]interface{}) *[]datadog.Graph {
 		}
 
 		if v, ok := t["scope"]; ok {
-			for _, s := range v.(*schema.Set).List() {
+			for _, s := range v.([]interface{}) {
 				d.Definition.Scopes = append(d.Definition.Groups, s.(string))
 			}
 		}
@@ -473,7 +473,7 @@ func buildGraphs(terraformGraphs *[]interface{}) *[]datadog.Graph {
 		v := t["marker"].([]interface{})
 		appendMarkers(d, &v)
 
-		v = t["events"].(*schema.Set).List()
+		v = t["events"].([]interface{})
 		appendEvents(d, &v)
 
 		v = t["request"].([]interface{})

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -3,6 +3,7 @@ package datadog
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -658,6 +659,7 @@ func resourceDatadogTimeboardRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
+	log.Printf("[DEBUG] timeboard: %v", timeboard)
 	if err = d.Set("title", timeboard.GetTitle()); err != nil {
 		return err
 	}


### PR DESCRIPTION
* Changes `resourceDataTimeboardRead` to use `Get<Property>Ok` instead of direct reference
* Fixes #20
* Changes lists for timeboards to use `Schema.TypeList` instead of `Schema.TypeSet` to match the type assigned (`[]string`)