### PR TITLE
Fix mismatch between code and documentation

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
         ```
 
 * `notify_no_data` (Optional) A boolean indicating whether this monitor will notify when data stops reporting. Defaults
-    to true.
+    to false.
 * `new_host_delay` (Optional) Time (in seconds) to allow a host to boot and
     applications to fully start before starting the evaluation of monitor
     results. Should be a non negative integer. Defaults to 300.


### PR DESCRIPTION
The PR fix a mismatch between the code, where the default value for datadog_monitor.notify_no_data [is false](https://github.com/terraform-providers/terraform-provider-datadog/blob/master/datadog/resource_datadog_monitor.go#L97) and the documentation.