### PR TITLE
Fix quoting in documentation

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -114,13 +114,13 @@ The following arguments are supported:
     To mute the alert completely:
 
         silenced {
-          '*' =  0
+          "*" =  0
         }
 
     To mute role:db for a short time:
 
         silenced {
-          'role:db' = 1412798116
+          "role:db" = 1412798116
         }
 
 ## Attributes Reference


### PR DESCRIPTION
Single quotes are not valid Terraform syntax.