### PR TITLE
Deprecated role for user resource

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -44,8 +44,9 @@ func resourceDatadogUser() *schema.Resource {
 				Required: true,
 			},
 			"role": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "This parameter was removed from the API and has no effect",
 			},
 			"verified": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
The endpoint to handle resources of type `User` doesn't accept anymore the `role` parameter, that is now ignored.
This is currently a problem because beside not being able to set a User role, Terraform remains in a dirty state where `terraform plan` always wants to update `role`.

See https://github.com/terraform-providers/terraform-provider-datadog/issues/12 for one of the issues we're facing.