### PR TITLE
Finish deprecating `role` argument for User resource

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -80,7 +80,6 @@ func resourceDatadogUserCreate(d *schema.ResourceData, meta interface{}) error {
 	u.SetHandle(d.Get("handle").(string))
 	u.SetIsAdmin(d.Get("is_admin").(bool))
 	u.SetName(d.Get("name").(string))
-	u.SetRole(d.Get("role").(string))
 
 	// Datadog does not actually delete users, so CreateUser might return a 409.
 	// We ignore that case and proceed, likely re-enabling the user.
@@ -113,7 +112,6 @@ func resourceDatadogUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("handle", u.GetHandle())
 	d.Set("is_admin", u.GetIsAdmin())
 	d.Set("name", u.GetName())
-	d.Set("role", u.GetRole())
 	d.Set("verified", u.GetVerified())
 
 	return nil
@@ -127,7 +125,6 @@ func resourceDatadogUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	u.SetHandle(d.Id())
 	u.SetIsAdmin(d.Get("is_admin").(bool))
 	u.SetName(d.Get("name").(string))
-	u.SetRole(d.Get("role").(string))
 
 	if err := client.UpdateUser(u); err != nil {
 		return fmt.Errorf("error updating user: %s", err.Error())


### PR DESCRIPTION
We already deprecated the use of the `role` attribute because the Datadog API just ignore the corresponding parameter.

The problem persists because if you manually add an user role through the UI, `terraform plan` will always try to set it to an empty string (the default value).

This PR makes Terraform completely unaware of the `role` API param, so it won't try to even read it from the response payload.