### PR TITLE
Add support for monitor recovery thresholds.

### DIFF
--- a/datadog/import_datadog_monitor_test.go
+++ b/datadog/import_datadog_monitor_test.go
@@ -26,10 +26,30 @@ func TestDatadogMonitor_import(t *testing.T) {
 	})
 }
 
+func TestDatadogMonitor_import_no_recovery(t *testing.T) {
+	resourceName := "datadog_monitor.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatadogMonitorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDatadogMonitorConfigImportedNoRecovery,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 const testAccCheckDatadogMonitorConfigImported = `
 resource "datadog_monitor" "foo" {
   name = "name for monitor foo"
-  type = "metric alert"
+  type = "query alert"
   message = "some message Notify: @hipchat-channel"
   escalation_message = "the situation has escalated @pagerduty"
 
@@ -37,8 +57,38 @@ resource "datadog_monitor" "foo" {
 
   thresholds {
     ok = 1.5
-    warning = 2.3
-    critical = 2.5
+    warning           = 2.3
+    warning_recovery  = 2.2
+    critical          = 2.5
+    critical_recovery = 2.4
+  }
+
+  notify_no_data = false
+  new_host_delay = 600
+  renotify_interval = 60
+
+  notify_audit = false
+  timeout_h = 60
+  include_tags = true
+  require_full_window = true
+  locked = false
+  tags = ["foo:bar", "bar:baz"]
+}
+`
+
+const testAccCheckDatadogMonitorConfigImportedNoRecovery = `
+resource "datadog_monitor" "foo" {
+  name = "name for monitor foo"
+  type = "query alert"
+  message = "some message Notify: @hipchat-channel"
+  escalation_message = "the situation has escalated @pagerduty"
+
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2.5"
+
+  thresholds {
+    ok = 1.5
+    warning           = 2.3
+    critical          = 2.5
   }
 
   notify_no_data = false

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -71,6 +71,14 @@ func resourceDatadogMonitor() *schema.Resource {
 							Type:     schema.TypeFloat,
 							Optional: true,
 						},
+						"warning_recovery": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"critical_recovery": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
 					},
 				},
 				DiffSuppressFunc: suppressDataDogFloatIntDiff,
@@ -146,6 +154,12 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 	}
 	if r, ok := d.GetOk("thresholds.critical"); ok {
 		thresholds.SetCritical(json.Number(r.(string)))
+	}
+	if r, ok := d.GetOk("thresholds.warning_recovery"); ok {
+		thresholds.SetWarningRecovery(json.Number(r.(string)))
+	}
+	if r, ok := d.GetOk("thresholds.critical_recovery"); ok {
+		thresholds.SetCriticalRecovery(json.Number(r.(string)))
 	}
 
 	o := datadog.Options{
@@ -259,9 +273,11 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 
 	thresholds := make(map[string]string)
 	for k, v := range map[string]json.Number{
-		"ok":       m.Options.Thresholds.GetOk(),
-		"warning":  m.Options.Thresholds.GetWarning(),
-		"critical": m.Options.Thresholds.GetCritical(),
+		"ok":                m.Options.Thresholds.GetOk(),
+		"warning":           m.Options.Thresholds.GetWarning(),
+		"critical":          m.Options.Thresholds.GetCritical(),
+		"warning_recovery":  m.Options.Thresholds.GetWarningRecovery(),
+		"critical_recovery": m.Options.Thresholds.GetCriticalRecovery(),
 	} {
 		s := v.String()
 		if s != "" {
@@ -343,6 +359,12 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 		if thresholds["critical"] != nil {
 			o.Thresholds.SetCritical(json.Number(thresholds["critical"].(string)))
+		}
+		if thresholds["warning_recovery"] != nil {
+			o.Thresholds.SetWarningRecovery(json.Number(thresholds["warning_recovery"].(string)))
+		}
+		if thresholds["critical_recovery"] != nil {
+			o.Thresholds.SetCriticalRecovery(json.Number(thresholds["critical_recovery"].(string)))
 		}
 	}
 

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -26,7 +26,7 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "message", "some message Notify: @hipchat-channel"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "type", "metric alert"),
+						"datadog_monitor.foo", "type", "query alert"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "query", "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"),
 					resource.TestCheckResourceAttr(
@@ -40,7 +40,11 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.5"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.critical", "2.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "1.5"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
@@ -70,7 +74,7 @@ func TestAccDatadogMonitor_BasicNoTreshold(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "message", "some message Notify: @hipchat-channel"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "type", "metric alert"),
+						"datadog_monitor.foo", "type", "query alert"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "query", "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"),
 					resource.TestCheckResourceAttr(
@@ -110,7 +114,7 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "query", "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "type", "metric alert"),
+						"datadog_monitor.foo", "type", "query alert"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "notify_no_data", "false"),
 					resource.TestCheckResourceAttr(
@@ -122,7 +126,11 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.5"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.critical", "2.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "1.5"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "notify_audit", "false"),
 					resource.TestCheckResourceAttr(
@@ -152,7 +160,7 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "escalation_message", "the situation has escalated! @pagerduty"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "type", "metric alert"),
+						"datadog_monitor.foo", "type", "query alert"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "notify_no_data", "true"),
 					resource.TestCheckResourceAttr(
@@ -168,7 +176,11 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.5"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.critical", "3.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "2.5"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "notify_audit", "true"),
 					resource.TestCheckResourceAttr(
@@ -206,7 +218,7 @@ func TestAccDatadogMonitor_TrimWhitespace(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "message", "some message Notify: @hipchat-channel"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "type", "metric alert"),
+						"datadog_monitor.foo", "type", "query alert"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "query", "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"),
 					resource.TestCheckResourceAttr(
@@ -218,7 +230,11 @@ func TestAccDatadogMonitor_TrimWhitespace(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.5"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.critical", "2.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "1.5"),
 				),
 			},
 		},
