### PR TITLE
Upgrade to latest Datadog client bits

### DIFF
--- a/datadog/resource_datadog_metric_metadata_test.go
+++ b/datadog/resource_datadog_metric_metadata_test.go
@@ -109,10 +109,7 @@ func checkPostEvent() resource.TestCheckFunc {
 			Metric: datadog.String("foo"),
 			Points: []datadog.DataPoint{{&dpNow, &dpValue}},
 		}
-		if err := client.PostMetrics([]datadog.Metric{metric}); err != nil {
-			return err
-		}
-		return nil
+		return client.PostMetrics([]datadog.Metric{metric})
 	}
 }
 

--- a/datadog/resource_datadog_metric_metadata_test.go
+++ b/datadog/resource_datadog_metric_metadata_test.go
@@ -103,9 +103,11 @@ func checkMetricMetadataExists(name string) resource.TestCheckFunc {
 func checkPostEvent() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*datadog.Client)
+		dpNow := float64(time.Now().Unix())
+		dpValue := float64(1)
 		metric := datadog.Metric{
 			Metric: datadog.String("foo"),
-			Points: []datadog.DataPoint{{float64(time.Now().Unix()), 1}},
+			Points: []datadog.DataPoint{{&dpNow, &dpValue}},
 		}
 		if err := client.PostMetrics([]datadog.Metric{metric}); err != nil {
 			return err

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/comments.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/comments.go
@@ -30,7 +30,10 @@ type reqComment struct {
 // CreateComment adds a new comment to the system.
 func (client *Client) CreateComment(handle, message string) (*Comment, error) {
 	var out reqComment
-	comment := Comment{Handle: String(handle), Message: String(message)}
+	comment := Comment{Message: String(message)}
+	if len(handle) > 0 {
+		comment.Handle = String(handle)
+	}
 	if err := client.doJsonRequest("POST", "/v1/comments", &comment, &out); err != nil {
 		return nil, err
 	}
@@ -42,7 +45,10 @@ func (client *Client) CreateComment(handle, message string) (*Comment, error) {
 func (client *Client) CreateRelatedComment(handle, message string,
 	relid int) (*Comment, error) {
 	var out reqComment
-	comment := Comment{Handle: String(handle), Message: String(message), RelatedId: Int(relid)}
+	comment := Comment{Message: String(message), RelatedId: Int(relid)}
+	if len(handle) > 0 {
+		comment.Handle = String(handle)
+	}
 	if err := client.doJsonRequest("POST", "/v1/comments", &comment, &out); err != nil {
 		return nil, err
 	}
@@ -51,7 +57,10 @@ func (client *Client) CreateRelatedComment(handle, message string,
 
 // EditComment changes the message and possibly handle of a particular comment.
 func (client *Client) EditComment(id int, handle, message string) error {
-	comment := Comment{Handle: String(handle), Message: String(message)}
+	comment := Comment{Message: String(message)}
+	if len(handle) > 0 {
+		comment.Handle = String(handle)
+	}
 	return client.doJsonRequest("PUT", fmt.Sprintf("/v1/comments/%d", id),
 		&comment, nil)
 }

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/datadog-accessors.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/datadog-accessors.go
@@ -4,7 +4,7 @@
  *
  * Please see the included LICENSE file for licensing information.
  *
- * Copyright 2017 by authors and contributors.
+ * Copyright 2018 by authors and contributors.
 */
 
 package datadog
@@ -1468,6 +1468,99 @@ func (c *ChangeWidget) HasY() bool {
 // SetY allocates a new c.Y and returns the pointer to it.
 func (c *ChangeWidget) SetY(v int) {
 	c.Y = &v
+}
+
+// GetAccount returns the Account field if non-nil, zero value otherwise.
+func (c *ChannelSlackRequest) GetAccount() string {
+	if c == nil || c.Account == nil {
+		return ""
+	}
+	return *c.Account
+}
+
+// GetOkAccount returns a tuple with the Account field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ChannelSlackRequest) GetAccountOk() (string, bool) {
+	if c == nil || c.Account == nil {
+		return "", false
+	}
+	return *c.Account, true
+}
+
+// HasAccount returns a boolean if a field has been set.
+func (c *ChannelSlackRequest) HasAccount() bool {
+	if c != nil && c.Account != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAccount allocates a new c.Account and returns the pointer to it.
+func (c *ChannelSlackRequest) SetAccount(v string) {
+	c.Account = &v
+}
+
+// GetChannelName returns the ChannelName field if non-nil, zero value otherwise.
+func (c *ChannelSlackRequest) GetChannelName() string {
+	if c == nil || c.ChannelName == nil {
+		return ""
+	}
+	return *c.ChannelName
+}
+
+// GetOkChannelName returns a tuple with the ChannelName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ChannelSlackRequest) GetChannelNameOk() (string, bool) {
+	if c == nil || c.ChannelName == nil {
+		return "", false
+	}
+	return *c.ChannelName, true
+}
+
+// HasChannelName returns a boolean if a field has been set.
+func (c *ChannelSlackRequest) HasChannelName() bool {
+	if c != nil && c.ChannelName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetChannelName allocates a new c.ChannelName and returns the pointer to it.
+func (c *ChannelSlackRequest) SetChannelName(v string) {
+	c.ChannelName = &v
+}
+
+// GetTransferAllUserComments returns the TransferAllUserComments field if non-nil, zero value otherwise.
+func (c *ChannelSlackRequest) GetTransferAllUserComments() bool {
+	if c == nil || c.TransferAllUserComments == nil {
+		return false
+	}
+	return *c.TransferAllUserComments
+}
+
+// GetOkTransferAllUserComments returns a tuple with the TransferAllUserComments field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ChannelSlackRequest) GetTransferAllUserCommentsOk() (bool, bool) {
+	if c == nil || c.TransferAllUserComments == nil {
+		return false, false
+	}
+	return *c.TransferAllUserComments, true
+}
+
+// HasTransferAllUserComments returns a boolean if a field has been set.
+func (c *ChannelSlackRequest) HasTransferAllUserComments() bool {
+	if c != nil && c.TransferAllUserComments != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTransferAllUserComments allocates a new c.TransferAllUserComments and returns the pointer to it.
+func (c *ChannelSlackRequest) SetTransferAllUserComments(v bool) {
+	c.TransferAllUserComments = &v
 }
 
 // GetCheck returns the Check field if non-nil, zero value otherwise.
@@ -7205,6 +7298,192 @@ func (i *ImageWidget) SetY(v int) {
 	i.Y = &v
 }
 
+// GetAPIToken returns the APIToken field if non-nil, zero value otherwise.
+func (i *integrationPD) GetAPIToken() string {
+	if i == nil || i.APIToken == nil {
+		return ""
+	}
+	return *i.APIToken
+}
+
+// GetOkAPIToken returns a tuple with the APIToken field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *integrationPD) GetAPITokenOk() (string, bool) {
+	if i == nil || i.APIToken == nil {
+		return "", false
+	}
+	return *i.APIToken, true
+}
+
+// HasAPIToken returns a boolean if a field has been set.
+func (i *integrationPD) HasAPIToken() bool {
+	if i != nil && i.APIToken != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPIToken allocates a new i.APIToken and returns the pointer to it.
+func (i *integrationPD) SetAPIToken(v string) {
+	i.APIToken = &v
+}
+
+// GetSubdomain returns the Subdomain field if non-nil, zero value otherwise.
+func (i *integrationPD) GetSubdomain() string {
+	if i == nil || i.Subdomain == nil {
+		return ""
+	}
+	return *i.Subdomain
+}
+
+// GetOkSubdomain returns a tuple with the Subdomain field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *integrationPD) GetSubdomainOk() (string, bool) {
+	if i == nil || i.Subdomain == nil {
+		return "", false
+	}
+	return *i.Subdomain, true
+}
+
+// HasSubdomain returns a boolean if a field has been set.
+func (i *integrationPD) HasSubdomain() bool {
+	if i != nil && i.Subdomain != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubdomain allocates a new i.Subdomain and returns the pointer to it.
+func (i *integrationPD) SetSubdomain(v string) {
+	i.Subdomain = &v
+}
+
+// GetAPIToken returns the APIToken field if non-nil, zero value otherwise.
+func (i *IntegrationPDRequest) GetAPIToken() string {
+	if i == nil || i.APIToken == nil {
+		return ""
+	}
+	return *i.APIToken
+}
+
+// GetOkAPIToken returns a tuple with the APIToken field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationPDRequest) GetAPITokenOk() (string, bool) {
+	if i == nil || i.APIToken == nil {
+		return "", false
+	}
+	return *i.APIToken, true
+}
+
+// HasAPIToken returns a boolean if a field has been set.
+func (i *IntegrationPDRequest) HasAPIToken() bool {
+	if i != nil && i.APIToken != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPIToken allocates a new i.APIToken and returns the pointer to it.
+func (i *IntegrationPDRequest) SetAPIToken(v string) {
+	i.APIToken = &v
+}
+
+// GetRunCheck returns the RunCheck field if non-nil, zero value otherwise.
+func (i *IntegrationPDRequest) GetRunCheck() bool {
+	if i == nil || i.RunCheck == nil {
+		return false
+	}
+	return *i.RunCheck
+}
+
+// GetOkRunCheck returns a tuple with the RunCheck field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationPDRequest) GetRunCheckOk() (bool, bool) {
+	if i == nil || i.RunCheck == nil {
+		return false, false
+	}
+	return *i.RunCheck, true
+}
+
+// HasRunCheck returns a boolean if a field has been set.
+func (i *IntegrationPDRequest) HasRunCheck() bool {
+	if i != nil && i.RunCheck != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRunCheck allocates a new i.RunCheck and returns the pointer to it.
+func (i *IntegrationPDRequest) SetRunCheck(v bool) {
+	i.RunCheck = &v
+}
+
+// GetSubdomain returns the Subdomain field if non-nil, zero value otherwise.
+func (i *IntegrationPDRequest) GetSubdomain() string {
+	if i == nil || i.Subdomain == nil {
+		return ""
+	}
+	return *i.Subdomain
+}
+
+// GetOkSubdomain returns a tuple with the Subdomain field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationPDRequest) GetSubdomainOk() (string, bool) {
+	if i == nil || i.Subdomain == nil {
+		return "", false
+	}
+	return *i.Subdomain, true
+}
+
+// HasSubdomain returns a boolean if a field has been set.
+func (i *IntegrationPDRequest) HasSubdomain() bool {
+	if i != nil && i.Subdomain != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubdomain allocates a new i.Subdomain and returns the pointer to it.
+func (i *IntegrationPDRequest) SetSubdomain(v string) {
+	i.Subdomain = &v
+}
+
+// GetRunCheck returns the RunCheck field if non-nil, zero value otherwise.
+func (i *IntegrationSlackRequest) GetRunCheck() bool {
+	if i == nil || i.RunCheck == nil {
+		return false
+	}
+	return *i.RunCheck
+}
+
+// GetOkRunCheck returns a tuple with the RunCheck field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationSlackRequest) GetRunCheckOk() (bool, bool) {
+	if i == nil || i.RunCheck == nil {
+		return false, false
+	}
+	return *i.RunCheck, true
+}
+
+// HasRunCheck returns a boolean if a field has been set.
+func (i *IntegrationSlackRequest) HasRunCheck() bool {
+	if i != nil && i.RunCheck != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRunCheck allocates a new i.RunCheck and returns the pointer to it.
+func (i *IntegrationSlackRequest) SetRunCheck(v bool) {
+	i.RunCheck = &v
+}
+
 // GetHost returns the Host field if non-nil, zero value otherwise.
 func (m *Metric) GetHost() string {
 	if m == nil || m.Host == nil {
@@ -10212,6 +10491,223 @@ func (s *Series) SetStart(v float64) {
 	s.Start = &v
 }
 
+// GetUnits returns the Units field if non-nil, zero value otherwise.
+func (s *Series) GetUnits() UnitPair {
+	if s == nil || s.Units == nil {
+		return UnitPair{}
+	}
+	return *s.Units
+}
+
+// GetOkUnits returns a tuple with the Units field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *Series) GetUnitsOk() (UnitPair, bool) {
+	if s == nil || s.Units == nil {
+		return UnitPair{}, false
+	}
+	return *s.Units, true
+}
+
+// HasUnits returns a boolean if a field has been set.
+func (s *Series) HasUnits() bool {
+	if s != nil && s.Units != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUnits allocates a new s.Units and returns the pointer to it.
+func (s *Series) SetUnits(v UnitPair) {
+	s.Units = &v
+}
+
+// GetAccount returns the Account field if non-nil, zero value otherwise.
+func (s *ServiceHookSlackRequest) GetAccount() string {
+	if s == nil || s.Account == nil {
+		return ""
+	}
+	return *s.Account
+}
+
+// GetOkAccount returns a tuple with the Account field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServiceHookSlackRequest) GetAccountOk() (string, bool) {
+	if s == nil || s.Account == nil {
+		return "", false
+	}
+	return *s.Account, true
+}
+
+// HasAccount returns a boolean if a field has been set.
+func (s *ServiceHookSlackRequest) HasAccount() bool {
+	if s != nil && s.Account != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAccount allocates a new s.Account and returns the pointer to it.
+func (s *ServiceHookSlackRequest) SetAccount(v string) {
+	s.Account = &v
+}
+
+// GetUrl returns the Url field if non-nil, zero value otherwise.
+func (s *ServiceHookSlackRequest) GetUrl() string {
+	if s == nil || s.Url == nil {
+		return ""
+	}
+	return *s.Url
+}
+
+// GetOkUrl returns a tuple with the Url field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServiceHookSlackRequest) GetUrlOk() (string, bool) {
+	if s == nil || s.Url == nil {
+		return "", false
+	}
+	return *s.Url, true
+}
+
+// HasUrl returns a boolean if a field has been set.
+func (s *ServiceHookSlackRequest) HasUrl() bool {
+	if s != nil && s.Url != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUrl allocates a new s.Url and returns the pointer to it.
+func (s *ServiceHookSlackRequest) SetUrl(v string) {
+	s.Url = &v
+}
+
+// GetServiceKey returns the ServiceKey field if non-nil, zero value otherwise.
+func (s *servicePD) GetServiceKey() string {
+	if s == nil || s.ServiceKey == nil {
+		return ""
+	}
+	return *s.ServiceKey
+}
+
+// GetOkServiceKey returns a tuple with the ServiceKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *servicePD) GetServiceKeyOk() (string, bool) {
+	if s == nil || s.ServiceKey == nil {
+		return "", false
+	}
+	return *s.ServiceKey, true
+}
+
+// HasServiceKey returns a boolean if a field has been set.
+func (s *servicePD) HasServiceKey() bool {
+	if s != nil && s.ServiceKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceKey allocates a new s.ServiceKey and returns the pointer to it.
+func (s *servicePD) SetServiceKey(v string) {
+	s.ServiceKey = &v
+}
+
+// GetServiceName returns the ServiceName field if non-nil, zero value otherwise.
+func (s *servicePD) GetServiceName() string {
+	if s == nil || s.ServiceName == nil {
+		return ""
+	}
+	return *s.ServiceName
+}
+
+// GetOkServiceName returns a tuple with the ServiceName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *servicePD) GetServiceNameOk() (string, bool) {
+	if s == nil || s.ServiceName == nil {
+		return "", false
+	}
+	return *s.ServiceName, true
+}
+
+// HasServiceName returns a boolean if a field has been set.
+func (s *servicePD) HasServiceName() bool {
+	if s != nil && s.ServiceName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceName allocates a new s.ServiceName and returns the pointer to it.
+func (s *servicePD) SetServiceName(v string) {
+	s.ServiceName = &v
+}
+
+// GetServiceKey returns the ServiceKey field if non-nil, zero value otherwise.
+func (s *ServicePDRequest) GetServiceKey() string {
+	if s == nil || s.ServiceKey == nil {
+		return ""
+	}
+	return *s.ServiceKey
+}
+
+// GetOkServiceKey returns a tuple with the ServiceKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServicePDRequest) GetServiceKeyOk() (string, bool) {
+	if s == nil || s.ServiceKey == nil {
+		return "", false
+	}
+	return *s.ServiceKey, true
+}
+
+// HasServiceKey returns a boolean if a field has been set.
+func (s *ServicePDRequest) HasServiceKey() bool {
+	if s != nil && s.ServiceKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceKey allocates a new s.ServiceKey and returns the pointer to it.
+func (s *ServicePDRequest) SetServiceKey(v string) {
+	s.ServiceKey = &v
+}
+
+// GetServiceName returns the ServiceName field if non-nil, zero value otherwise.
+func (s *ServicePDRequest) GetServiceName() string {
+	if s == nil || s.ServiceName == nil {
+		return ""
+	}
+	return *s.ServiceName
+}
+
+// GetOkServiceName returns a tuple with the ServiceName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServicePDRequest) GetServiceNameOk() (string, bool) {
+	if s == nil || s.ServiceName == nil {
+		return "", false
+	}
+	return *s.ServiceName, true
+}
+
+// HasServiceName returns a boolean if a field has been set.
+func (s *ServicePDRequest) HasServiceName() bool {
+	if s != nil && s.ServiceName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceName allocates a new s.ServiceName and returns the pointer to it.
+func (s *ServicePDRequest) SetServiceName(v string) {
+	s.ServiceName = &v
+}
+
 // GetPalette returns the Palette field if non-nil, zero value otherwise.
 func (s *Style) GetPalette() string {
 	if s == nil || s.Palette == nil {
@@ -10520,6 +11016,37 @@ func (t *ThresholdCount) HasOk() bool {
 // SetOk allocates a new t.Ok and returns the pointer to it.
 func (t *ThresholdCount) SetOk(v json.Number) {
 	t.Ok = &v
+}
+
+// GetUnknown returns the Unknown field if non-nil, zero value otherwise.
+func (t *ThresholdCount) GetUnknown() json.Number {
+	if t == nil || t.Unknown == nil {
+		return ""
+	}
+	return *t.Unknown
+}
+
+// GetOkUnknown returns a tuple with the Unknown field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *ThresholdCount) GetUnknownOk() (json.Number, bool) {
+	if t == nil || t.Unknown == nil {
+		return "", false
+	}
+	return *t.Unknown, true
+}
+
+// HasUnknown returns a boolean if a field has been set.
+func (t *ThresholdCount) HasUnknown() bool {
+	if t != nil && t.Unknown != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUnknown allocates a new t.Unknown and returns the pointer to it.
+func (t *ThresholdCount) SetUnknown(v json.Number) {
+	t.Unknown = &v
 }
 
 // GetWarning returns the Warning field if non-nil, zero value otherwise.
@@ -11636,6 +12163,37 @@ func (t *ToplistWidget) HasY() bool {
 // SetY allocates a new t.Y and returns the pointer to it.
 func (t *ToplistWidget) SetY(v int) {
 	t.Y = &v
+}
+
+// GetAccessRole returns the AccessRole field if non-nil, zero value otherwise.
+func (u *User) GetAccessRole() string {
+	if u == nil || u.AccessRole == nil {
+		return ""
+	}
+	return *u.AccessRole
+}
+
+// GetOkAccessRole returns a tuple with the AccessRole field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (u *User) GetAccessRoleOk() (string, bool) {
+	if u == nil || u.AccessRole == nil {
+		return "", false
+	}
+	return *u.AccessRole, true
+}
+
+// HasAccessRole returns a boolean if a field has been set.
+func (u *User) HasAccessRole() bool {
+	if u != nil && u.AccessRole != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAccessRole allocates a new u.AccessRole and returns the pointer to it.
+func (u *User) SetAccessRole(v string) {
+	u.AccessRole = &v
 }
 
 // GetDisabled returns the Disabled field if non-nil, zero value otherwise.

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/integrations.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/integrations.go
@@ -1,0 +1,122 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2018 by authors and contributors.
+ */
+
+package datadog
+
+/*
+	PagerDuty Integration
+*/
+
+type servicePD struct {
+	ServiceName *string `json:"service"`
+	ServiceKey  *string `json:"key"`
+}
+
+type integrationPD struct {
+	Services  []servicePD `json:"services"`
+	Subdomain *string     `json:"subdomain"`
+	Schedules []string    `json:"schedules"`
+	APIToken  *string     `json:"api_token"`
+}
+
+// ServicePDRequest defines the Services struct that is part of the IntegrationPDRequest.
+type ServicePDRequest struct {
+	ServiceName *string `json:"service_name"`
+	ServiceKey  *string `json:"service_key"`
+}
+
+// IntegrationPDRequest defines the request payload for
+// creating & updating Datadog-PagerDuty integration.
+type IntegrationPDRequest struct {
+	Services  []ServicePDRequest `json:"services,omitempty"`
+	Subdomain *string            `json:"subdomain,omitempty"`
+	Schedules []string           `json:"schedules,omitempty"`
+	APIToken  *string            `json:"api_token,omitempty"`
+	RunCheck  *bool              `json:"run_check,omitempty"`
+}
+
+// CreateIntegrationPD creates new PagerDuty Integrations.
+// Use this if you want to setup the integration for the first time
+// or to add more services/schedules.
+func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
+	return client.doJsonRequest("POST", "/v1/integration/pagerduty", pdIntegration, nil)
+}
+
+// UpdateIntegrationPD updates the PagerDuty Integration.
+// This will replace the existing values with the new values.
+func (client *Client) UpdateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
+	return client.doJsonRequest("PUT", "/v1/integration/pagerduty", pdIntegration, nil)
+}
+
+// GetIntegrationPD gets all the PagerDuty Integrations from the system.
+func (client *Client) GetIntegrationPD() (*integrationPD, error) {
+	var out integrationPD
+	if err := client.doJsonRequest("GET", "/v1/integration/pagerduty", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// DeleteIntegrationPD removes the PagerDuty Integration from the system.
+func (client *Client) DeleteIntegrationPD() error {
+	return client.doJsonRequest("DELETE", "/v1/integration/pagerduty", nil, nil)
+}
+
+/*
+	Slack Integration
+*/
+
+// ServiceHookSlackRequest defines the ServiceHooks struct that is part of the IntegrationSlackRequest.
+type ServiceHookSlackRequest struct {
+	Account *string `json:"account"`
+	Url     *string `json:"url"`
+}
+
+// ChannelSlackRequest defines the Channels struct that is part of the IntegrationSlackRequest.
+type ChannelSlackRequest struct {
+	ChannelName             *string `json:"channel_name"`
+	TransferAllUserComments *bool   `json:"transfer_all_user_comments,omitempty,string"`
+	Account                 *string `json:"account"`
+}
+
+// IntegrationSlackRequest defines the request payload for
+// creating & updating Datadog-Slack integration.
+type IntegrationSlackRequest struct {
+	ServiceHooks []ServiceHookSlackRequest `json:"service_hooks,omitempty"`
+	Channels     []ChannelSlackRequest     `json:"channels,omitempty"`
+	RunCheck     *bool                     `json:"run_check,omitempty,string"`
+}
+
+// CreateIntegrationSlack creates new Slack Integrations.
+// Use this if you want to setup the integration for the first time
+// or to add more channels.
+func (client *Client) CreateIntegrationSlack(slackIntegration *IntegrationSlackRequest) error {
+	return client.doJsonRequest("POST", "/v1/integration/slack", slackIntegration, nil)
+}
+
+// UpdateIntegrationSlack updates the Slack Integration.
+// This will replace the existing values with the new values.
+func (client *Client) UpdateIntegrationSlack(slackIntegration *IntegrationSlackRequest) error {
+	return client.doJsonRequest("PUT", "/v1/integration/slack", slackIntegration, nil)
+}
+
+// GetIntegrationSlack gets all the Slack Integrations from the system.
+func (client *Client) GetIntegrationSlack() (*IntegrationSlackRequest, error) {
+	var out IntegrationSlackRequest
+	if err := client.doJsonRequest("GET", "/v1/integration/slack", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// DeleteIntegrationSlack removes the Slack Integration from the system.
+func (client *Client) DeleteIntegrationSlack() error {
+	return client.doJsonRequest("DELETE", "/v1/integration/slack", nil, nil)
+}

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/monitors.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/monitors.go
@@ -20,6 +20,7 @@ type ThresholdCount struct {
 	Ok               *json.Number `json:"ok,omitempty"`
 	Critical         *json.Number `json:"critical,omitempty"`
 	Warning          *json.Number `json:"warning,omitempty"`
+	Unknown          *json.Number `json:"unknown,omitempty"`
 	CriticalRecovery *json.Number `json:"critical_recovery,omitempty"`
 	WarningRecovery  *json.Number `json:"warning_recovery,omitempty"`
 }
@@ -65,7 +66,7 @@ type Monitor struct {
 	Query   *string  `json:"query,omitempty"`
 	Name    *string  `json:"name,omitempty"`
 	Message *string  `json:"message,omitempty"`
-	Tags    []string `json:"tags,omitempty"`
+	Tags    []string `json:"tags"`
 	Options *Options `json:"options,omitempty"`
 }
 

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/request.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/request.go
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -26,11 +25,7 @@ import (
 // uriForAPI is to be called with something like "/v1/events" and it will give
 // the proper request URI to be posted to.
 func (client *Client) uriForAPI(api string) (string, error) {
-	baseUrl := os.Getenv("DATADOG_HOST")
-	if baseUrl == "" {
-		baseUrl = "https://app.datadoghq.com"
-	}
-	apiBase, err := url.Parse(baseUrl + "/api" + api)
+	apiBase, err := url.Parse(client.baseUrl + "/api" + api)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/series.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/series.go
@@ -15,7 +15,7 @@ import (
 
 // DataPoint is a tuple of [UNIX timestamp, value]. This has to use floats
 // because the value could be non-integer.
-type DataPoint [2]float64
+type DataPoint [2]*float64
 
 // Metric represents a collection of data points that we might send or receive
 // on one single metric line.
@@ -27,6 +27,20 @@ type Metric struct {
 	Tags   []string    `json:"tags,omitempty"`
 	Unit   *string     `json:"unit,omitempty"`
 }
+
+// Unit represents a unit definition that we might receive when query for timeseries data.
+type Unit struct {
+	Family string       `json:"family"`
+	ScaleFactor float32 `json:"scale_factor"`
+	Name string         `json:"name"`
+	ShortName string    `json:"short_name"`
+	Plural string       `json:"plural"`
+	Id int              `json:"id"`
+}
+
+// A Series is characterized by 2 units as: x per y
+// One or both could be missing
+type UnitPair []*Unit
 
 // Series represents a collection of data points we get when we query for timeseries data
 type Series struct {
@@ -40,6 +54,7 @@ type Series struct {
 	Length      *int        `json:"length,omitempty"`
 	Scope       *string     `json:"scope,omitempty"`
 	Expression  *string     `json:"expression,omitempty"`
+	Units       *UnitPair   `json:"unit,omitempty"`
 }
 
 // reqPostSeries from /api/v1/series

--- a/vendor/gopkg.in/zorkian/go-datadog-api.v2/users.go
+++ b/vendor/gopkg.in/zorkian/go-datadog-api.v2/users.go
@@ -9,13 +9,18 @@
 package datadog
 
 type User struct {
-	Handle   *string `json:"handle,omitempty"`
-	Email    *string `json:"email,omitempty"`
-	Name     *string `json:"name,omitempty"`
-	Role     *string `json:"role,omitempty"`
-	IsAdmin  *bool   `json:"is_admin,omitempty"`
-	Verified *bool   `json:"verified,omitempty"`
-	Disabled *bool   `json:"disabled,omitempty"`
+	Handle     *string `json:"handle,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	Role       *string `json:"role,omitempty"`
+	AccessRole *string `json:"access_role,omitempty"`
+	Verified   *bool   `json:"verified,omitempty"`
+	Disabled   *bool   `json:"disabled,omitempty"`
+
+	// DEPRECATED: IsAdmin is deprecated and will be removed in the next major
+	// revision. For more info on why it is being removed, see discussion on
+	// https://github.com/zorkian/go-datadog-api/issues/126.
+	IsAdmin *bool `json:"is_admin,omitempty"`
 }
 
 // reqInviteUsers contains email addresses to send invitations to.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -640,10 +640,10 @@
 			"revisionTime": "2017-08-04T00:04:37Z"
 		},
 		{
-			"checksumSHA1": "JurJlkycckJ+fK1kQw2VKndlK18=",
+			"checksumSHA1": "7vPX+PY7f/WfJX0XFyhYj6b08Cs=",
 			"path": "gopkg.in/zorkian/go-datadog-api.v2",
-			"revision": "2ba72e380572e4d47f66358c875618afe24721ee",
-			"revisionTime": "2017-12-01T21:35:26Z"
+			"revision": "e105a8d59e751cc42d6e7aed2eab4bc9a38aabeb",
+			"revisionTime": "2018-04-19T00:55:52Z"
 		},
 		{
 			"checksumSHA1": "wICWAGQfZcHD2y0dHesz9R2YSiw=",


### PR DESCRIPTION
In order to address some HTTP `503`'s from Datadog's API, upgrade to the latest version of the [client](https://github.com/zorkian/go-datadog-api).

**Background**
An appreciable percentage of our CI jobs end up failing during refreshing state due to intermittent `503`s from Datadogs API and the lack of the retry logic on the Datadog client's method for validating credentials. I added retry to logic to that method in [this commit](https://github.com/zorkian/go-datadog-api/commit/ea1134dba239db450d4565f8e74594b0112625d1) to fix.