### PR TITLE
Deprecate is_admin for resource "datadog_user"

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -35,9 +35,10 @@ func resourceDatadogUser() *schema.Resource {
 				Required: true,
 			},
 			"is_admin": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Default:    false,
+				Deprecated: "This parameter will be replaced by `access_role` and will be removed from the next Major version",
 			},
 			"name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
In order to introduce `access_role`, `is_admin` has to be deprecated, then removed. This is the first step.

See #4 for more details.