@@ -238,7 +254,11 @@ func TestAccDatadogMonitor_Basic_float_int(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.critical", "2"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "1"),
 				),
 			},
 
@@ -249,7 +269,11 @@ func TestAccDatadogMonitor_Basic_float_int(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.5"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.critical", "3.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "2.0"),
 				),
 			},
 		},
@@ -278,7 +302,7 @@ func testAccCheckDatadogMonitorExists(n string) resource.TestCheckFunc {
 const testAccCheckDatadogMonitorConfig = `
 resource "datadog_monitor" "foo" {
   name = "name for monitor foo"
-  type = "metric alert"
+  type = "query alert"
   message = "some message Notify: @hipchat-channel"
   escalation_message = "the situation has escalated @pagerduty"
 
@@ -287,6 +311,8 @@ resource "datadog_monitor" "foo" {
   thresholds {
 	warning = "1.0"
 	critical = "2.0"
+	warning_recovery = "0.5"
+	critical_recovery = "1.5"
   }
 
   renotify_interval = 60
@@ -304,7 +330,7 @@ resource "datadog_monitor" "foo" {
 const testAccCheckDatadogMonitorConfigNoThresholds = `
 resource "datadog_monitor" "foo" {
   name = "name for monitor foo"
-  type = "metric alert"
+  type = "query alert"
   message = "some message Notify: @hipchat-channel"
   escalation_message = "the situation has escalated @pagerduty"
 
@@ -325,15 +351,17 @@ resource "datadog_monitor" "foo" {
 const testAccCheckDatadogMonitorConfig_ints = `
 resource "datadog_monitor" "foo" {
   name               = "name for monitor foo"
-  type               = "metric alert"
+  type               = "query alert"
   message            = "some message Notify: @hipchat-channel"
   escalation_message = "the situation has escalated @pagerduty"
 
   query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"
 
   thresholds {
-    warning  = 1
-    critical = 2
+	warning           = 1
+	warning_recovery  = 0
+	critical          = 2
+	critical_recovery = 1
   }
 
   notify_no_data    = false
@@ -352,15 +380,17 @@ resource "datadog_monitor" "foo" {
 const testAccCheckDatadogMonitorConfig_ints_mixed = `
 resource "datadog_monitor" "foo" {
   name               = "name for monitor foo"
-  type               = "metric alert"
+  type               = "query alert"
   message            = "some message Notify: @hipchat-channel"
   escalation_message = "the situation has escalated @pagerduty"
 
   query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 3"
 
   thresholds {
-    warning  = 1
-    critical = 3.0 
+	warning           = 1
+	warning_recovery  = 0.5
+	critical          = 3.0
+	critical_recovery = 2
   }
 
   notify_no_data    = false
@@ -379,16 +409,18 @@ resource "datadog_monitor" "foo" {
 const testAccCheckDatadogMonitorConfigUpdated = `
 resource "datadog_monitor" "foo" {
   name = "name for monitor bar"
-  type = "metric alert"
+  type = "query alert"
   message = "a different message Notify: @hipchat-channel"
   escalation_message = "the situation has escalated @pagerduty"
 
   query = "avg(last_1h):avg:aws.ec2.cpu{environment:bar,host:bar} by {host} > 3"
 
   thresholds {
-	ok = "0.0"
-	warning = "1.0"
-	critical = "3.0"
+	ok                = "0.0"
+	warning           = "1.0"
+	warning_recovery  = "0.5"
+	critical          = "3.0"
+	critical_recovery = "2.5"
   }
 
   notify_no_data = true
@@ -412,7 +444,7 @@ resource "datadog_monitor" "foo" {
 const testAccCheckDatadogMonitorConfigWhitespace = `
 resource "datadog_monitor" "foo" {
   name = "name for monitor foo"
-  type = "metric alert"
+  type = "query alert"
   message = <<EOF
 some message Notify: @hipchat-channel
 EOF
@@ -425,7 +457,9 @@ EOF
   thresholds {
 	ok = "0.0"
 	warning = "1.0"
+	warning_recovery = "0.5"
 	critical = "2.0"
+	critical_recovery = "1.5"
   }
 
   notify_no_data = false

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -20,12 +20,14 @@ resource "datadog_monitor" "foo" {
   message            = "Monitor triggered. Notify: @hipchat-channel"
   escalation_message = "Escalation message @pagerduty"
 
-  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 2"
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4"
 
   thresholds {
-    ok       = 0
-    warning  = 1
-    critical = 2
+    ok                = 0
+    warning           = 2
+    warning_recovery  = 1
+    critical          = 4
+    critical_recovery = 3
   }
 
   notify_no_data    = false
@@ -62,12 +64,14 @@ The following arguments are supported:
     notification allowed elsewhere.
 * `thresholds` - (Optional)
     * Metric alerts:
-    A dictionary of thresholds by threshold type. Currently we have two threshold types for metric alerts: critical and warning. Critical is defined in the query, but can also be specified in this option. Warning threshold can only be specified using the thresholds option.
+    A dictionary of thresholds by threshold type. Currently we have four threshold types for metric alerts: critical, critical recovery, warning, and warning recovery. Critical is defined in the query, but can also be specified in this option. Warning and recovery thresholds can only be specified using the thresholds option.
     Example usage:
         ```
         thresholds {
-            critical = 90
-            warning  = 80
+            critical          = 90
+            critical_recovery = 85
+            warning           = 80
+            warning_recovery  = 75
         }
         ```
     * Service checks:


### PR DESCRIPTION
Recovery thresholds are a recently-added datadog feature:
https://www.datadoghq.com/blog/introducing-recovery-thresholds/

This commit adds support for warning_recovery and critical_recovery
threshold configurations. Resolves issue #33 

I also changed the tests from `metric alert` to `query alert` because Datadog automatically reclassifies these more complex monitors, see issue #3 