### PR TITLE
Fixes #19 by updating go-datadog-api lib version

### DIFF
--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -261,1215 +261,6 @@ func (a *Alert) SetState(v string) {
 	a.State = &v
 }
 
-// GetAddTimeframe returns the AddTimeframe field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetAddTimeframe() bool {
-	if a == nil || a.AddTimeframe == nil {
-		return false
-	}
-	return *a.AddTimeframe
-}
-
-// GetOkAddTimeframe returns a tuple with the AddTimeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetAddTimeframeOk() (bool, bool) {
-	if a == nil || a.AddTimeframe == nil {
-		return false, false
-	}
-	return *a.AddTimeframe, true
-}
-
-// HasAddTimeframe returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasAddTimeframe() bool {
-	if a != nil && a.AddTimeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAddTimeframe allocates a new a.AddTimeframe and returns the pointer to it.
-func (a *AlertGraphWidget) SetAddTimeframe(v bool) {
-	a.AddTimeframe = &v
-}
-
-// GetAlertId returns the AlertId field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetAlertId() int {
-	if a == nil || a.AlertId == nil {
-		return 0
-	}
-	return *a.AlertId
-}
-
-// GetOkAlertId returns a tuple with the AlertId field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetAlertIdOk() (int, bool) {
-	if a == nil || a.AlertId == nil {
-		return 0, false
-	}
-	return *a.AlertId, true
-}
-
-// HasAlertId returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasAlertId() bool {
-	if a != nil && a.AlertId != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAlertId allocates a new a.AlertId and returns the pointer to it.
-func (a *AlertGraphWidget) SetAlertId(v int) {
-	a.AlertId = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetHeight() int {
-	if a == nil || a.Height == nil {
-		return 0
-	}
-	return *a.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetHeightOk() (int, bool) {
-	if a == nil || a.Height == nil {
-		return 0, false
-	}
-	return *a.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasHeight() bool {
-	if a != nil && a.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new a.Height and returns the pointer to it.
-func (a *AlertGraphWidget) SetHeight(v int) {
-	a.Height = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetTimeframe() string {
-	if a == nil || a.Timeframe == nil {
-		return ""
-	}
-	return *a.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetTimeframeOk() (string, bool) {
-	if a == nil || a.Timeframe == nil {
-		return "", false
-	}
-	return *a.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasTimeframe() bool {
-	if a != nil && a.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new a.Timeframe and returns the pointer to it.
-func (a *AlertGraphWidget) SetTimeframe(v string) {
-	a.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetTitle() bool {
-	if a == nil || a.Title == nil {
-		return false
-	}
-	return *a.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetTitleOk() (bool, bool) {
-	if a == nil || a.Title == nil {
-		return false, false
-	}
-	return *a.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasTitle() bool {
-	if a != nil && a.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new a.Title and returns the pointer to it.
-func (a *AlertGraphWidget) SetTitle(v bool) {
-	a.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetTitleAlign() string {
-	if a == nil || a.TitleAlign == nil {
-		return ""
-	}
-	return *a.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetTitleAlignOk() (string, bool) {
-	if a == nil || a.TitleAlign == nil {
-		return "", false
-	}
-	return *a.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasTitleAlign() bool {
-	if a != nil && a.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new a.TitleAlign and returns the pointer to it.
-func (a *AlertGraphWidget) SetTitleAlign(v string) {
-	a.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetTitleSize() int {
-	if a == nil || a.TitleSize == nil {
-		return 0
-	}
-	return *a.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetTitleSizeOk() (int, bool) {
-	if a == nil || a.TitleSize == nil {
-		return 0, false
-	}
-	return *a.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasTitleSize() bool {
-	if a != nil && a.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new a.TitleSize and returns the pointer to it.
-func (a *AlertGraphWidget) SetTitleSize(v int) {
-	a.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetTitleText() string {
-	if a == nil || a.TitleText == nil {
-		return ""
-	}
-	return *a.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetTitleTextOk() (string, bool) {
-	if a == nil || a.TitleText == nil {
-		return "", false
-	}
-	return *a.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasTitleText() bool {
-	if a != nil && a.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new a.TitleText and returns the pointer to it.
-func (a *AlertGraphWidget) SetTitleText(v string) {
-	a.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetType() string {
-	if a == nil || a.Type == nil {
-		return ""
-	}
-	return *a.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetTypeOk() (string, bool) {
-	if a == nil || a.Type == nil {
-		return "", false
-	}
-	return *a.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasType() bool {
-	if a != nil && a.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new a.Type and returns the pointer to it.
-func (a *AlertGraphWidget) SetType(v string) {
-	a.Type = &v
-}
-
-// GetVizType returns the VizType field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetVizType() string {
-	if a == nil || a.VizType == nil {
-		return ""
-	}
-	return *a.VizType
-}
-
-// GetOkVizType returns a tuple with the VizType field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetVizTypeOk() (string, bool) {
-	if a == nil || a.VizType == nil {
-		return "", false
-	}
-	return *a.VizType, true
-}
-
-// HasVizType returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasVizType() bool {
-	if a != nil && a.VizType != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetVizType allocates a new a.VizType and returns the pointer to it.
-func (a *AlertGraphWidget) SetVizType(v string) {
-	a.VizType = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetWidth() int {
-	if a == nil || a.Width == nil {
-		return 0
-	}
-	return *a.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetWidthOk() (int, bool) {
-	if a == nil || a.Width == nil {
-		return 0, false
-	}
-	return *a.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasWidth() bool {
-	if a != nil && a.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new a.Width and returns the pointer to it.
-func (a *AlertGraphWidget) SetWidth(v int) {
-	a.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetX() int {
-	if a == nil || a.X == nil {
-		return 0
-	}
-	return *a.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetXOk() (int, bool) {
-	if a == nil || a.X == nil {
-		return 0, false
-	}
-	return *a.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasX() bool {
-	if a != nil && a.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new a.X and returns the pointer to it.
-func (a *AlertGraphWidget) SetX(v int) {
-	a.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (a *AlertGraphWidget) GetY() int {
-	if a == nil || a.Y == nil {
-		return 0
-	}
-	return *a.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertGraphWidget) GetYOk() (int, bool) {
-	if a == nil || a.Y == nil {
-		return 0, false
-	}
-	return *a.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (a *AlertGraphWidget) HasY() bool {
-	if a != nil && a.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new a.Y and returns the pointer to it.
-func (a *AlertGraphWidget) SetY(v int) {
-	a.Y = &v
-}
-
-// GetAddTimeframe returns the AddTimeframe field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetAddTimeframe() bool {
-	if a == nil || a.AddTimeframe == nil {
-		return false
-	}
-	return *a.AddTimeframe
-}
-
-// GetOkAddTimeframe returns a tuple with the AddTimeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetAddTimeframeOk() (bool, bool) {
-	if a == nil || a.AddTimeframe == nil {
-		return false, false
-	}
-	return *a.AddTimeframe, true
-}
-
-// HasAddTimeframe returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasAddTimeframe() bool {
-	if a != nil && a.AddTimeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAddTimeframe allocates a new a.AddTimeframe and returns the pointer to it.
-func (a *AlertValueWidget) SetAddTimeframe(v bool) {
-	a.AddTimeframe = &v
-}
-
-// GetAlertId returns the AlertId field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetAlertId() int {
-	if a == nil || a.AlertId == nil {
-		return 0
-	}
-	return *a.AlertId
-}
-
-// GetOkAlertId returns a tuple with the AlertId field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetAlertIdOk() (int, bool) {
-	if a == nil || a.AlertId == nil {
-		return 0, false
-	}
-	return *a.AlertId, true
-}
-
-// HasAlertId returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasAlertId() bool {
-	if a != nil && a.AlertId != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAlertId allocates a new a.AlertId and returns the pointer to it.
-func (a *AlertValueWidget) SetAlertId(v int) {
-	a.AlertId = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetHeight() int {
-	if a == nil || a.Height == nil {
-		return 0
-	}
-	return *a.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetHeightOk() (int, bool) {
-	if a == nil || a.Height == nil {
-		return 0, false
-	}
-	return *a.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasHeight() bool {
-	if a != nil && a.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new a.Height and returns the pointer to it.
-func (a *AlertValueWidget) SetHeight(v int) {
-	a.Height = &v
-}
-
-// GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetPrecision() int {
-	if a == nil || a.Precision == nil {
-		return 0
-	}
-	return *a.Precision
-}
-
-// GetOkPrecision returns a tuple with the Precision field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetPrecisionOk() (int, bool) {
-	if a == nil || a.Precision == nil {
-		return 0, false
-	}
-	return *a.Precision, true
-}
-
-// HasPrecision returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasPrecision() bool {
-	if a != nil && a.Precision != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetPrecision allocates a new a.Precision and returns the pointer to it.
-func (a *AlertValueWidget) SetPrecision(v int) {
-	a.Precision = &v
-}
-
-// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTextAlign() string {
-	if a == nil || a.TextAlign == nil {
-		return ""
-	}
-	return *a.TextAlign
-}
-
-// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTextAlignOk() (string, bool) {
-	if a == nil || a.TextAlign == nil {
-		return "", false
-	}
-	return *a.TextAlign, true
-}
-
-// HasTextAlign returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTextAlign() bool {
-	if a != nil && a.TextAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextAlign allocates a new a.TextAlign and returns the pointer to it.
-func (a *AlertValueWidget) SetTextAlign(v string) {
-	a.TextAlign = &v
-}
-
-// GetTextSize returns the TextSize field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTextSize() string {
-	if a == nil || a.TextSize == nil {
-		return ""
-	}
-	return *a.TextSize
-}
-
-// GetOkTextSize returns a tuple with the TextSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTextSizeOk() (string, bool) {
-	if a == nil || a.TextSize == nil {
-		return "", false
-	}
-	return *a.TextSize, true
-}
-
-// HasTextSize returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTextSize() bool {
-	if a != nil && a.TextSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextSize allocates a new a.TextSize and returns the pointer to it.
-func (a *AlertValueWidget) SetTextSize(v string) {
-	a.TextSize = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTimeframe() string {
-	if a == nil || a.Timeframe == nil {
-		return ""
-	}
-	return *a.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTimeframeOk() (string, bool) {
-	if a == nil || a.Timeframe == nil {
-		return "", false
-	}
-	return *a.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTimeframe() bool {
-	if a != nil && a.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new a.Timeframe and returns the pointer to it.
-func (a *AlertValueWidget) SetTimeframe(v string) {
-	a.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTitle() bool {
-	if a == nil || a.Title == nil {
-		return false
-	}
-	return *a.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTitleOk() (bool, bool) {
-	if a == nil || a.Title == nil {
-		return false, false
-	}
-	return *a.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTitle() bool {
-	if a != nil && a.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new a.Title and returns the pointer to it.
-func (a *AlertValueWidget) SetTitle(v bool) {
-	a.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTitleAlign() string {
-	if a == nil || a.TitleAlign == nil {
-		return ""
-	}
-	return *a.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTitleAlignOk() (string, bool) {
-	if a == nil || a.TitleAlign == nil {
-		return "", false
-	}
-	return *a.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTitleAlign() bool {
-	if a != nil && a.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new a.TitleAlign and returns the pointer to it.
-func (a *AlertValueWidget) SetTitleAlign(v string) {
-	a.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTitleSize() int {
-	if a == nil || a.TitleSize == nil {
-		return 0
-	}
-	return *a.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTitleSizeOk() (int, bool) {
-	if a == nil || a.TitleSize == nil {
-		return 0, false
-	}
-	return *a.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTitleSize() bool {
-	if a != nil && a.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new a.TitleSize and returns the pointer to it.
-func (a *AlertValueWidget) SetTitleSize(v int) {
-	a.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetTitleText() string {
-	if a == nil || a.TitleText == nil {
-		return ""
-	}
-	return *a.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTitleTextOk() (string, bool) {
-	if a == nil || a.TitleText == nil {
-		return "", false
-	}
-	return *a.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasTitleText() bool {
-	if a != nil && a.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new a.TitleText and returns the pointer to it.
-func (a *AlertValueWidget) SetTitleText(v string) {
-	a.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetType() string {
-	if a == nil || a.Type == nil {
-		return ""
-	}
-	return *a.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetTypeOk() (string, bool) {
-	if a == nil || a.Type == nil {
-		return "", false
-	}
-	return *a.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasType() bool {
-	if a != nil && a.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new a.Type and returns the pointer to it.
-func (a *AlertValueWidget) SetType(v string) {
-	a.Type = &v
-}
-
-// GetUnit returns the Unit field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetUnit() string {
-	if a == nil || a.Unit == nil {
-		return ""
-	}
-	return *a.Unit
-}
-
-// GetOkUnit returns a tuple with the Unit field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetUnitOk() (string, bool) {
-	if a == nil || a.Unit == nil {
-		return "", false
-	}
-	return *a.Unit, true
-}
-
-// HasUnit returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasUnit() bool {
-	if a != nil && a.Unit != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetUnit allocates a new a.Unit and returns the pointer to it.
-func (a *AlertValueWidget) SetUnit(v string) {
-	a.Unit = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetWidth() int {
-	if a == nil || a.Width == nil {
-		return 0
-	}
-	return *a.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetWidthOk() (int, bool) {
-	if a == nil || a.Width == nil {
-		return 0, false
-	}
-	return *a.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasWidth() bool {
-	if a != nil && a.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new a.Width and returns the pointer to it.
-func (a *AlertValueWidget) SetWidth(v int) {
-	a.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetX() int {
-	if a == nil || a.X == nil {
-		return 0
-	}
-	return *a.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetXOk() (int, bool) {
-	if a == nil || a.X == nil {
-		return 0, false
-	}
-	return *a.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasX() bool {
-	if a != nil && a.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new a.X and returns the pointer to it.
-func (a *AlertValueWidget) SetX(v int) {
-	a.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (a *AlertValueWidget) GetY() int {
-	if a == nil || a.Y == nil {
-		return 0
-	}
-	return *a.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (a *AlertValueWidget) GetYOk() (int, bool) {
-	if a == nil || a.Y == nil {
-		return 0, false
-	}
-	return *a.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (a *AlertValueWidget) HasY() bool {
-	if a != nil && a.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new a.Y and returns the pointer to it.
-func (a *AlertValueWidget) SetY(v int) {
-	a.Y = &v
-}
-
-// GetAggregator returns the Aggregator field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetAggregator() string {
-	if c == nil || c.Aggregator == nil {
-		return ""
-	}
-	return *c.Aggregator
-}
-
-// GetOkAggregator returns a tuple with the Aggregator field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetAggregatorOk() (string, bool) {
-	if c == nil || c.Aggregator == nil {
-		return "", false
-	}
-	return *c.Aggregator, true
-}
-
-// HasAggregator returns a boolean if a field has been set.
-func (c *ChangeWidget) HasAggregator() bool {
-	if c != nil && c.Aggregator != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAggregator allocates a new c.Aggregator and returns the pointer to it.
-func (c *ChangeWidget) SetAggregator(v string) {
-	c.Aggregator = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetHeight() int {
-	if c == nil || c.Height == nil {
-		return 0
-	}
-	return *c.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetHeightOk() (int, bool) {
-	if c == nil || c.Height == nil {
-		return 0, false
-	}
-	return *c.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (c *ChangeWidget) HasHeight() bool {
-	if c != nil && c.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new c.Height and returns the pointer to it.
-func (c *ChangeWidget) SetHeight(v int) {
-	c.Height = &v
-}
-
-// GetTileDef returns the TileDef field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetTileDef() TileDef {
-	if c == nil || c.TileDef == nil {
-		return TileDef{}
-	}
-	return *c.TileDef
-}
-
-// GetOkTileDef returns a tuple with the TileDef field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetTileDefOk() (TileDef, bool) {
-	if c == nil || c.TileDef == nil {
-		return TileDef{}, false
-	}
-	return *c.TileDef, true
-}
-
-// HasTileDef returns a boolean if a field has been set.
-func (c *ChangeWidget) HasTileDef() bool {
-	if c != nil && c.TileDef != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTileDef allocates a new c.TileDef and returns the pointer to it.
-func (c *ChangeWidget) SetTileDef(v TileDef) {
-	c.TileDef = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetTitle() bool {
-	if c == nil || c.Title == nil {
-		return false
-	}
-	return *c.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetTitleOk() (bool, bool) {
-	if c == nil || c.Title == nil {
-		return false, false
-	}
-	return *c.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (c *ChangeWidget) HasTitle() bool {
-	if c != nil && c.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new c.Title and returns the pointer to it.
-func (c *ChangeWidget) SetTitle(v bool) {
-	c.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetTitleAlign() string {
-	if c == nil || c.TitleAlign == nil {
-		return ""
-	}
-	return *c.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetTitleAlignOk() (string, bool) {
-	if c == nil || c.TitleAlign == nil {
-		return "", false
-	}
-	return *c.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (c *ChangeWidget) HasTitleAlign() bool {
-	if c != nil && c.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new c.TitleAlign and returns the pointer to it.
-func (c *ChangeWidget) SetTitleAlign(v string) {
-	c.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetTitleSize() int {
-	if c == nil || c.TitleSize == nil {
-		return 0
-	}
-	return *c.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetTitleSizeOk() (int, bool) {
-	if c == nil || c.TitleSize == nil {
-		return 0, false
-	}
-	return *c.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (c *ChangeWidget) HasTitleSize() bool {
-	if c != nil && c.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new c.TitleSize and returns the pointer to it.
-func (c *ChangeWidget) SetTitleSize(v int) {
-	c.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetTitleText() string {
-	if c == nil || c.TitleText == nil {
-		return ""
-	}
-	return *c.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetTitleTextOk() (string, bool) {
-	if c == nil || c.TitleText == nil {
-		return "", false
-	}
-	return *c.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (c *ChangeWidget) HasTitleText() bool {
-	if c != nil && c.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new c.TitleText and returns the pointer to it.
-func (c *ChangeWidget) SetTitleText(v string) {
-	c.TitleText = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetWidth() int {
-	if c == nil || c.Width == nil {
-		return 0
-	}
-	return *c.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetWidthOk() (int, bool) {
-	if c == nil || c.Width == nil {
-		return 0, false
-	}
-	return *c.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (c *ChangeWidget) HasWidth() bool {
-	if c != nil && c.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new c.Width and returns the pointer to it.
-func (c *ChangeWidget) SetWidth(v int) {
-	c.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetX() int {
-	if c == nil || c.X == nil {
-		return 0
-	}
-	return *c.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetXOk() (int, bool) {
-	if c == nil || c.X == nil {
-		return 0, false
-	}
-	return *c.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (c *ChangeWidget) HasX() bool {
-	if c != nil && c.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new c.X and returns the pointer to it.
-func (c *ChangeWidget) SetX(v int) {
-	c.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (c *ChangeWidget) GetY() int {
-	if c == nil || c.Y == nil {
-		return 0
-	}
-	return *c.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *ChangeWidget) GetYOk() (int, bool) {
-	if c == nil || c.Y == nil {
-		return 0, false
-	}
-	return *c.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (c *ChangeWidget) HasY() bool {
-	if c != nil && c.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new c.Y and returns the pointer to it.
-func (c *ChangeWidget) SetY(v int) {
-	c.Y = &v
-}
-
 // GetAccount returns the Account field if non-nil, zero value otherwise.
 func (c *ChannelSlackRequest) GetAccount() string {
 	if c == nil || c.Account == nil {
@@ -1716,502 +507,6 @@ func (c *Check) HasTimestamp() bool {
 // SetTimestamp allocates a new c.Timestamp and returns the pointer to it.
 func (c *Check) SetTimestamp(v string) {
 	c.Timestamp = &v
-}
-
-// GetCheck returns the Check field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetCheck() string {
-	if c == nil || c.Check == nil {
-		return ""
-	}
-	return *c.Check
-}
-
-// GetOkCheck returns a tuple with the Check field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetCheckOk() (string, bool) {
-	if c == nil || c.Check == nil {
-		return "", false
-	}
-	return *c.Check, true
-}
-
-// HasCheck returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasCheck() bool {
-	if c != nil && c.Check != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetCheck allocates a new c.Check and returns the pointer to it.
-func (c *CheckStatusWidget) SetCheck(v string) {
-	c.Check = &v
-}
-
-// GetGroup returns the Group field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetGroup() string {
-	if c == nil || c.Group == nil {
-		return ""
-	}
-	return *c.Group
-}
-
-// GetOkGroup returns a tuple with the Group field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetGroupOk() (string, bool) {
-	if c == nil || c.Group == nil {
-		return "", false
-	}
-	return *c.Group, true
-}
-
-// HasGroup returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasGroup() bool {
-	if c != nil && c.Group != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetGroup allocates a new c.Group and returns the pointer to it.
-func (c *CheckStatusWidget) SetGroup(v string) {
-	c.Group = &v
-}
-
-// GetGrouping returns the Grouping field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetGrouping() string {
-	if c == nil || c.Grouping == nil {
-		return ""
-	}
-	return *c.Grouping
-}
-
-// GetOkGrouping returns a tuple with the Grouping field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetGroupingOk() (string, bool) {
-	if c == nil || c.Grouping == nil {
-		return "", false
-	}
-	return *c.Grouping, true
-}
-
-// HasGrouping returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasGrouping() bool {
-	if c != nil && c.Grouping != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetGrouping allocates a new c.Grouping and returns the pointer to it.
-func (c *CheckStatusWidget) SetGrouping(v string) {
-	c.Grouping = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetHeight() int {
-	if c == nil || c.Height == nil {
-		return 0
-	}
-	return *c.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetHeightOk() (int, bool) {
-	if c == nil || c.Height == nil {
-		return 0, false
-	}
-	return *c.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasHeight() bool {
-	if c != nil && c.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new c.Height and returns the pointer to it.
-func (c *CheckStatusWidget) SetHeight(v int) {
-	c.Height = &v
-}
-
-// GetTags returns the Tags field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTags() string {
-	if c == nil || c.Tags == nil {
-		return ""
-	}
-	return *c.Tags
-}
-
-// GetOkTags returns a tuple with the Tags field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTagsOk() (string, bool) {
-	if c == nil || c.Tags == nil {
-		return "", false
-	}
-	return *c.Tags, true
-}
-
-// HasTags returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTags() bool {
-	if c != nil && c.Tags != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTags allocates a new c.Tags and returns the pointer to it.
-func (c *CheckStatusWidget) SetTags(v string) {
-	c.Tags = &v
-}
-
-// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTextAlign() string {
-	if c == nil || c.TextAlign == nil {
-		return ""
-	}
-	return *c.TextAlign
-}
-
-// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTextAlignOk() (string, bool) {
-	if c == nil || c.TextAlign == nil {
-		return "", false
-	}
-	return *c.TextAlign, true
-}
-
-// HasTextAlign returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTextAlign() bool {
-	if c != nil && c.TextAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextAlign allocates a new c.TextAlign and returns the pointer to it.
-func (c *CheckStatusWidget) SetTextAlign(v string) {
-	c.TextAlign = &v
-}
-
-// GetTextSize returns the TextSize field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTextSize() string {
-	if c == nil || c.TextSize == nil {
-		return ""
-	}
-	return *c.TextSize
-}
-
-// GetOkTextSize returns a tuple with the TextSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTextSizeOk() (string, bool) {
-	if c == nil || c.TextSize == nil {
-		return "", false
-	}
-	return *c.TextSize, true
-}
-
-// HasTextSize returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTextSize() bool {
-	if c != nil && c.TextSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextSize allocates a new c.TextSize and returns the pointer to it.
-func (c *CheckStatusWidget) SetTextSize(v string) {
-	c.TextSize = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTimeframe() string {
-	if c == nil || c.Timeframe == nil {
-		return ""
-	}
-	return *c.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTimeframeOk() (string, bool) {
-	if c == nil || c.Timeframe == nil {
-		return "", false
-	}
-	return *c.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTimeframe() bool {
-	if c != nil && c.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new c.Timeframe and returns the pointer to it.
-func (c *CheckStatusWidget) SetTimeframe(v string) {
-	c.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTitle() bool {
-	if c == nil || c.Title == nil {
-		return false
-	}
-	return *c.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTitleOk() (bool, bool) {
-	if c == nil || c.Title == nil {
-		return false, false
-	}
-	return *c.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTitle() bool {
-	if c != nil && c.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new c.Title and returns the pointer to it.
-func (c *CheckStatusWidget) SetTitle(v bool) {
-	c.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTitleAlign() string {
-	if c == nil || c.TitleAlign == nil {
-		return ""
-	}
-	return *c.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTitleAlignOk() (string, bool) {
-	if c == nil || c.TitleAlign == nil {
-		return "", false
-	}
-	return *c.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTitleAlign() bool {
-	if c != nil && c.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new c.TitleAlign and returns the pointer to it.
-func (c *CheckStatusWidget) SetTitleAlign(v string) {
-	c.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTitleSize() int {
-	if c == nil || c.TitleSize == nil {
-		return 0
-	}
-	return *c.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTitleSizeOk() (int, bool) {
-	if c == nil || c.TitleSize == nil {
-		return 0, false
-	}
-	return *c.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTitleSize() bool {
-	if c != nil && c.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new c.TitleSize and returns the pointer to it.
-func (c *CheckStatusWidget) SetTitleSize(v int) {
-	c.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetTitleText() string {
-	if c == nil || c.TitleText == nil {
-		return ""
-	}
-	return *c.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTitleTextOk() (string, bool) {
-	if c == nil || c.TitleText == nil {
-		return "", false
-	}
-	return *c.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasTitleText() bool {
-	if c != nil && c.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new c.TitleText and returns the pointer to it.
-func (c *CheckStatusWidget) SetTitleText(v string) {
-	c.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetType() string {
-	if c == nil || c.Type == nil {
-		return ""
-	}
-	return *c.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetTypeOk() (string, bool) {
-	if c == nil || c.Type == nil {
-		return "", false
-	}
-	return *c.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasType() bool {
-	if c != nil && c.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new c.Type and returns the pointer to it.
-func (c *CheckStatusWidget) SetType(v string) {
-	c.Type = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetWidth() int {
-	if c == nil || c.Width == nil {
-		return 0
-	}
-	return *c.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetWidthOk() (int, bool) {
-	if c == nil || c.Width == nil {
-		return 0, false
-	}
-	return *c.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasWidth() bool {
-	if c != nil && c.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new c.Width and returns the pointer to it.
-func (c *CheckStatusWidget) SetWidth(v int) {
-	c.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetX() int {
-	if c == nil || c.X == nil {
-		return 0
-	}
-	return *c.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetXOk() (int, bool) {
-	if c == nil || c.X == nil {
-		return 0, false
-	}
-	return *c.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasX() bool {
-	if c != nil && c.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new c.X and returns the pointer to it.
-func (c *CheckStatusWidget) SetX(v int) {
-	c.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (c *CheckStatusWidget) GetY() int {
-	if c == nil || c.Y == nil {
-		return 0
-	}
-	return *c.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (c *CheckStatusWidget) GetYOk() (int, bool) {
-	if c == nil || c.Y == nil {
-		return 0, false
-	}
-	return *c.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (c *CheckStatusWidget) HasY() bool {
-	if c != nil && c.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new c.Y and returns the pointer to it.
-func (c *CheckStatusWidget) SetY(v int) {
-	c.Y = &v
 }
 
 // GetHandle returns the Handle field if non-nil, zero value otherwise.
@@ -2462,50 +757,112 @@ func (c *ConditionalFormat) SetComparator(v string) {
 	c.Comparator = &v
 }
 
-// GetInverted returns the Inverted field if non-nil, zero value otherwise.
-func (c *ConditionalFormat) GetInverted() bool {
-	if c == nil || c.Inverted == nil {
-		return false
+// GetImageURL returns the ImageURL field if non-nil, zero value otherwise.
+func (c *ConditionalFormat) GetImageURL() string {
+	if c == nil || c.ImageURL == nil {
+		return ""
 	}
-	return *c.Inverted
+	return *c.ImageURL
 }
 
-// GetOkInverted returns a tuple with the Inverted field if it's non-nil, zero value otherwise
+// GetOkImageURL returns a tuple with the ImageURL field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (c *ConditionalFormat) GetInvertedOk() (bool, bool) {
-	if c == nil || c.Inverted == nil {
-		return false, false
+func (c *ConditionalFormat) GetImageURLOk() (string, bool) {
+	if c == nil || c.ImageURL == nil {
+		return "", false
 	}
-	return *c.Inverted, true
+	return *c.ImageURL, true
 }
 
-// HasInverted returns a boolean if a field has been set.
-func (c *ConditionalFormat) HasInverted() bool {
-	if c != nil && c.Inverted != nil {
+// HasImageURL returns a boolean if a field has been set.
+func (c *ConditionalFormat) HasImageURL() bool {
+	if c != nil && c.ImageURL != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetInverted allocates a new c.Inverted and returns the pointer to it.
-func (c *ConditionalFormat) SetInverted(v bool) {
-	c.Inverted = &v
+// SetImageURL allocates a new c.ImageURL and returns the pointer to it.
+func (c *ConditionalFormat) SetImageURL(v string) {
+	c.ImageURL = &v
+}
+
+// GetInvert returns the Invert field if non-nil, zero value otherwise.
+func (c *ConditionalFormat) GetInvert() bool {
+	if c == nil || c.Invert == nil {
+		return false
+	}
+	return *c.Invert
+}
+
+// GetOkInvert returns a tuple with the Invert field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ConditionalFormat) GetInvertOk() (bool, bool) {
+	if c == nil || c.Invert == nil {
+		return false, false
+	}
+	return *c.Invert, true
+}
+
+// HasInvert returns a boolean if a field has been set.
+func (c *ConditionalFormat) HasInvert() bool {
+	if c != nil && c.Invert != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetInvert allocates a new c.Invert and returns the pointer to it.
+func (c *ConditionalFormat) SetInvert(v bool) {
+	c.Invert = &v
+}
+
+// GetPalette returns the Palette field if non-nil, zero value otherwise.
+func (c *ConditionalFormat) GetPalette() string {
+	if c == nil || c.Palette == nil {
+		return ""
+	}
+	return *c.Palette
+}
+
+// GetOkPalette returns a tuple with the Palette field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ConditionalFormat) GetPaletteOk() (string, bool) {
+	if c == nil || c.Palette == nil {
+		return "", false
+	}
+	return *c.Palette, true
+}
+
+// HasPalette returns a boolean if a field has been set.
+func (c *ConditionalFormat) HasPalette() bool {
+	if c != nil && c.Palette != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPalette allocates a new c.Palette and returns the pointer to it.
+func (c *ConditionalFormat) SetPalette(v string) {
+	c.Palette = &v
 }
 
 // GetValue returns the Value field if non-nil, zero value otherwise.
-func (c *ConditionalFormat) GetValue() int {
+func (c *ConditionalFormat) GetValue() string {
 	if c == nil || c.Value == nil {
-		return 0
+		return ""
 	}
 	return *c.Value
 }
 
 // GetOkValue returns a tuple with the Value field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (c *ConditionalFormat) GetValueOk() (int, bool) {
+func (c *ConditionalFormat) GetValueOk() (string, bool) {
 	if c == nil || c.Value == nil {
-		return 0, false
+		return "", false
 	}
 	return *c.Value, true
 }
@@ -2520,7 +877,7 @@ func (c *ConditionalFormat) HasValue() bool {
 }
 
 // SetValue allocates a new c.Value and returns the pointer to it.
-func (c *ConditionalFormat) SetValue(v int) {
+func (c *ConditionalFormat) SetValue(v string) {
 	c.Value = &v
 }
 
@@ -3919,998 +2276,6 @@ func (e *Event) SetUrl(v string) {
 	e.Url = &v
 }
 
-// GetEventSize returns the EventSize field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetEventSize() string {
-	if e == nil || e.EventSize == nil {
-		return ""
-	}
-	return *e.EventSize
-}
-
-// GetOkEventSize returns a tuple with the EventSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetEventSizeOk() (string, bool) {
-	if e == nil || e.EventSize == nil {
-		return "", false
-	}
-	return *e.EventSize, true
-}
-
-// HasEventSize returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasEventSize() bool {
-	if e != nil && e.EventSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetEventSize allocates a new e.EventSize and returns the pointer to it.
-func (e *EventStreamWidget) SetEventSize(v string) {
-	e.EventSize = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetHeight() int {
-	if e == nil || e.Height == nil {
-		return 0
-	}
-	return *e.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetHeightOk() (int, bool) {
-	if e == nil || e.Height == nil {
-		return 0, false
-	}
-	return *e.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasHeight() bool {
-	if e != nil && e.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new e.Height and returns the pointer to it.
-func (e *EventStreamWidget) SetHeight(v int) {
-	e.Height = &v
-}
-
-// GetQuery returns the Query field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetQuery() string {
-	if e == nil || e.Query == nil {
-		return ""
-	}
-	return *e.Query
-}
-
-// GetOkQuery returns a tuple with the Query field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetQueryOk() (string, bool) {
-	if e == nil || e.Query == nil {
-		return "", false
-	}
-	return *e.Query, true
-}
-
-// HasQuery returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasQuery() bool {
-	if e != nil && e.Query != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetQuery allocates a new e.Query and returns the pointer to it.
-func (e *EventStreamWidget) SetQuery(v string) {
-	e.Query = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetTimeframe() string {
-	if e == nil || e.Timeframe == nil {
-		return ""
-	}
-	return *e.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetTimeframeOk() (string, bool) {
-	if e == nil || e.Timeframe == nil {
-		return "", false
-	}
-	return *e.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasTimeframe() bool {
-	if e != nil && e.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new e.Timeframe and returns the pointer to it.
-func (e *EventStreamWidget) SetTimeframe(v string) {
-	e.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetTitle() bool {
-	if e == nil || e.Title == nil {
-		return false
-	}
-	return *e.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetTitleOk() (bool, bool) {
-	if e == nil || e.Title == nil {
-		return false, false
-	}
-	return *e.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasTitle() bool {
-	if e != nil && e.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new e.Title and returns the pointer to it.
-func (e *EventStreamWidget) SetTitle(v bool) {
-	e.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetTitleAlign() string {
-	if e == nil || e.TitleAlign == nil {
-		return ""
-	}
-	return *e.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetTitleAlignOk() (string, bool) {
-	if e == nil || e.TitleAlign == nil {
-		return "", false
-	}
-	return *e.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasTitleAlign() bool {
-	if e != nil && e.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new e.TitleAlign and returns the pointer to it.
-func (e *EventStreamWidget) SetTitleAlign(v string) {
-	e.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetTitleSize() TextSize {
-	if e == nil || e.TitleSize == nil {
-		return TextSize{}
-	}
-	return *e.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetTitleSizeOk() (TextSize, bool) {
-	if e == nil || e.TitleSize == nil {
-		return TextSize{}, false
-	}
-	return *e.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasTitleSize() bool {
-	if e != nil && e.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new e.TitleSize and returns the pointer to it.
-func (e *EventStreamWidget) SetTitleSize(v TextSize) {
-	e.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetTitleText() string {
-	if e == nil || e.TitleText == nil {
-		return ""
-	}
-	return *e.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetTitleTextOk() (string, bool) {
-	if e == nil || e.TitleText == nil {
-		return "", false
-	}
-	return *e.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasTitleText() bool {
-	if e != nil && e.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new e.TitleText and returns the pointer to it.
-func (e *EventStreamWidget) SetTitleText(v string) {
-	e.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetType() string {
-	if e == nil || e.Type == nil {
-		return ""
-	}
-	return *e.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetTypeOk() (string, bool) {
-	if e == nil || e.Type == nil {
-		return "", false
-	}
-	return *e.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasType() bool {
-	if e != nil && e.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new e.Type and returns the pointer to it.
-func (e *EventStreamWidget) SetType(v string) {
-	e.Type = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetWidth() int {
-	if e == nil || e.Width == nil {
-		return 0
-	}
-	return *e.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetWidthOk() (int, bool) {
-	if e == nil || e.Width == nil {
-		return 0, false
-	}
-	return *e.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasWidth() bool {
-	if e != nil && e.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new e.Width and returns the pointer to it.
-func (e *EventStreamWidget) SetWidth(v int) {
-	e.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetX() int {
-	if e == nil || e.X == nil {
-		return 0
-	}
-	return *e.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetXOk() (int, bool) {
-	if e == nil || e.X == nil {
-		return 0, false
-	}
-	return *e.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasX() bool {
-	if e != nil && e.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new e.X and returns the pointer to it.
-func (e *EventStreamWidget) SetX(v int) {
-	e.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (e *EventStreamWidget) GetY() int {
-	if e == nil || e.Y == nil {
-		return 0
-	}
-	return *e.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventStreamWidget) GetYOk() (int, bool) {
-	if e == nil || e.Y == nil {
-		return 0, false
-	}
-	return *e.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (e *EventStreamWidget) HasY() bool {
-	if e != nil && e.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new e.Y and returns the pointer to it.
-func (e *EventStreamWidget) SetY(v int) {
-	e.Y = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetHeight() int {
-	if e == nil || e.Height == nil {
-		return 0
-	}
-	return *e.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetHeightOk() (int, bool) {
-	if e == nil || e.Height == nil {
-		return 0, false
-	}
-	return *e.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasHeight() bool {
-	if e != nil && e.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new e.Height and returns the pointer to it.
-func (e *EventTimelineWidget) SetHeight(v int) {
-	e.Height = &v
-}
-
-// GetQuery returns the Query field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetQuery() string {
-	if e == nil || e.Query == nil {
-		return ""
-	}
-	return *e.Query
-}
-
-// GetOkQuery returns a tuple with the Query field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetQueryOk() (string, bool) {
-	if e == nil || e.Query == nil {
-		return "", false
-	}
-	return *e.Query, true
-}
-
-// HasQuery returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasQuery() bool {
-	if e != nil && e.Query != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetQuery allocates a new e.Query and returns the pointer to it.
-func (e *EventTimelineWidget) SetQuery(v string) {
-	e.Query = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetTimeframe() string {
-	if e == nil || e.Timeframe == nil {
-		return ""
-	}
-	return *e.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetTimeframeOk() (string, bool) {
-	if e == nil || e.Timeframe == nil {
-		return "", false
-	}
-	return *e.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasTimeframe() bool {
-	if e != nil && e.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new e.Timeframe and returns the pointer to it.
-func (e *EventTimelineWidget) SetTimeframe(v string) {
-	e.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetTitle() bool {
-	if e == nil || e.Title == nil {
-		return false
-	}
-	return *e.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetTitleOk() (bool, bool) {
-	if e == nil || e.Title == nil {
-		return false, false
-	}
-	return *e.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasTitle() bool {
-	if e != nil && e.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new e.Title and returns the pointer to it.
-func (e *EventTimelineWidget) SetTitle(v bool) {
-	e.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetTitleAlign() string {
-	if e == nil || e.TitleAlign == nil {
-		return ""
-	}
-	return *e.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetTitleAlignOk() (string, bool) {
-	if e == nil || e.TitleAlign == nil {
-		return "", false
-	}
-	return *e.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasTitleAlign() bool {
-	if e != nil && e.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new e.TitleAlign and returns the pointer to it.
-func (e *EventTimelineWidget) SetTitleAlign(v string) {
-	e.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetTitleSize() int {
-	if e == nil || e.TitleSize == nil {
-		return 0
-	}
-	return *e.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetTitleSizeOk() (int, bool) {
-	if e == nil || e.TitleSize == nil {
-		return 0, false
-	}
-	return *e.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasTitleSize() bool {
-	if e != nil && e.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new e.TitleSize and returns the pointer to it.
-func (e *EventTimelineWidget) SetTitleSize(v int) {
-	e.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetTitleText() string {
-	if e == nil || e.TitleText == nil {
-		return ""
-	}
-	return *e.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetTitleTextOk() (string, bool) {
-	if e == nil || e.TitleText == nil {
-		return "", false
-	}
-	return *e.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasTitleText() bool {
-	if e != nil && e.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new e.TitleText and returns the pointer to it.
-func (e *EventTimelineWidget) SetTitleText(v string) {
-	e.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetType() string {
-	if e == nil || e.Type == nil {
-		return ""
-	}
-	return *e.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetTypeOk() (string, bool) {
-	if e == nil || e.Type == nil {
-		return "", false
-	}
-	return *e.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasType() bool {
-	if e != nil && e.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new e.Type and returns the pointer to it.
-func (e *EventTimelineWidget) SetType(v string) {
-	e.Type = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetWidth() int {
-	if e == nil || e.Width == nil {
-		return 0
-	}
-	return *e.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetWidthOk() (int, bool) {
-	if e == nil || e.Width == nil {
-		return 0, false
-	}
-	return *e.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasWidth() bool {
-	if e != nil && e.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new e.Width and returns the pointer to it.
-func (e *EventTimelineWidget) SetWidth(v int) {
-	e.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetX() int {
-	if e == nil || e.X == nil {
-		return 0
-	}
-	return *e.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetXOk() (int, bool) {
-	if e == nil || e.X == nil {
-		return 0, false
-	}
-	return *e.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasX() bool {
-	if e != nil && e.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new e.X and returns the pointer to it.
-func (e *EventTimelineWidget) SetX(v int) {
-	e.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (e *EventTimelineWidget) GetY() int {
-	if e == nil || e.Y == nil {
-		return 0
-	}
-	return *e.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (e *EventTimelineWidget) GetYOk() (int, bool) {
-	if e == nil || e.Y == nil {
-		return 0, false
-	}
-	return *e.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (e *EventTimelineWidget) HasY() bool {
-	if e != nil && e.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new e.Y and returns the pointer to it.
-func (e *EventTimelineWidget) SetY(v int) {
-	e.Y = &v
-}
-
-// GetColor returns the Color field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetColor() string {
-	if f == nil || f.Color == nil {
-		return ""
-	}
-	return *f.Color
-}
-
-// GetOkColor returns a tuple with the Color field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetColorOk() (string, bool) {
-	if f == nil || f.Color == nil {
-		return "", false
-	}
-	return *f.Color, true
-}
-
-// HasColor returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasColor() bool {
-	if f != nil && f.Color != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetColor allocates a new f.Color and returns the pointer to it.
-func (f *FreeTextWidget) SetColor(v string) {
-	f.Color = &v
-}
-
-// GetFontSize returns the FontSize field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetFontSize() string {
-	if f == nil || f.FontSize == nil {
-		return ""
-	}
-	return *f.FontSize
-}
-
-// GetOkFontSize returns a tuple with the FontSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetFontSizeOk() (string, bool) {
-	if f == nil || f.FontSize == nil {
-		return "", false
-	}
-	return *f.FontSize, true
-}
-
-// HasFontSize returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasFontSize() bool {
-	if f != nil && f.FontSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetFontSize allocates a new f.FontSize and returns the pointer to it.
-func (f *FreeTextWidget) SetFontSize(v string) {
-	f.FontSize = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetHeight() int {
-	if f == nil || f.Height == nil {
-		return 0
-	}
-	return *f.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetHeightOk() (int, bool) {
-	if f == nil || f.Height == nil {
-		return 0, false
-	}
-	return *f.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasHeight() bool {
-	if f != nil && f.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new f.Height and returns the pointer to it.
-func (f *FreeTextWidget) SetHeight(v int) {
-	f.Height = &v
-}
-
-// GetText returns the Text field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetText() string {
-	if f == nil || f.Text == nil {
-		return ""
-	}
-	return *f.Text
-}
-
-// GetOkText returns a tuple with the Text field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetTextOk() (string, bool) {
-	if f == nil || f.Text == nil {
-		return "", false
-	}
-	return *f.Text, true
-}
-
-// HasText returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasText() bool {
-	if f != nil && f.Text != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetText allocates a new f.Text and returns the pointer to it.
-func (f *FreeTextWidget) SetText(v string) {
-	f.Text = &v
-}
-
-// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetTextAlign() string {
-	if f == nil || f.TextAlign == nil {
-		return ""
-	}
-	return *f.TextAlign
-}
-
-// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetTextAlignOk() (string, bool) {
-	if f == nil || f.TextAlign == nil {
-		return "", false
-	}
-	return *f.TextAlign, true
-}
-
-// HasTextAlign returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasTextAlign() bool {
-	if f != nil && f.TextAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextAlign allocates a new f.TextAlign and returns the pointer to it.
-func (f *FreeTextWidget) SetTextAlign(v string) {
-	f.TextAlign = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetType() string {
-	if f == nil || f.Type == nil {
-		return ""
-	}
-	return *f.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetTypeOk() (string, bool) {
-	if f == nil || f.Type == nil {
-		return "", false
-	}
-	return *f.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasType() bool {
-	if f != nil && f.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new f.Type and returns the pointer to it.
-func (f *FreeTextWidget) SetType(v string) {
-	f.Type = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetWidth() int {
-	if f == nil || f.Width == nil {
-		return 0
-	}
-	return *f.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetWidthOk() (int, bool) {
-	if f == nil || f.Width == nil {
-		return 0, false
-	}
-	return *f.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasWidth() bool {
-	if f != nil && f.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new f.Width and returns the pointer to it.
-func (f *FreeTextWidget) SetWidth(v int) {
-	f.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetX() int {
-	if f == nil || f.X == nil {
-		return 0
-	}
-	return *f.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetXOk() (int, bool) {
-	if f == nil || f.X == nil {
-		return 0, false
-	}
-	return *f.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasX() bool {
-	if f != nil && f.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new f.X and returns the pointer to it.
-func (f *FreeTextWidget) SetX(v int) {
-	f.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (f *FreeTextWidget) GetY() int {
-	if f == nil || f.Y == nil {
-		return 0
-	}
-	return *f.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (f *FreeTextWidget) GetYOk() (int, bool) {
-	if f == nil || f.Y == nil {
-		return 0, false
-	}
-	return *f.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (f *FreeTextWidget) HasY() bool {
-	if f != nil && f.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new f.Y and returns the pointer to it.
-func (f *FreeTextWidget) SetY(v int) {
-	f.Y = &v
-}
-
 // GetDefinition returns the Definition field if non-nil, zero value otherwise.
 func (g *Graph) GetDefinition() GraphDefinition {
 	if g == nil || g.Definition == nil {
@@ -5872,409 +3237,6 @@ func (g *GraphEvent) SetQuery(v string) {
 	g.Query = &v
 }
 
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetHeight() int {
-	if g == nil || g.Height == nil {
-		return 0
-	}
-	return *g.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetHeightOk() (int, bool) {
-	if g == nil || g.Height == nil {
-		return 0, false
-	}
-	return *g.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (g *GraphWidget) HasHeight() bool {
-	if g != nil && g.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new g.Height and returns the pointer to it.
-func (g *GraphWidget) SetHeight(v int) {
-	g.Height = &v
-}
-
-// GetLegend returns the Legend field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetLegend() bool {
-	if g == nil || g.Legend == nil {
-		return false
-	}
-	return *g.Legend
-}
-
-// GetOkLegend returns a tuple with the Legend field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetLegendOk() (bool, bool) {
-	if g == nil || g.Legend == nil {
-		return false, false
-	}
-	return *g.Legend, true
-}
-
-// HasLegend returns a boolean if a field has been set.
-func (g *GraphWidget) HasLegend() bool {
-	if g != nil && g.Legend != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegend allocates a new g.Legend and returns the pointer to it.
-func (g *GraphWidget) SetLegend(v bool) {
-	g.Legend = &v
-}
-
-// GetLegendSize returns the LegendSize field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetLegendSize() int {
-	if g == nil || g.LegendSize == nil {
-		return 0
-	}
-	return *g.LegendSize
-}
-
-// GetOkLegendSize returns a tuple with the LegendSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetLegendSizeOk() (int, bool) {
-	if g == nil || g.LegendSize == nil {
-		return 0, false
-	}
-	return *g.LegendSize, true
-}
-
-// HasLegendSize returns a boolean if a field has been set.
-func (g *GraphWidget) HasLegendSize() bool {
-	if g != nil && g.LegendSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegendSize allocates a new g.LegendSize and returns the pointer to it.
-func (g *GraphWidget) SetLegendSize(v int) {
-	g.LegendSize = &v
-}
-
-// GetTileDef returns the TileDef field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetTileDef() TileDef {
-	if g == nil || g.TileDef == nil {
-		return TileDef{}
-	}
-	return *g.TileDef
-}
-
-// GetOkTileDef returns a tuple with the TileDef field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTileDefOk() (TileDef, bool) {
-	if g == nil || g.TileDef == nil {
-		return TileDef{}, false
-	}
-	return *g.TileDef, true
-}
-
-// HasTileDef returns a boolean if a field has been set.
-func (g *GraphWidget) HasTileDef() bool {
-	if g != nil && g.TileDef != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTileDef allocates a new g.TileDef and returns the pointer to it.
-func (g *GraphWidget) SetTileDef(v TileDef) {
-	g.TileDef = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetTimeframe() string {
-	if g == nil || g.Timeframe == nil {
-		return ""
-	}
-	return *g.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTimeframeOk() (string, bool) {
-	if g == nil || g.Timeframe == nil {
-		return "", false
-	}
-	return *g.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (g *GraphWidget) HasTimeframe() bool {
-	if g != nil && g.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new g.Timeframe and returns the pointer to it.
-func (g *GraphWidget) SetTimeframe(v string) {
-	g.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetTitle() bool {
-	if g == nil || g.Title == nil {
-		return false
-	}
-	return *g.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTitleOk() (bool, bool) {
-	if g == nil || g.Title == nil {
-		return false, false
-	}
-	return *g.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (g *GraphWidget) HasTitle() bool {
-	if g != nil && g.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new g.Title and returns the pointer to it.
-func (g *GraphWidget) SetTitle(v bool) {
-	g.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetTitleAlign() string {
-	if g == nil || g.TitleAlign == nil {
-		return ""
-	}
-	return *g.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTitleAlignOk() (string, bool) {
-	if g == nil || g.TitleAlign == nil {
-		return "", false
-	}
-	return *g.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (g *GraphWidget) HasTitleAlign() bool {
-	if g != nil && g.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new g.TitleAlign and returns the pointer to it.
-func (g *GraphWidget) SetTitleAlign(v string) {
-	g.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetTitleSize() int {
-	if g == nil || g.TitleSize == nil {
-		return 0
-	}
-	return *g.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTitleSizeOk() (int, bool) {
-	if g == nil || g.TitleSize == nil {
-		return 0, false
-	}
-	return *g.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (g *GraphWidget) HasTitleSize() bool {
-	if g != nil && g.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new g.TitleSize and returns the pointer to it.
-func (g *GraphWidget) SetTitleSize(v int) {
-	g.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetTitleText() string {
-	if g == nil || g.TitleText == nil {
-		return ""
-	}
-	return *g.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTitleTextOk() (string, bool) {
-	if g == nil || g.TitleText == nil {
-		return "", false
-	}
-	return *g.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (g *GraphWidget) HasTitleText() bool {
-	if g != nil && g.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new g.TitleText and returns the pointer to it.
-func (g *GraphWidget) SetTitleText(v string) {
-	g.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetType() string {
-	if g == nil || g.Type == nil {
-		return ""
-	}
-	return *g.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetTypeOk() (string, bool) {
-	if g == nil || g.Type == nil {
-		return "", false
-	}
-	return *g.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (g *GraphWidget) HasType() bool {
-	if g != nil && g.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new g.Type and returns the pointer to it.
-func (g *GraphWidget) SetType(v string) {
-	g.Type = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetWidth() int {
-	if g == nil || g.Width == nil {
-		return 0
-	}
-	return *g.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetWidthOk() (int, bool) {
-	if g == nil || g.Width == nil {
-		return 0, false
-	}
-	return *g.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (g *GraphWidget) HasWidth() bool {
-	if g != nil && g.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new g.Width and returns the pointer to it.
-func (g *GraphWidget) SetWidth(v int) {
-	g.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetX() int {
-	if g == nil || g.X == nil {
-		return 0
-	}
-	return *g.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetXOk() (int, bool) {
-	if g == nil || g.X == nil {
-		return 0, false
-	}
-	return *g.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (g *GraphWidget) HasX() bool {
-	if g != nil && g.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new g.X and returns the pointer to it.
-func (g *GraphWidget) SetX(v int) {
-	g.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (g *GraphWidget) GetY() int {
-	if g == nil || g.Y == nil {
-		return 0
-	}
-	return *g.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (g *GraphWidget) GetYOk() (int, bool) {
-	if g == nil || g.Y == nil {
-		return 0, false
-	}
-	return *g.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (g *GraphWidget) HasY() bool {
-	if g != nil && g.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new g.Y and returns the pointer to it.
-func (g *GraphWidget) SetY(v int) {
-	g.Y = &v
-}
-
 // GetEndTime returns the EndTime field if non-nil, zero value otherwise.
 func (h *HostActionMute) GetEndTime() string {
 	if h == nil || h.EndTime == nil {
@@ -6366,1091 +3328,6 @@ func (h *HostActionMute) HasOverride() bool {
 // SetOverride allocates a new h.Override and returns the pointer to it.
 func (h *HostActionMute) SetOverride(v bool) {
 	h.Override = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetHeight() int {
-	if h == nil || h.Height == nil {
-		return 0
-	}
-	return *h.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetHeightOk() (int, bool) {
-	if h == nil || h.Height == nil {
-		return 0, false
-	}
-	return *h.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (h *HostMapWidget) HasHeight() bool {
-	if h != nil && h.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new h.Height and returns the pointer to it.
-func (h *HostMapWidget) SetHeight(v int) {
-	h.Height = &v
-}
-
-// GetLegend returns the Legend field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetLegend() bool {
-	if h == nil || h.Legend == nil {
-		return false
-	}
-	return *h.Legend
-}
-
-// GetOkLegend returns a tuple with the Legend field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetLegendOk() (bool, bool) {
-	if h == nil || h.Legend == nil {
-		return false, false
-	}
-	return *h.Legend, true
-}
-
-// HasLegend returns a boolean if a field has been set.
-func (h *HostMapWidget) HasLegend() bool {
-	if h != nil && h.Legend != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegend allocates a new h.Legend and returns the pointer to it.
-func (h *HostMapWidget) SetLegend(v bool) {
-	h.Legend = &v
-}
-
-// GetLegendSize returns the LegendSize field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetLegendSize() int {
-	if h == nil || h.LegendSize == nil {
-		return 0
-	}
-	return *h.LegendSize
-}
-
-// GetOkLegendSize returns a tuple with the LegendSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetLegendSizeOk() (int, bool) {
-	if h == nil || h.LegendSize == nil {
-		return 0, false
-	}
-	return *h.LegendSize, true
-}
-
-// HasLegendSize returns a boolean if a field has been set.
-func (h *HostMapWidget) HasLegendSize() bool {
-	if h != nil && h.LegendSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegendSize allocates a new h.LegendSize and returns the pointer to it.
-func (h *HostMapWidget) SetLegendSize(v int) {
-	h.LegendSize = &v
-}
-
-// GetQuery returns the Query field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetQuery() string {
-	if h == nil || h.Query == nil {
-		return ""
-	}
-	return *h.Query
-}
-
-// GetOkQuery returns a tuple with the Query field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetQueryOk() (string, bool) {
-	if h == nil || h.Query == nil {
-		return "", false
-	}
-	return *h.Query, true
-}
-
-// HasQuery returns a boolean if a field has been set.
-func (h *HostMapWidget) HasQuery() bool {
-	if h != nil && h.Query != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetQuery allocates a new h.Query and returns the pointer to it.
-func (h *HostMapWidget) SetQuery(v string) {
-	h.Query = &v
-}
-
-// GetTileDef returns the TileDef field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetTileDef() TileDef {
-	if h == nil || h.TileDef == nil {
-		return TileDef{}
-	}
-	return *h.TileDef
-}
-
-// GetOkTileDef returns a tuple with the TileDef field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTileDefOk() (TileDef, bool) {
-	if h == nil || h.TileDef == nil {
-		return TileDef{}, false
-	}
-	return *h.TileDef, true
-}
-
-// HasTileDef returns a boolean if a field has been set.
-func (h *HostMapWidget) HasTileDef() bool {
-	if h != nil && h.TileDef != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTileDef allocates a new h.TileDef and returns the pointer to it.
-func (h *HostMapWidget) SetTileDef(v TileDef) {
-	h.TileDef = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetTimeframe() string {
-	if h == nil || h.Timeframe == nil {
-		return ""
-	}
-	return *h.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTimeframeOk() (string, bool) {
-	if h == nil || h.Timeframe == nil {
-		return "", false
-	}
-	return *h.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (h *HostMapWidget) HasTimeframe() bool {
-	if h != nil && h.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new h.Timeframe and returns the pointer to it.
-func (h *HostMapWidget) SetTimeframe(v string) {
-	h.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetTitle() bool {
-	if h == nil || h.Title == nil {
-		return false
-	}
-	return *h.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTitleOk() (bool, bool) {
-	if h == nil || h.Title == nil {
-		return false, false
-	}
-	return *h.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (h *HostMapWidget) HasTitle() bool {
-	if h != nil && h.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new h.Title and returns the pointer to it.
-func (h *HostMapWidget) SetTitle(v bool) {
-	h.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetTitleAlign() string {
-	if h == nil || h.TitleAlign == nil {
-		return ""
-	}
-	return *h.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTitleAlignOk() (string, bool) {
-	if h == nil || h.TitleAlign == nil {
-		return "", false
-	}
-	return *h.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (h *HostMapWidget) HasTitleAlign() bool {
-	if h != nil && h.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new h.TitleAlign and returns the pointer to it.
-func (h *HostMapWidget) SetTitleAlign(v string) {
-	h.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetTitleSize() int {
-	if h == nil || h.TitleSize == nil {
-		return 0
-	}
-	return *h.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTitleSizeOk() (int, bool) {
-	if h == nil || h.TitleSize == nil {
-		return 0, false
-	}
-	return *h.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (h *HostMapWidget) HasTitleSize() bool {
-	if h != nil && h.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new h.TitleSize and returns the pointer to it.
-func (h *HostMapWidget) SetTitleSize(v int) {
-	h.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetTitleText() string {
-	if h == nil || h.TitleText == nil {
-		return ""
-	}
-	return *h.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTitleTextOk() (string, bool) {
-	if h == nil || h.TitleText == nil {
-		return "", false
-	}
-	return *h.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (h *HostMapWidget) HasTitleText() bool {
-	if h != nil && h.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new h.TitleText and returns the pointer to it.
-func (h *HostMapWidget) SetTitleText(v string) {
-	h.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetType() string {
-	if h == nil || h.Type == nil {
-		return ""
-	}
-	return *h.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetTypeOk() (string, bool) {
-	if h == nil || h.Type == nil {
-		return "", false
-	}
-	return *h.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (h *HostMapWidget) HasType() bool {
-	if h != nil && h.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new h.Type and returns the pointer to it.
-func (h *HostMapWidget) SetType(v string) {
-	h.Type = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetWidth() int {
-	if h == nil || h.Width == nil {
-		return 0
-	}
-	return *h.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetWidthOk() (int, bool) {
-	if h == nil || h.Width == nil {
-		return 0, false
-	}
-	return *h.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (h *HostMapWidget) HasWidth() bool {
-	if h != nil && h.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new h.Width and returns the pointer to it.
-func (h *HostMapWidget) SetWidth(v int) {
-	h.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetX() int {
-	if h == nil || h.X == nil {
-		return 0
-	}
-	return *h.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetXOk() (int, bool) {
-	if h == nil || h.X == nil {
-		return 0, false
-	}
-	return *h.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (h *HostMapWidget) HasX() bool {
-	if h != nil && h.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new h.X and returns the pointer to it.
-func (h *HostMapWidget) SetX(v int) {
-	h.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (h *HostMapWidget) GetY() int {
-	if h == nil || h.Y == nil {
-		return 0
-	}
-	return *h.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (h *HostMapWidget) GetYOk() (int, bool) {
-	if h == nil || h.Y == nil {
-		return 0, false
-	}
-	return *h.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (h *HostMapWidget) HasY() bool {
-	if h != nil && h.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new h.Y and returns the pointer to it.
-func (h *HostMapWidget) SetY(v int) {
-	h.Y = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetHeight() int {
-	if i == nil || i.Height == nil {
-		return 0
-	}
-	return *i.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetHeightOk() (int, bool) {
-	if i == nil || i.Height == nil {
-		return 0, false
-	}
-	return *i.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (i *IFrameWidget) HasHeight() bool {
-	if i != nil && i.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new i.Height and returns the pointer to it.
-func (i *IFrameWidget) SetHeight(v int) {
-	i.Height = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetTitle() bool {
-	if i == nil || i.Title == nil {
-		return false
-	}
-	return *i.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetTitleOk() (bool, bool) {
-	if i == nil || i.Title == nil {
-		return false, false
-	}
-	return *i.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (i *IFrameWidget) HasTitle() bool {
-	if i != nil && i.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new i.Title and returns the pointer to it.
-func (i *IFrameWidget) SetTitle(v bool) {
-	i.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetTitleAlign() string {
-	if i == nil || i.TitleAlign == nil {
-		return ""
-	}
-	return *i.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetTitleAlignOk() (string, bool) {
-	if i == nil || i.TitleAlign == nil {
-		return "", false
-	}
-	return *i.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (i *IFrameWidget) HasTitleAlign() bool {
-	if i != nil && i.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new i.TitleAlign and returns the pointer to it.
-func (i *IFrameWidget) SetTitleAlign(v string) {
-	i.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetTitleSize() int {
-	if i == nil || i.TitleSize == nil {
-		return 0
-	}
-	return *i.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetTitleSizeOk() (int, bool) {
-	if i == nil || i.TitleSize == nil {
-		return 0, false
-	}
-	return *i.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (i *IFrameWidget) HasTitleSize() bool {
-	if i != nil && i.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new i.TitleSize and returns the pointer to it.
-func (i *IFrameWidget) SetTitleSize(v int) {
-	i.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetTitleText() string {
-	if i == nil || i.TitleText == nil {
-		return ""
-	}
-	return *i.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetTitleTextOk() (string, bool) {
-	if i == nil || i.TitleText == nil {
-		return "", false
-	}
-	return *i.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (i *IFrameWidget) HasTitleText() bool {
-	if i != nil && i.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new i.TitleText and returns the pointer to it.
-func (i *IFrameWidget) SetTitleText(v string) {
-	i.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetType() string {
-	if i == nil || i.Type == nil {
-		return ""
-	}
-	return *i.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetTypeOk() (string, bool) {
-	if i == nil || i.Type == nil {
-		return "", false
-	}
-	return *i.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (i *IFrameWidget) HasType() bool {
-	if i != nil && i.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new i.Type and returns the pointer to it.
-func (i *IFrameWidget) SetType(v string) {
-	i.Type = &v
-}
-
-// GetUrl returns the Url field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetUrl() string {
-	if i == nil || i.Url == nil {
-		return ""
-	}
-	return *i.Url
-}
-
-// GetOkUrl returns a tuple with the Url field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetUrlOk() (string, bool) {
-	if i == nil || i.Url == nil {
-		return "", false
-	}
-	return *i.Url, true
-}
-
-// HasUrl returns a boolean if a field has been set.
-func (i *IFrameWidget) HasUrl() bool {
-	if i != nil && i.Url != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetUrl allocates a new i.Url and returns the pointer to it.
-func (i *IFrameWidget) SetUrl(v string) {
-	i.Url = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetWidth() int {
-	if i == nil || i.Width == nil {
-		return 0
-	}
-	return *i.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetWidthOk() (int, bool) {
-	if i == nil || i.Width == nil {
-		return 0, false
-	}
-	return *i.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (i *IFrameWidget) HasWidth() bool {
-	if i != nil && i.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new i.Width and returns the pointer to it.
-func (i *IFrameWidget) SetWidth(v int) {
-	i.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetX() int {
-	if i == nil || i.X == nil {
-		return 0
-	}
-	return *i.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetXOk() (int, bool) {
-	if i == nil || i.X == nil {
-		return 0, false
-	}
-	return *i.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (i *IFrameWidget) HasX() bool {
-	if i != nil && i.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new i.X and returns the pointer to it.
-func (i *IFrameWidget) SetX(v int) {
-	i.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (i *IFrameWidget) GetY() int {
-	if i == nil || i.Y == nil {
-		return 0
-	}
-	return *i.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *IFrameWidget) GetYOk() (int, bool) {
-	if i == nil || i.Y == nil {
-		return 0, false
-	}
-	return *i.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (i *IFrameWidget) HasY() bool {
-	if i != nil && i.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new i.Y and returns the pointer to it.
-func (i *IFrameWidget) SetY(v int) {
-	i.Y = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetHeight() int {
-	if i == nil || i.Height == nil {
-		return 0
-	}
-	return *i.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetHeightOk() (int, bool) {
-	if i == nil || i.Height == nil {
-		return 0, false
-	}
-	return *i.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (i *ImageWidget) HasHeight() bool {
-	if i != nil && i.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new i.Height and returns the pointer to it.
-func (i *ImageWidget) SetHeight(v int) {
-	i.Height = &v
-}
-
-// GetSizing returns the Sizing field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetSizing() string {
-	if i == nil || i.Sizing == nil {
-		return ""
-	}
-	return *i.Sizing
-}
-
-// GetOkSizing returns a tuple with the Sizing field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetSizingOk() (string, bool) {
-	if i == nil || i.Sizing == nil {
-		return "", false
-	}
-	return *i.Sizing, true
-}
-
-// HasSizing returns a boolean if a field has been set.
-func (i *ImageWidget) HasSizing() bool {
-	if i != nil && i.Sizing != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetSizing allocates a new i.Sizing and returns the pointer to it.
-func (i *ImageWidget) SetSizing(v string) {
-	i.Sizing = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetTitle() bool {
-	if i == nil || i.Title == nil {
-		return false
-	}
-	return *i.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetTitleOk() (bool, bool) {
-	if i == nil || i.Title == nil {
-		return false, false
-	}
-	return *i.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (i *ImageWidget) HasTitle() bool {
-	if i != nil && i.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new i.Title and returns the pointer to it.
-func (i *ImageWidget) SetTitle(v bool) {
-	i.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetTitleAlign() string {
-	if i == nil || i.TitleAlign == nil {
-		return ""
-	}
-	return *i.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetTitleAlignOk() (string, bool) {
-	if i == nil || i.TitleAlign == nil {
-		return "", false
-	}
-	return *i.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (i *ImageWidget) HasTitleAlign() bool {
-	if i != nil && i.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new i.TitleAlign and returns the pointer to it.
-func (i *ImageWidget) SetTitleAlign(v string) {
-	i.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetTitleSize() TextSize {
-	if i == nil || i.TitleSize == nil {
-		return TextSize{}
-	}
-	return *i.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetTitleSizeOk() (TextSize, bool) {
-	if i == nil || i.TitleSize == nil {
-		return TextSize{}, false
-	}
-	return *i.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (i *ImageWidget) HasTitleSize() bool {
-	if i != nil && i.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new i.TitleSize and returns the pointer to it.
-func (i *ImageWidget) SetTitleSize(v TextSize) {
-	i.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetTitleText() string {
-	if i == nil || i.TitleText == nil {
-		return ""
-	}
-	return *i.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetTitleTextOk() (string, bool) {
-	if i == nil || i.TitleText == nil {
-		return "", false
-	}
-	return *i.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (i *ImageWidget) HasTitleText() bool {
-	if i != nil && i.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new i.TitleText and returns the pointer to it.
-func (i *ImageWidget) SetTitleText(v string) {
-	i.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetType() string {
-	if i == nil || i.Type == nil {
-		return ""
-	}
-	return *i.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetTypeOk() (string, bool) {
-	if i == nil || i.Type == nil {
-		return "", false
-	}
-	return *i.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (i *ImageWidget) HasType() bool {
-	if i != nil && i.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new i.Type and returns the pointer to it.
-func (i *ImageWidget) SetType(v string) {
-	i.Type = &v
-}
-
-// GetUrl returns the Url field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetUrl() string {
-	if i == nil || i.Url == nil {
-		return ""
-	}
-	return *i.Url
-}
-
-// GetOkUrl returns a tuple with the Url field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetUrlOk() (string, bool) {
-	if i == nil || i.Url == nil {
-		return "", false
-	}
-	return *i.Url, true
-}
-
-// HasUrl returns a boolean if a field has been set.
-func (i *ImageWidget) HasUrl() bool {
-	if i != nil && i.Url != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetUrl allocates a new i.Url and returns the pointer to it.
-func (i *ImageWidget) SetUrl(v string) {
-	i.Url = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetWidth() int {
-	if i == nil || i.Width == nil {
-		return 0
-	}
-	return *i.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetWidthOk() (int, bool) {
-	if i == nil || i.Width == nil {
-		return 0, false
-	}
-	return *i.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (i *ImageWidget) HasWidth() bool {
-	if i != nil && i.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new i.Width and returns the pointer to it.
-func (i *ImageWidget) SetWidth(v int) {
-	i.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetX() int {
-	if i == nil || i.X == nil {
-		return 0
-	}
-	return *i.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetXOk() (int, bool) {
-	if i == nil || i.X == nil {
-		return 0, false
-	}
-	return *i.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (i *ImageWidget) HasX() bool {
-	if i != nil && i.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new i.X and returns the pointer to it.
-func (i *ImageWidget) SetX(v int) {
-	i.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (i *ImageWidget) GetY() int {
-	if i == nil || i.Y == nil {
-		return 0
-	}
-	return *i.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (i *ImageWidget) GetYOk() (int, bool) {
-	if i == nil || i.Y == nil {
-		return 0, false
-	}
-	return *i.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (i *ImageWidget) HasY() bool {
-	if i != nil && i.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new i.Y and returns the pointer to it.
-func (i *ImageWidget) SetY(v int) {
-	i.Y = &v
 }
 
 // GetAccountID returns the AccountID field if non-nil, zero value otherwise.
@@ -8228,6 +4105,37 @@ func (m *Monitor) SetOptions(v Options) {
 	m.Options = &v
 }
 
+// GetOverallState returns the OverallState field if non-nil, zero value otherwise.
+func (m *Monitor) GetOverallState() string {
+	if m == nil || m.OverallState == nil {
+		return ""
+	}
+	return *m.OverallState
+}
+
+// GetOkOverallState returns a tuple with the OverallState field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *Monitor) GetOverallStateOk() (string, bool) {
+	if m == nil || m.OverallState == nil {
+		return "", false
+	}
+	return *m.OverallState, true
+}
+
+// HasOverallState returns a boolean if a field has been set.
+func (m *Monitor) HasOverallState() bool {
+	if m != nil && m.OverallState != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOverallState allocates a new m.OverallState and returns the pointer to it.
+func (m *Monitor) SetOverallState(v string) {
+	m.OverallState = &v
+}
+
 // GetQuery returns the Query field if non-nil, zero value otherwise.
 func (m *Monitor) GetQuery() string {
 	if m == nil || m.Query == nil {
@@ -8288,564 +4196,6 @@ func (m *Monitor) HasType() bool {
 // SetType allocates a new m.Type and returns the pointer to it.
 func (m *Monitor) SetType(v string) {
 	m.Type = &v
-}
-
-// GetAutoRefresh returns the AutoRefresh field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetAutoRefresh() bool {
-	if n == nil || n.AutoRefresh == nil {
-		return false
-	}
-	return *n.AutoRefresh
-}
-
-// GetOkAutoRefresh returns a tuple with the AutoRefresh field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetAutoRefreshOk() (bool, bool) {
-	if n == nil || n.AutoRefresh == nil {
-		return false, false
-	}
-	return *n.AutoRefresh, true
-}
-
-// HasAutoRefresh returns a boolean if a field has been set.
-func (n *NoteWidget) HasAutoRefresh() bool {
-	if n != nil && n.AutoRefresh != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAutoRefresh allocates a new n.AutoRefresh and returns the pointer to it.
-func (n *NoteWidget) SetAutoRefresh(v bool) {
-	n.AutoRefresh = &v
-}
-
-// GetColor returns the Color field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetColor() string {
-	if n == nil || n.Color == nil {
-		return ""
-	}
-	return *n.Color
-}
-
-// GetOkColor returns a tuple with the Color field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetColorOk() (string, bool) {
-	if n == nil || n.Color == nil {
-		return "", false
-	}
-	return *n.Color, true
-}
-
-// HasColor returns a boolean if a field has been set.
-func (n *NoteWidget) HasColor() bool {
-	if n != nil && n.Color != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetColor allocates a new n.Color and returns the pointer to it.
-func (n *NoteWidget) SetColor(v string) {
-	n.Color = &v
-}
-
-// GetFontSize returns the FontSize field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetFontSize() int {
-	if n == nil || n.FontSize == nil {
-		return 0
-	}
-	return *n.FontSize
-}
-
-// GetOkFontSize returns a tuple with the FontSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetFontSizeOk() (int, bool) {
-	if n == nil || n.FontSize == nil {
-		return 0, false
-	}
-	return *n.FontSize, true
-}
-
-// HasFontSize returns a boolean if a field has been set.
-func (n *NoteWidget) HasFontSize() bool {
-	if n != nil && n.FontSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetFontSize allocates a new n.FontSize and returns the pointer to it.
-func (n *NoteWidget) SetFontSize(v int) {
-	n.FontSize = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetHeight() int {
-	if n == nil || n.Height == nil {
-		return 0
-	}
-	return *n.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetHeightOk() (int, bool) {
-	if n == nil || n.Height == nil {
-		return 0, false
-	}
-	return *n.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (n *NoteWidget) HasHeight() bool {
-	if n != nil && n.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new n.Height and returns the pointer to it.
-func (n *NoteWidget) SetHeight(v int) {
-	n.Height = &v
-}
-
-// GetHtml returns the Html field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetHtml() string {
-	if n == nil || n.Html == nil {
-		return ""
-	}
-	return *n.Html
-}
-
-// GetOkHtml returns a tuple with the Html field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetHtmlOk() (string, bool) {
-	if n == nil || n.Html == nil {
-		return "", false
-	}
-	return *n.Html, true
-}
-
-// HasHtml returns a boolean if a field has been set.
-func (n *NoteWidget) HasHtml() bool {
-	if n != nil && n.Html != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHtml allocates a new n.Html and returns the pointer to it.
-func (n *NoteWidget) SetHtml(v string) {
-	n.Html = &v
-}
-
-// GetNote returns the Note field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetNote() string {
-	if n == nil || n.Note == nil {
-		return ""
-	}
-	return *n.Note
-}
-
-// GetOkNote returns a tuple with the Note field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetNoteOk() (string, bool) {
-	if n == nil || n.Note == nil {
-		return "", false
-	}
-	return *n.Note, true
-}
-
-// HasNote returns a boolean if a field has been set.
-func (n *NoteWidget) HasNote() bool {
-	if n != nil && n.Note != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetNote allocates a new n.Note and returns the pointer to it.
-func (n *NoteWidget) SetNote(v string) {
-	n.Note = &v
-}
-
-// GetRefreshEvery returns the RefreshEvery field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetRefreshEvery() int {
-	if n == nil || n.RefreshEvery == nil {
-		return 0
-	}
-	return *n.RefreshEvery
-}
-
-// GetOkRefreshEvery returns a tuple with the RefreshEvery field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetRefreshEveryOk() (int, bool) {
-	if n == nil || n.RefreshEvery == nil {
-		return 0, false
-	}
-	return *n.RefreshEvery, true
-}
-
-// HasRefreshEvery returns a boolean if a field has been set.
-func (n *NoteWidget) HasRefreshEvery() bool {
-	if n != nil && n.RefreshEvery != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetRefreshEvery allocates a new n.RefreshEvery and returns the pointer to it.
-func (n *NoteWidget) SetRefreshEvery(v int) {
-	n.RefreshEvery = &v
-}
-
-// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTextAlign() string {
-	if n == nil || n.TextAlign == nil {
-		return ""
-	}
-	return *n.TextAlign
-}
-
-// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTextAlignOk() (string, bool) {
-	if n == nil || n.TextAlign == nil {
-		return "", false
-	}
-	return *n.TextAlign, true
-}
-
-// HasTextAlign returns a boolean if a field has been set.
-func (n *NoteWidget) HasTextAlign() bool {
-	if n != nil && n.TextAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextAlign allocates a new n.TextAlign and returns the pointer to it.
-func (n *NoteWidget) SetTextAlign(v string) {
-	n.TextAlign = &v
-}
-
-// GetTick returns the Tick field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTick() bool {
-	if n == nil || n.Tick == nil {
-		return false
-	}
-	return *n.Tick
-}
-
-// GetOkTick returns a tuple with the Tick field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTickOk() (bool, bool) {
-	if n == nil || n.Tick == nil {
-		return false, false
-	}
-	return *n.Tick, true
-}
-
-// HasTick returns a boolean if a field has been set.
-func (n *NoteWidget) HasTick() bool {
-	if n != nil && n.Tick != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTick allocates a new n.Tick and returns the pointer to it.
-func (n *NoteWidget) SetTick(v bool) {
-	n.Tick = &v
-}
-
-// GetTickEdge returns the TickEdge field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTickEdge() string {
-	if n == nil || n.TickEdge == nil {
-		return ""
-	}
-	return *n.TickEdge
-}
-
-// GetOkTickEdge returns a tuple with the TickEdge field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTickEdgeOk() (string, bool) {
-	if n == nil || n.TickEdge == nil {
-		return "", false
-	}
-	return *n.TickEdge, true
-}
-
-// HasTickEdge returns a boolean if a field has been set.
-func (n *NoteWidget) HasTickEdge() bool {
-	if n != nil && n.TickEdge != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTickEdge allocates a new n.TickEdge and returns the pointer to it.
-func (n *NoteWidget) SetTickEdge(v string) {
-	n.TickEdge = &v
-}
-
-// GetTickPos returns the TickPos field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTickPos() string {
-	if n == nil || n.TickPos == nil {
-		return ""
-	}
-	return *n.TickPos
-}
-
-// GetOkTickPos returns a tuple with the TickPos field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTickPosOk() (string, bool) {
-	if n == nil || n.TickPos == nil {
-		return "", false
-	}
-	return *n.TickPos, true
-}
-
-// HasTickPos returns a boolean if a field has been set.
-func (n *NoteWidget) HasTickPos() bool {
-	if n != nil && n.TickPos != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTickPos allocates a new n.TickPos and returns the pointer to it.
-func (n *NoteWidget) SetTickPos(v string) {
-	n.TickPos = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTitle() bool {
-	if n == nil || n.Title == nil {
-		return false
-	}
-	return *n.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTitleOk() (bool, bool) {
-	if n == nil || n.Title == nil {
-		return false, false
-	}
-	return *n.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (n *NoteWidget) HasTitle() bool {
-	if n != nil && n.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new n.Title and returns the pointer to it.
-func (n *NoteWidget) SetTitle(v bool) {
-	n.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTitleAlign() string {
-	if n == nil || n.TitleAlign == nil {
-		return ""
-	}
-	return *n.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTitleAlignOk() (string, bool) {
-	if n == nil || n.TitleAlign == nil {
-		return "", false
-	}
-	return *n.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (n *NoteWidget) HasTitleAlign() bool {
-	if n != nil && n.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new n.TitleAlign and returns the pointer to it.
-func (n *NoteWidget) SetTitleAlign(v string) {
-	n.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTitleSize() int {
-	if n == nil || n.TitleSize == nil {
-		return 0
-	}
-	return *n.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTitleSizeOk() (int, bool) {
-	if n == nil || n.TitleSize == nil {
-		return 0, false
-	}
-	return *n.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (n *NoteWidget) HasTitleSize() bool {
-	if n != nil && n.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new n.TitleSize and returns the pointer to it.
-func (n *NoteWidget) SetTitleSize(v int) {
-	n.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetTitleText() string {
-	if n == nil || n.TitleText == nil {
-		return ""
-	}
-	return *n.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetTitleTextOk() (string, bool) {
-	if n == nil || n.TitleText == nil {
-		return "", false
-	}
-	return *n.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (n *NoteWidget) HasTitleText() bool {
-	if n != nil && n.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new n.TitleText and returns the pointer to it.
-func (n *NoteWidget) SetTitleText(v string) {
-	n.TitleText = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetWidth() int {
-	if n == nil || n.Width == nil {
-		return 0
-	}
-	return *n.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetWidthOk() (int, bool) {
-	if n == nil || n.Width == nil {
-		return 0, false
-	}
-	return *n.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (n *NoteWidget) HasWidth() bool {
-	if n != nil && n.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new n.Width and returns the pointer to it.
-func (n *NoteWidget) SetWidth(v int) {
-	n.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetX() int {
-	if n == nil || n.X == nil {
-		return 0
-	}
-	return *n.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetXOk() (int, bool) {
-	if n == nil || n.X == nil {
-		return 0, false
-	}
-	return *n.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (n *NoteWidget) HasX() bool {
-	if n != nil && n.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new n.X and returns the pointer to it.
-func (n *NoteWidget) SetX(v int) {
-	n.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (n *NoteWidget) GetY() int {
-	if n == nil || n.Y == nil {
-		return 0
-	}
-	return *n.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (n *NoteWidget) GetYOk() (int, bool) {
-	if n == nil || n.Y == nil {
-		return 0, false
-	}
-	return *n.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (n *NoteWidget) HasY() bool {
-	if n != nil && n.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new n.Y and returns the pointer to it.
-func (n *NoteWidget) SetY(v int) {
-	n.Y = &v
 }
 
 // GetEscalationMessage returns the EscalationMessage field if non-nil, zero value otherwise.
@@ -9189,686 +4539,128 @@ func (o *Options) SetTimeoutH(v int) {
 	o.TimeoutH = &v
 }
 
-// GetAggregator returns the Aggregator field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetAggregator() string {
-	if q == nil || q.Aggregator == nil {
+// GetCount returns the Count field if non-nil, zero value otherwise.
+func (p *Params) GetCount() string {
+	if p == nil || p.Count == nil {
 		return ""
 	}
-	return *q.Aggregator
+	return *p.Count
 }
 
-// GetOkAggregator returns a tuple with the Aggregator field if it's non-nil, zero value otherwise
+// GetOkCount returns a tuple with the Count field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetAggregatorOk() (string, bool) {
-	if q == nil || q.Aggregator == nil {
+func (p *Params) GetCountOk() (string, bool) {
+	if p == nil || p.Count == nil {
 		return "", false
 	}
-	return *q.Aggregator, true
+	return *p.Count, true
 }
 
-// HasAggregator returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasAggregator() bool {
-	if q != nil && q.Aggregator != nil {
+// HasCount returns a boolean if a field has been set.
+func (p *Params) HasCount() bool {
+	if p != nil && p.Count != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetAggregator allocates a new q.Aggregator and returns the pointer to it.
-func (q *QueryValueWidget) SetAggregator(v string) {
-	q.Aggregator = &v
+// SetCount allocates a new p.Count and returns the pointer to it.
+func (p *Params) SetCount(v string) {
+	p.Count = &v
 }
 
-// GetCalcFunc returns the CalcFunc field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetCalcFunc() string {
-	if q == nil || q.CalcFunc == nil {
+// GetSort returns the Sort field if non-nil, zero value otherwise.
+func (p *Params) GetSort() string {
+	if p == nil || p.Sort == nil {
 		return ""
 	}
-	return *q.CalcFunc
+	return *p.Sort
 }
 
-// GetOkCalcFunc returns a tuple with the CalcFunc field if it's non-nil, zero value otherwise
+// GetOkSort returns a tuple with the Sort field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetCalcFuncOk() (string, bool) {
-	if q == nil || q.CalcFunc == nil {
+func (p *Params) GetSortOk() (string, bool) {
+	if p == nil || p.Sort == nil {
 		return "", false
 	}
-	return *q.CalcFunc, true
+	return *p.Sort, true
 }
 
-// HasCalcFunc returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasCalcFunc() bool {
-	if q != nil && q.CalcFunc != nil {
+// HasSort returns a boolean if a field has been set.
+func (p *Params) HasSort() bool {
+	if p != nil && p.Sort != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetCalcFunc allocates a new q.CalcFunc and returns the pointer to it.
-func (q *QueryValueWidget) SetCalcFunc(v string) {
-	q.CalcFunc = &v
+// SetSort allocates a new p.Sort and returns the pointer to it.
+func (p *Params) SetSort(v string) {
+	p.Sort = &v
 }
 
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetHeight() int {
-	if q == nil || q.Height == nil {
-		return 0
-	}
-	return *q.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetHeightOk() (int, bool) {
-	if q == nil || q.Height == nil {
-		return 0, false
-	}
-	return *q.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasHeight() bool {
-	if q != nil && q.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new q.Height and returns the pointer to it.
-func (q *QueryValueWidget) SetHeight(v int) {
-	q.Height = &v
-}
-
-// GetIsValidQuery returns the IsValidQuery field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetIsValidQuery() bool {
-	if q == nil || q.IsValidQuery == nil {
-		return false
-	}
-	return *q.IsValidQuery
-}
-
-// GetOkIsValidQuery returns a tuple with the IsValidQuery field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetIsValidQueryOk() (bool, bool) {
-	if q == nil || q.IsValidQuery == nil {
-		return false, false
-	}
-	return *q.IsValidQuery, true
-}
-
-// HasIsValidQuery returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasIsValidQuery() bool {
-	if q != nil && q.IsValidQuery != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetIsValidQuery allocates a new q.IsValidQuery and returns the pointer to it.
-func (q *QueryValueWidget) SetIsValidQuery(v bool) {
-	q.IsValidQuery = &v
-}
-
-// GetMetric returns the Metric field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetMetric() string {
-	if q == nil || q.Metric == nil {
+// GetStart returns the Start field if non-nil, zero value otherwise.
+func (p *Params) GetStart() string {
+	if p == nil || p.Start == nil {
 		return ""
 	}
-	return *q.Metric
+	return *p.Start
 }
 
-// GetOkMetric returns a tuple with the Metric field if it's non-nil, zero value otherwise
+// GetOkStart returns a tuple with the Start field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetMetricOk() (string, bool) {
-	if q == nil || q.Metric == nil {
+func (p *Params) GetStartOk() (string, bool) {
+	if p == nil || p.Start == nil {
 		return "", false
 	}
-	return *q.Metric, true
+	return *p.Start, true
 }
 
-// HasMetric returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasMetric() bool {
-	if q != nil && q.Metric != nil {
+// HasStart returns a boolean if a field has been set.
+func (p *Params) HasStart() bool {
+	if p != nil && p.Start != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetMetric allocates a new q.Metric and returns the pointer to it.
-func (q *QueryValueWidget) SetMetric(v string) {
-	q.Metric = &v
+// SetStart allocates a new p.Start and returns the pointer to it.
+func (p *Params) SetStart(v string) {
+	p.Start = &v
 }
 
-// GetMetricType returns the MetricType field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetMetricType() string {
-	if q == nil || q.MetricType == nil {
+// GetText returns the Text field if non-nil, zero value otherwise.
+func (p *Params) GetText() string {
+	if p == nil || p.Text == nil {
 		return ""
 	}
-	return *q.MetricType
+	return *p.Text
 }
 
-// GetOkMetricType returns a tuple with the MetricType field if it's non-nil, zero value otherwise
+// GetOkText returns a tuple with the Text field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetMetricTypeOk() (string, bool) {
-	if q == nil || q.MetricType == nil {
+func (p *Params) GetTextOk() (string, bool) {
+	if p == nil || p.Text == nil {
 		return "", false
 	}
-	return *q.MetricType, true
+	return *p.Text, true
 }
 
-// HasMetricType returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasMetricType() bool {
-	if q != nil && q.MetricType != nil {
+// HasText returns a boolean if a field has been set.
+func (p *Params) HasText() bool {
+	if p != nil && p.Text != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetMetricType allocates a new q.MetricType and returns the pointer to it.
-func (q *QueryValueWidget) SetMetricType(v string) {
-	q.MetricType = &v
-}
-
-// GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetPrecision() int {
-	if q == nil || q.Precision == nil {
-		return 0
-	}
-	return *q.Precision
-}
-
-// GetOkPrecision returns a tuple with the Precision field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetPrecisionOk() (int, bool) {
-	if q == nil || q.Precision == nil {
-		return 0, false
-	}
-	return *q.Precision, true
-}
-
-// HasPrecision returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasPrecision() bool {
-	if q != nil && q.Precision != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetPrecision allocates a new q.Precision and returns the pointer to it.
-func (q *QueryValueWidget) SetPrecision(v int) {
-	q.Precision = &v
-}
-
-// GetQuery returns the Query field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetQuery() string {
-	if q == nil || q.Query == nil {
-		return ""
-	}
-	return *q.Query
-}
-
-// GetOkQuery returns a tuple with the Query field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetQueryOk() (string, bool) {
-	if q == nil || q.Query == nil {
-		return "", false
-	}
-	return *q.Query, true
-}
-
-// HasQuery returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasQuery() bool {
-	if q != nil && q.Query != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetQuery allocates a new q.Query and returns the pointer to it.
-func (q *QueryValueWidget) SetQuery(v string) {
-	q.Query = &v
-}
-
-// GetResultCalcFunc returns the ResultCalcFunc field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetResultCalcFunc() string {
-	if q == nil || q.ResultCalcFunc == nil {
-		return ""
-	}
-	return *q.ResultCalcFunc
-}
-
-// GetOkResultCalcFunc returns a tuple with the ResultCalcFunc field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetResultCalcFuncOk() (string, bool) {
-	if q == nil || q.ResultCalcFunc == nil {
-		return "", false
-	}
-	return *q.ResultCalcFunc, true
-}
-
-// HasResultCalcFunc returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasResultCalcFunc() bool {
-	if q != nil && q.ResultCalcFunc != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetResultCalcFunc allocates a new q.ResultCalcFunc and returns the pointer to it.
-func (q *QueryValueWidget) SetResultCalcFunc(v string) {
-	q.ResultCalcFunc = &v
-}
-
-// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTextAlign() string {
-	if q == nil || q.TextAlign == nil {
-		return ""
-	}
-	return *q.TextAlign
-}
-
-// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTextAlignOk() (string, bool) {
-	if q == nil || q.TextAlign == nil {
-		return "", false
-	}
-	return *q.TextAlign, true
-}
-
-// HasTextAlign returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTextAlign() bool {
-	if q != nil && q.TextAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextAlign allocates a new q.TextAlign and returns the pointer to it.
-func (q *QueryValueWidget) SetTextAlign(v string) {
-	q.TextAlign = &v
-}
-
-// GetTextSize returns the TextSize field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTextSize() TextSize {
-	if q == nil || q.TextSize == nil {
-		return TextSize{}
-	}
-	return *q.TextSize
-}
-
-// GetOkTextSize returns a tuple with the TextSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTextSizeOk() (TextSize, bool) {
-	if q == nil || q.TextSize == nil {
-		return TextSize{}, false
-	}
-	return *q.TextSize, true
-}
-
-// HasTextSize returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTextSize() bool {
-	if q != nil && q.TextSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTextSize allocates a new q.TextSize and returns the pointer to it.
-func (q *QueryValueWidget) SetTextSize(v TextSize) {
-	q.TextSize = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTimeframe() string {
-	if q == nil || q.Timeframe == nil {
-		return ""
-	}
-	return *q.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTimeframeOk() (string, bool) {
-	if q == nil || q.Timeframe == nil {
-		return "", false
-	}
-	return *q.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTimeframe() bool {
-	if q != nil && q.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new q.Timeframe and returns the pointer to it.
-func (q *QueryValueWidget) SetTimeframe(v string) {
-	q.Timeframe = &v
-}
-
-// GetTimeframeAggregator returns the TimeframeAggregator field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTimeframeAggregator() string {
-	if q == nil || q.TimeframeAggregator == nil {
-		return ""
-	}
-	return *q.TimeframeAggregator
-}
-
-// GetOkTimeframeAggregator returns a tuple with the TimeframeAggregator field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTimeframeAggregatorOk() (string, bool) {
-	if q == nil || q.TimeframeAggregator == nil {
-		return "", false
-	}
-	return *q.TimeframeAggregator, true
-}
-
-// HasTimeframeAggregator returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTimeframeAggregator() bool {
-	if q != nil && q.TimeframeAggregator != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframeAggregator allocates a new q.TimeframeAggregator and returns the pointer to it.
-func (q *QueryValueWidget) SetTimeframeAggregator(v string) {
-	q.TimeframeAggregator = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTitle() bool {
-	if q == nil || q.Title == nil {
-		return false
-	}
-	return *q.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTitleOk() (bool, bool) {
-	if q == nil || q.Title == nil {
-		return false, false
-	}
-	return *q.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTitle() bool {
-	if q != nil && q.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new q.Title and returns the pointer to it.
-func (q *QueryValueWidget) SetTitle(v bool) {
-	q.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTitleAlign() string {
-	if q == nil || q.TitleAlign == nil {
-		return ""
-	}
-	return *q.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTitleAlignOk() (string, bool) {
-	if q == nil || q.TitleAlign == nil {
-		return "", false
-	}
-	return *q.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTitleAlign() bool {
-	if q != nil && q.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new q.TitleAlign and returns the pointer to it.
-func (q *QueryValueWidget) SetTitleAlign(v string) {
-	q.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTitleSize() TextSize {
-	if q == nil || q.TitleSize == nil {
-		return TextSize{}
-	}
-	return *q.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTitleSizeOk() (TextSize, bool) {
-	if q == nil || q.TitleSize == nil {
-		return TextSize{}, false
-	}
-	return *q.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTitleSize() bool {
-	if q != nil && q.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new q.TitleSize and returns the pointer to it.
-func (q *QueryValueWidget) SetTitleSize(v TextSize) {
-	q.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetTitleText() string {
-	if q == nil || q.TitleText == nil {
-		return ""
-	}
-	return *q.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTitleTextOk() (string, bool) {
-	if q == nil || q.TitleText == nil {
-		return "", false
-	}
-	return *q.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasTitleText() bool {
-	if q != nil && q.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new q.TitleText and returns the pointer to it.
-func (q *QueryValueWidget) SetTitleText(v string) {
-	q.TitleText = &v
-}
-
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetType() string {
-	if q == nil || q.Type == nil {
-		return ""
-	}
-	return *q.Type
-}
-
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetTypeOk() (string, bool) {
-	if q == nil || q.Type == nil {
-		return "", false
-	}
-	return *q.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasType() bool {
-	if q != nil && q.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType allocates a new q.Type and returns the pointer to it.
-func (q *QueryValueWidget) SetType(v string) {
-	q.Type = &v
-}
-
-// GetUnit returns the Unit field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetUnit() string {
-	if q == nil || q.Unit == nil {
-		return ""
-	}
-	return *q.Unit
-}
-
-// GetOkUnit returns a tuple with the Unit field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetUnitOk() (string, bool) {
-	if q == nil || q.Unit == nil {
-		return "", false
-	}
-	return *q.Unit, true
-}
-
-// HasUnit returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasUnit() bool {
-	if q != nil && q.Unit != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetUnit allocates a new q.Unit and returns the pointer to it.
-func (q *QueryValueWidget) SetUnit(v string) {
-	q.Unit = &v
-}
-
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetWidth() int {
-	if q == nil || q.Width == nil {
-		return 0
-	}
-	return *q.Width
-}
-
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetWidthOk() (int, bool) {
-	if q == nil || q.Width == nil {
-		return 0, false
-	}
-	return *q.Width, true
-}
-
-// HasWidth returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasWidth() bool {
-	if q != nil && q.Width != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetWidth allocates a new q.Width and returns the pointer to it.
-func (q *QueryValueWidget) SetWidth(v int) {
-	q.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetX() int {
-	if q == nil || q.X == nil {
-		return 0
-	}
-	return *q.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetXOk() (int, bool) {
-	if q == nil || q.X == nil {
-		return 0, false
-	}
-	return *q.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasX() bool {
-	if q != nil && q.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new q.X and returns the pointer to it.
-func (q *QueryValueWidget) SetX(v int) {
-	q.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (q *QueryValueWidget) GetY() int {
-	if q == nil || q.Y == nil {
-		return 0
-	}
-	return *q.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (q *QueryValueWidget) GetYOk() (int, bool) {
-	if q == nil || q.Y == nil {
-		return 0, false
-	}
-	return *q.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (q *QueryValueWidget) HasY() bool {
-	if q != nil && q.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new q.Y and returns the pointer to it.
-func (q *QueryValueWidget) SetY(v int) {
-	q.Y = &v
+// SetText allocates a new p.Text and returns the pointer to it.
+func (p *Params) SetText(v string) {
+	p.Text = &v
 }
 
 // GetPeriod returns the Period field if non-nil, zero value otherwise.
@@ -10181,6 +4973,99 @@ func (r *reqGetTags) SetTags(v TagMap) {
 	r.Tags = &v
 }
 
+// GetColor returns the Color field if non-nil, zero value otherwise.
+func (r *Rule) GetColor() string {
+	if r == nil || r.Color == nil {
+		return ""
+	}
+	return *r.Color
+}
+
+// GetOkColor returns a tuple with the Color field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *Rule) GetColorOk() (string, bool) {
+	if r == nil || r.Color == nil {
+		return "", false
+	}
+	return *r.Color, true
+}
+
+// HasColor returns a boolean if a field has been set.
+func (r *Rule) HasColor() bool {
+	if r != nil && r.Color != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetColor allocates a new r.Color and returns the pointer to it.
+func (r *Rule) SetColor(v string) {
+	r.Color = &v
+}
+
+// GetThreshold returns the Threshold field if non-nil, zero value otherwise.
+func (r *Rule) GetThreshold() int {
+	if r == nil || r.Threshold == nil {
+		return 0
+	}
+	return *r.Threshold
+}
+
+// GetOkThreshold returns a tuple with the Threshold field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *Rule) GetThresholdOk() (int, bool) {
+	if r == nil || r.Threshold == nil {
+		return 0, false
+	}
+	return *r.Threshold, true
+}
+
+// HasThreshold returns a boolean if a field has been set.
+func (r *Rule) HasThreshold() bool {
+	if r != nil && r.Threshold != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetThreshold allocates a new r.Threshold and returns the pointer to it.
+func (r *Rule) SetThreshold(v int) {
+	r.Threshold = &v
+}
+
+// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
+func (r *Rule) GetTimeframe() string {
+	if r == nil || r.Timeframe == nil {
+		return ""
+	}
+	return *r.Timeframe
+}
+
+// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *Rule) GetTimeframeOk() (string, bool) {
+	if r == nil || r.Timeframe == nil {
+		return "", false
+	}
+	return *r.Timeframe, true
+}
+
+// HasTimeframe returns a boolean if a field has been set.
+func (r *Rule) HasTimeframe() bool {
+	if r != nil && r.Timeframe != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTimeframe allocates a new r.Timeframe and returns the pointer to it.
+func (r *Rule) SetTimeframe(v string) {
+	r.Timeframe = &v
+}
+
 // GetHeight returns the Height field if non-nil, zero value otherwise.
 func (s *Screenboard) GetHeight() string {
 	if s == nil || s.Height == nil {
@@ -10303,37 +5188,6 @@ func (s *Screenboard) HasShared() bool {
 // SetShared allocates a new s.Shared and returns the pointer to it.
 func (s *Screenboard) SetShared(v bool) {
 	s.Shared = &v
-}
-
-// GetTemplated returns the Templated field if non-nil, zero value otherwise.
-func (s *Screenboard) GetTemplated() bool {
-	if s == nil || s.Templated == nil {
-		return false
-	}
-	return *s.Templated
-}
-
-// GetOkTemplated returns a tuple with the Templated field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (s *Screenboard) GetTemplatedOk() (bool, bool) {
-	if s == nil || s.Templated == nil {
-		return false, false
-	}
-	return *s.Templated, true
-}
-
-// HasTemplated returns a boolean if a field has been set.
-func (s *Screenboard) HasTemplated() bool {
-	if s != nil && s.Templated != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTemplated allocates a new s.Templated and returns the pointer to it.
-func (s *Screenboard) SetTemplated(v bool) {
-	s.Templated = &v
 }
 
 // GetTitle returns the Title field if non-nil, zero value otherwise.
@@ -10489,6 +5343,37 @@ func (s *ScreenboardLite) HasTitle() bool {
 // SetTitle allocates a new s.Title and returns the pointer to it.
 func (s *ScreenboardLite) SetTitle(v string) {
 	s.Title = &v
+}
+
+// GetId returns the Id field if non-nil, zero value otherwise.
+func (s *ScreenboardMonitor) GetId() int {
+	if s == nil || s.Id == nil {
+		return 0
+	}
+	return *s.Id
+}
+
+// GetOkId returns a tuple with the Id field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ScreenboardMonitor) GetIdOk() (int, bool) {
+	if s == nil || s.Id == nil {
+		return 0, false
+	}
+	return *s.Id, true
+}
+
+// HasId returns a boolean if a field has been set.
+func (s *ScreenboardMonitor) HasId() bool {
+	if s != nil && s.Id != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetId allocates a new s.Id and returns the pointer to it.
+func (s *ScreenboardMonitor) SetId(v int) {
+	s.Id = &v
 }
 
 // GetAggr returns the Aggr field if non-nil, zero value otherwise.
@@ -11142,68 +6027,6 @@ func (t *TemplateVariable) SetPrefix(v string) {
 	t.Prefix = &v
 }
 
-// GetAuto returns the Auto field if non-nil, zero value otherwise.
-func (t *TextSize) GetAuto() bool {
-	if t == nil || t.Auto == nil {
-		return false
-	}
-	return *t.Auto
-}
-
-// GetOkAuto returns a tuple with the Auto field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TextSize) GetAutoOk() (bool, bool) {
-	if t == nil || t.Auto == nil {
-		return false, false
-	}
-	return *t.Auto, true
-}
-
-// HasAuto returns a boolean if a field has been set.
-func (t *TextSize) HasAuto() bool {
-	if t != nil && t.Auto != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetAuto allocates a new t.Auto and returns the pointer to it.
-func (t *TextSize) SetAuto(v bool) {
-	t.Auto = &v
-}
-
-// GetSize returns the Size field if non-nil, zero value otherwise.
-func (t *TextSize) GetSize() int {
-	if t == nil || t.Size == nil {
-		return 0
-	}
-	return *t.Size
-}
-
-// GetOkSize returns a tuple with the Size field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TextSize) GetSizeOk() (int, bool) {
-	if t == nil || t.Size == nil {
-		return 0, false
-	}
-	return *t.Size, true
-}
-
-// HasSize returns a boolean if a field has been set.
-func (t *TextSize) HasSize() bool {
-	if t != nil && t.Size != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetSize allocates a new t.Size and returns the pointer to it.
-func (t *TextSize) SetSize(v int) {
-	t.Size = &v
-}
-
 // GetCritical returns the Critical field if non-nil, zero value otherwise.
 func (t *ThresholdCount) GetCritical() json.Number {
 	if t == nil || t.Critical == nil {
@@ -11390,6 +6213,254 @@ func (t *ThresholdCount) SetWarningRecovery(v json.Number) {
 	t.WarningRecovery = &v
 }
 
+// GetAutoscale returns the Autoscale field if non-nil, zero value otherwise.
+func (t *TileDef) GetAutoscale() bool {
+	if t == nil || t.Autoscale == nil {
+		return false
+	}
+	return *t.Autoscale
+}
+
+// GetOkAutoscale returns a tuple with the Autoscale field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetAutoscaleOk() (bool, bool) {
+	if t == nil || t.Autoscale == nil {
+		return false, false
+	}
+	return *t.Autoscale, true
+}
+
+// HasAutoscale returns a boolean if a field has been set.
+func (t *TileDef) HasAutoscale() bool {
+	if t != nil && t.Autoscale != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAutoscale allocates a new t.Autoscale and returns the pointer to it.
+func (t *TileDef) SetAutoscale(v bool) {
+	t.Autoscale = &v
+}
+
+// GetCustomUnit returns the CustomUnit field if non-nil, zero value otherwise.
+func (t *TileDef) GetCustomUnit() string {
+	if t == nil || t.CustomUnit == nil {
+		return ""
+	}
+	return *t.CustomUnit
+}
+
+// GetOkCustomUnit returns a tuple with the CustomUnit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetCustomUnitOk() (string, bool) {
+	if t == nil || t.CustomUnit == nil {
+		return "", false
+	}
+	return *t.CustomUnit, true
+}
+
+// HasCustomUnit returns a boolean if a field has been set.
+func (t *TileDef) HasCustomUnit() bool {
+	if t != nil && t.CustomUnit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomUnit allocates a new t.CustomUnit and returns the pointer to it.
+func (t *TileDef) SetCustomUnit(v string) {
+	t.CustomUnit = &v
+}
+
+// GetNodeType returns the NodeType field if non-nil, zero value otherwise.
+func (t *TileDef) GetNodeType() string {
+	if t == nil || t.NodeType == nil {
+		return ""
+	}
+	return *t.NodeType
+}
+
+// GetOkNodeType returns a tuple with the NodeType field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetNodeTypeOk() (string, bool) {
+	if t == nil || t.NodeType == nil {
+		return "", false
+	}
+	return *t.NodeType, true
+}
+
+// HasNodeType returns a boolean if a field has been set.
+func (t *TileDef) HasNodeType() bool {
+	if t != nil && t.NodeType != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNodeType allocates a new t.NodeType and returns the pointer to it.
+func (t *TileDef) SetNodeType(v string) {
+	t.NodeType = &v
+}
+
+// GetNoGroupHosts returns the NoGroupHosts field if non-nil, zero value otherwise.
+func (t *TileDef) GetNoGroupHosts() bool {
+	if t == nil || t.NoGroupHosts == nil {
+		return false
+	}
+	return *t.NoGroupHosts
+}
+
+// GetOkNoGroupHosts returns a tuple with the NoGroupHosts field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetNoGroupHostsOk() (bool, bool) {
+	if t == nil || t.NoGroupHosts == nil {
+		return false, false
+	}
+	return *t.NoGroupHosts, true
+}
+
+// HasNoGroupHosts returns a boolean if a field has been set.
+func (t *TileDef) HasNoGroupHosts() bool {
+	if t != nil && t.NoGroupHosts != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNoGroupHosts allocates a new t.NoGroupHosts and returns the pointer to it.
+func (t *TileDef) SetNoGroupHosts(v bool) {
+	t.NoGroupHosts = &v
+}
+
+// GetNoMetricHosts returns the NoMetricHosts field if non-nil, zero value otherwise.
+func (t *TileDef) GetNoMetricHosts() bool {
+	if t == nil || t.NoMetricHosts == nil {
+		return false
+	}
+	return *t.NoMetricHosts
+}
+
+// GetOkNoMetricHosts returns a tuple with the NoMetricHosts field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetNoMetricHostsOk() (bool, bool) {
+	if t == nil || t.NoMetricHosts == nil {
+		return false, false
+	}
+	return *t.NoMetricHosts, true
+}
+
+// HasNoMetricHosts returns a boolean if a field has been set.
+func (t *TileDef) HasNoMetricHosts() bool {
+	if t != nil && t.NoMetricHosts != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNoMetricHosts allocates a new t.NoMetricHosts and returns the pointer to it.
+func (t *TileDef) SetNoMetricHosts(v bool) {
+	t.NoMetricHosts = &v
+}
+
+// GetPrecision returns the Precision field if non-nil, zero value otherwise.
+func (t *TileDef) GetPrecision() string {
+	if t == nil || t.Precision == nil {
+		return ""
+	}
+	return *t.Precision
+}
+
+// GetOkPrecision returns a tuple with the Precision field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetPrecisionOk() (string, bool) {
+	if t == nil || t.Precision == nil {
+		return "", false
+	}
+	return *t.Precision, true
+}
+
+// HasPrecision returns a boolean if a field has been set.
+func (t *TileDef) HasPrecision() bool {
+	if t != nil && t.Precision != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPrecision allocates a new t.Precision and returns the pointer to it.
+func (t *TileDef) SetPrecision(v string) {
+	t.Precision = &v
+}
+
+// GetStyle returns the Style field if non-nil, zero value otherwise.
+func (t *TileDef) GetStyle() TileDefStyle {
+	if t == nil || t.Style == nil {
+		return TileDefStyle{}
+	}
+	return *t.Style
+}
+
+// GetOkStyle returns a tuple with the Style field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetStyleOk() (TileDefStyle, bool) {
+	if t == nil || t.Style == nil {
+		return TileDefStyle{}, false
+	}
+	return *t.Style, true
+}
+
+// HasStyle returns a boolean if a field has been set.
+func (t *TileDef) HasStyle() bool {
+	if t != nil && t.Style != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetStyle allocates a new t.Style and returns the pointer to it.
+func (t *TileDef) SetStyle(v TileDefStyle) {
+	t.Style = &v
+}
+
+// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
+func (t *TileDef) GetTextAlign() string {
+	if t == nil || t.TextAlign == nil {
+		return ""
+	}
+	return *t.TextAlign
+}
+
+// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDef) GetTextAlignOk() (string, bool) {
+	if t == nil || t.TextAlign == nil {
+		return "", false
+	}
+	return *t.TextAlign, true
+}
+
+// HasTextAlign returns a boolean if a field has been set.
+func (t *TileDef) HasTextAlign() bool {
+	if t != nil && t.TextAlign != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTextAlign allocates a new t.TextAlign and returns the pointer to it.
+func (t *TileDef) SetTextAlign(v string) {
+	t.TextAlign = &v
+}
+
 // GetViz returns the Viz field if non-nil, zero value otherwise.
 func (t *TileDef) GetViz() string {
 	if t == nil || t.Viz == nil {
@@ -11453,7 +6524,7 @@ func (t *TileDefEvent) SetQuery(v string) {
 }
 
 // GetLabel returns the Label field if non-nil, zero value otherwise.
-func (t *TimeseriesMarker) GetLabel() string {
+func (t *TileDefMarker) GetLabel() string {
 	if t == nil || t.Label == nil {
 		return ""
 	}
@@ -11462,7 +6533,7 @@ func (t *TimeseriesMarker) GetLabel() string {
 
 // GetOkLabel returns a tuple with the Label field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesMarker) GetLabelOk() (string, bool) {
+func (t *TileDefMarker) GetLabelOk() (string, bool) {
 	if t == nil || t.Label == nil {
 		return "", false
 	}
@@ -11470,7 +6541,7 @@ func (t *TimeseriesMarker) GetLabelOk() (string, bool) {
 }
 
 // HasLabel returns a boolean if a field has been set.
-func (t *TimeseriesMarker) HasLabel() bool {
+func (t *TileDefMarker) HasLabel() bool {
 	if t != nil && t.Label != nil {
 		return true
 	}
@@ -11479,12 +6550,12 @@ func (t *TimeseriesMarker) HasLabel() bool {
 }
 
 // SetLabel allocates a new t.Label and returns the pointer to it.
-func (t *TimeseriesMarker) SetLabel(v string) {
+func (t *TileDefMarker) SetLabel(v string) {
 	t.Label = &v
 }
 
 // GetType returns the Type field if non-nil, zero value otherwise.
-func (t *TimeseriesMarker) GetType() string {
+func (t *TileDefMarker) GetType() string {
 	if t == nil || t.Type == nil {
 		return ""
 	}
@@ -11493,7 +6564,7 @@ func (t *TimeseriesMarker) GetType() string {
 
 // GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesMarker) GetTypeOk() (string, bool) {
+func (t *TileDefMarker) GetTypeOk() (string, bool) {
 	if t == nil || t.Type == nil {
 		return "", false
 	}
@@ -11501,7 +6572,7 @@ func (t *TimeseriesMarker) GetTypeOk() (string, bool) {
 }
 
 // HasType returns a boolean if a field has been set.
-func (t *TimeseriesMarker) HasType() bool {
+func (t *TileDefMarker) HasType() bool {
 	if t != nil && t.Type != nil {
 		return true
 	}
@@ -11510,12 +6581,12 @@ func (t *TimeseriesMarker) HasType() bool {
 }
 
 // SetType allocates a new t.Type and returns the pointer to it.
-func (t *TimeseriesMarker) SetType(v string) {
+func (t *TileDefMarker) SetType(v string) {
 	t.Type = &v
 }
 
 // GetValue returns the Value field if non-nil, zero value otherwise.
-func (t *TimeseriesMarker) GetValue() string {
+func (t *TileDefMarker) GetValue() string {
 	if t == nil || t.Value == nil {
 		return ""
 	}
@@ -11524,7 +6595,7 @@ func (t *TimeseriesMarker) GetValue() string {
 
 // GetOkValue returns a tuple with the Value field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesMarker) GetValueOk() (string, bool) {
+func (t *TileDefMarker) GetValueOk() (string, bool) {
 	if t == nil || t.Value == nil {
 		return "", false
 	}
@@ -11532,7 +6603,7 @@ func (t *TimeseriesMarker) GetValueOk() (string, bool) {
 }
 
 // HasValue returns a boolean if a field has been set.
-func (t *TimeseriesMarker) HasValue() bool {
+func (t *TileDefMarker) HasValue() bool {
 	if t != nil && t.Value != nil {
 		return true
 	}
@@ -11541,12 +6612,291 @@ func (t *TimeseriesMarker) HasValue() bool {
 }
 
 // SetValue allocates a new t.Value and returns the pointer to it.
-func (t *TimeseriesMarker) SetValue(v string) {
+func (t *TileDefMarker) SetValue(v string) {
 	t.Value = &v
 }
 
+// GetAggregator returns the Aggregator field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetAggregator() string {
+	if t == nil || t.Aggregator == nil {
+		return ""
+	}
+	return *t.Aggregator
+}
+
+// GetOkAggregator returns a tuple with the Aggregator field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetAggregatorOk() (string, bool) {
+	if t == nil || t.Aggregator == nil {
+		return "", false
+	}
+	return *t.Aggregator, true
+}
+
+// HasAggregator returns a boolean if a field has been set.
+func (t *TileDefRequest) HasAggregator() bool {
+	if t != nil && t.Aggregator != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAggregator allocates a new t.Aggregator and returns the pointer to it.
+func (t *TileDefRequest) SetAggregator(v string) {
+	t.Aggregator = &v
+}
+
+// GetChangeType returns the ChangeType field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetChangeType() string {
+	if t == nil || t.ChangeType == nil {
+		return ""
+	}
+	return *t.ChangeType
+}
+
+// GetOkChangeType returns a tuple with the ChangeType field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetChangeTypeOk() (string, bool) {
+	if t == nil || t.ChangeType == nil {
+		return "", false
+	}
+	return *t.ChangeType, true
+}
+
+// HasChangeType returns a boolean if a field has been set.
+func (t *TileDefRequest) HasChangeType() bool {
+	if t != nil && t.ChangeType != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetChangeType allocates a new t.ChangeType and returns the pointer to it.
+func (t *TileDefRequest) SetChangeType(v string) {
+	t.ChangeType = &v
+}
+
+// GetCompareTo returns the CompareTo field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetCompareTo() string {
+	if t == nil || t.CompareTo == nil {
+		return ""
+	}
+	return *t.CompareTo
+}
+
+// GetOkCompareTo returns a tuple with the CompareTo field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetCompareToOk() (string, bool) {
+	if t == nil || t.CompareTo == nil {
+		return "", false
+	}
+	return *t.CompareTo, true
+}
+
+// HasCompareTo returns a boolean if a field has been set.
+func (t *TileDefRequest) HasCompareTo() bool {
+	if t != nil && t.CompareTo != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCompareTo allocates a new t.CompareTo and returns the pointer to it.
+func (t *TileDefRequest) SetCompareTo(v string) {
+	t.CompareTo = &v
+}
+
+// GetExtraCol returns the ExtraCol field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetExtraCol() string {
+	if t == nil || t.ExtraCol == nil {
+		return ""
+	}
+	return *t.ExtraCol
+}
+
+// GetOkExtraCol returns a tuple with the ExtraCol field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetExtraColOk() (string, bool) {
+	if t == nil || t.ExtraCol == nil {
+		return "", false
+	}
+	return *t.ExtraCol, true
+}
+
+// HasExtraCol returns a boolean if a field has been set.
+func (t *TileDefRequest) HasExtraCol() bool {
+	if t != nil && t.ExtraCol != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetExtraCol allocates a new t.ExtraCol and returns the pointer to it.
+func (t *TileDefRequest) SetExtraCol(v string) {
+	t.ExtraCol = &v
+}
+
+// GetIncreaseGood returns the IncreaseGood field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetIncreaseGood() bool {
+	if t == nil || t.IncreaseGood == nil {
+		return false
+	}
+	return *t.IncreaseGood
+}
+
+// GetOkIncreaseGood returns a tuple with the IncreaseGood field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetIncreaseGoodOk() (bool, bool) {
+	if t == nil || t.IncreaseGood == nil {
+		return false, false
+	}
+	return *t.IncreaseGood, true
+}
+
+// HasIncreaseGood returns a boolean if a field has been set.
+func (t *TileDefRequest) HasIncreaseGood() bool {
+	if t != nil && t.IncreaseGood != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIncreaseGood allocates a new t.IncreaseGood and returns the pointer to it.
+func (t *TileDefRequest) SetIncreaseGood(v bool) {
+	t.IncreaseGood = &v
+}
+
+// GetLimit returns the Limit field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetLimit() int {
+	if t == nil || t.Limit == nil {
+		return 0
+	}
+	return *t.Limit
+}
+
+// GetOkLimit returns a tuple with the Limit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetLimitOk() (int, bool) {
+	if t == nil || t.Limit == nil {
+		return 0, false
+	}
+	return *t.Limit, true
+}
+
+// HasLimit returns a boolean if a field has been set.
+func (t *TileDefRequest) HasLimit() bool {
+	if t != nil && t.Limit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLimit allocates a new t.Limit and returns the pointer to it.
+func (t *TileDefRequest) SetLimit(v int) {
+	t.Limit = &v
+}
+
+// GetMetric returns the Metric field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetMetric() string {
+	if t == nil || t.Metric == nil {
+		return ""
+	}
+	return *t.Metric
+}
+
+// GetOkMetric returns a tuple with the Metric field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetMetricOk() (string, bool) {
+	if t == nil || t.Metric == nil {
+		return "", false
+	}
+	return *t.Metric, true
+}
+
+// HasMetric returns a boolean if a field has been set.
+func (t *TileDefRequest) HasMetric() bool {
+	if t != nil && t.Metric != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetric allocates a new t.Metric and returns the pointer to it.
+func (t *TileDefRequest) SetMetric(v string) {
+	t.Metric = &v
+}
+
+// GetOrderBy returns the OrderBy field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetOrderBy() string {
+	if t == nil || t.OrderBy == nil {
+		return ""
+	}
+	return *t.OrderBy
+}
+
+// GetOkOrderBy returns a tuple with the OrderBy field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetOrderByOk() (string, bool) {
+	if t == nil || t.OrderBy == nil {
+		return "", false
+	}
+	return *t.OrderBy, true
+}
+
+// HasOrderBy returns a boolean if a field has been set.
+func (t *TileDefRequest) HasOrderBy() bool {
+	if t != nil && t.OrderBy != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOrderBy allocates a new t.OrderBy and returns the pointer to it.
+func (t *TileDefRequest) SetOrderBy(v string) {
+	t.OrderBy = &v
+}
+
+// GetOrderDir returns the OrderDir field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetOrderDir() string {
+	if t == nil || t.OrderDir == nil {
+		return ""
+	}
+	return *t.OrderDir
+}
+
+// GetOkOrderDir returns a tuple with the OrderDir field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetOrderDirOk() (string, bool) {
+	if t == nil || t.OrderDir == nil {
+		return "", false
+	}
+	return *t.OrderDir, true
+}
+
+// HasOrderDir returns a boolean if a field has been set.
+func (t *TileDefRequest) HasOrderDir() bool {
+	if t != nil && t.OrderDir != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOrderDir allocates a new t.OrderDir and returns the pointer to it.
+func (t *TileDefRequest) SetOrderDir(v string) {
+	t.OrderDir = &v
+}
+
 // GetQuery returns the Query field if non-nil, zero value otherwise.
-func (t *TimeseriesRequest) GetQuery() string {
+func (t *TileDefRequest) GetQuery() string {
 	if t == nil || t.Query == nil {
 		return ""
 	}
@@ -11555,7 +6905,7 @@ func (t *TimeseriesRequest) GetQuery() string {
 
 // GetOkQuery returns a tuple with the Query field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesRequest) GetQueryOk() (string, bool) {
+func (t *TileDefRequest) GetQueryOk() (string, bool) {
 	if t == nil || t.Query == nil {
 		return "", false
 	}
@@ -11563,7 +6913,7 @@ func (t *TimeseriesRequest) GetQueryOk() (string, bool) {
 }
 
 // HasQuery returns a boolean if a field has been set.
-func (t *TimeseriesRequest) HasQuery() bool {
+func (t *TileDefRequest) HasQuery() bool {
 	if t != nil && t.Query != nil {
 		return true
 	}
@@ -11572,29 +6922,60 @@ func (t *TimeseriesRequest) HasQuery() bool {
 }
 
 // SetQuery allocates a new t.Query and returns the pointer to it.
-func (t *TimeseriesRequest) SetQuery(v string) {
+func (t *TileDefRequest) SetQuery(v string) {
 	t.Query = &v
 }
 
+// GetQueryType returns the QueryType field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetQueryType() string {
+	if t == nil || t.QueryType == nil {
+		return ""
+	}
+	return *t.QueryType
+}
+
+// GetOkQueryType returns a tuple with the QueryType field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetQueryTypeOk() (string, bool) {
+	if t == nil || t.QueryType == nil {
+		return "", false
+	}
+	return *t.QueryType, true
+}
+
+// HasQueryType returns a boolean if a field has been set.
+func (t *TileDefRequest) HasQueryType() bool {
+	if t != nil && t.QueryType != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetQueryType allocates a new t.QueryType and returns the pointer to it.
+func (t *TileDefRequest) SetQueryType(v string) {
+	t.QueryType = &v
+}
+
 // GetStyle returns the Style field if non-nil, zero value otherwise.
-func (t *TimeseriesRequest) GetStyle() TimeseriesRequestStyle {
+func (t *TileDefRequest) GetStyle() TileDefRequestStyle {
 	if t == nil || t.Style == nil {
-		return TimeseriesRequestStyle{}
+		return TileDefRequestStyle{}
 	}
 	return *t.Style
 }
 
 // GetOkStyle returns a tuple with the Style field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesRequest) GetStyleOk() (TimeseriesRequestStyle, bool) {
+func (t *TileDefRequest) GetStyleOk() (TileDefRequestStyle, bool) {
 	if t == nil || t.Style == nil {
-		return TimeseriesRequestStyle{}, false
+		return TileDefRequestStyle{}, false
 	}
 	return *t.Style, true
 }
 
 // HasStyle returns a boolean if a field has been set.
-func (t *TimeseriesRequest) HasStyle() bool {
+func (t *TileDefRequest) HasStyle() bool {
 	if t != nil && t.Style != nil {
 		return true
 	}
@@ -11603,12 +6984,43 @@ func (t *TimeseriesRequest) HasStyle() bool {
 }
 
 // SetStyle allocates a new t.Style and returns the pointer to it.
-func (t *TimeseriesRequest) SetStyle(v TimeseriesRequestStyle) {
+func (t *TileDefRequest) SetStyle(v TileDefRequestStyle) {
 	t.Style = &v
 }
 
+// GetTextFilter returns the TextFilter field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetTextFilter() string {
+	if t == nil || t.TextFilter == nil {
+		return ""
+	}
+	return *t.TextFilter
+}
+
+// GetOkTextFilter returns a tuple with the TextFilter field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetTextFilterOk() (string, bool) {
+	if t == nil || t.TextFilter == nil {
+		return "", false
+	}
+	return *t.TextFilter, true
+}
+
+// HasTextFilter returns a boolean if a field has been set.
+func (t *TileDefRequest) HasTextFilter() bool {
+	if t != nil && t.TextFilter != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTextFilter allocates a new t.TextFilter and returns the pointer to it.
+func (t *TileDefRequest) SetTextFilter(v string) {
+	t.TextFilter = &v
+}
+
 // GetType returns the Type field if non-nil, zero value otherwise.
-func (t *TimeseriesRequest) GetType() string {
+func (t *TileDefRequest) GetType() string {
 	if t == nil || t.Type == nil {
 		return ""
 	}
@@ -11617,7 +7029,7 @@ func (t *TimeseriesRequest) GetType() string {
 
 // GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesRequest) GetTypeOk() (string, bool) {
+func (t *TileDefRequest) GetTypeOk() (string, bool) {
 	if t == nil || t.Type == nil {
 		return "", false
 	}
@@ -11625,7 +7037,7 @@ func (t *TimeseriesRequest) GetTypeOk() (string, bool) {
 }
 
 // HasType returns a boolean if a field has been set.
-func (t *TimeseriesRequest) HasType() bool {
+func (t *TileDefRequest) HasType() bool {
 	if t != nil && t.Type != nil {
 		return true
 	}
@@ -11634,12 +7046,12 @@ func (t *TimeseriesRequest) HasType() bool {
 }
 
 // SetType allocates a new t.Type and returns the pointer to it.
-func (t *TimeseriesRequest) SetType(v string) {
+func (t *TileDefRequest) SetType(v string) {
 	t.Type = &v
 }
 
 // GetPalette returns the Palette field if non-nil, zero value otherwise.
-func (t *TimeseriesRequestStyle) GetPalette() string {
+func (t *TileDefRequestStyle) GetPalette() string {
 	if t == nil || t.Palette == nil {
 		return ""
 	}
@@ -11648,7 +7060,7 @@ func (t *TimeseriesRequestStyle) GetPalette() string {
 
 // GetOkPalette returns a tuple with the Palette field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesRequestStyle) GetPaletteOk() (string, bool) {
+func (t *TileDefRequestStyle) GetPaletteOk() (string, bool) {
 	if t == nil || t.Palette == nil {
 		return "", false
 	}
@@ -11656,7 +7068,7 @@ func (t *TimeseriesRequestStyle) GetPaletteOk() (string, bool) {
 }
 
 // HasPalette returns a boolean if a field has been set.
-func (t *TimeseriesRequestStyle) HasPalette() bool {
+func (t *TileDefRequestStyle) HasPalette() bool {
 	if t != nil && t.Palette != nil {
 		return true
 	}
@@ -11665,260 +7077,12 @@ func (t *TimeseriesRequestStyle) HasPalette() bool {
 }
 
 // SetPalette allocates a new t.Palette and returns the pointer to it.
-func (t *TimeseriesRequestStyle) SetPalette(v string) {
+func (t *TileDefRequestStyle) SetPalette(v string) {
 	t.Palette = &v
 }
 
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetHeight() int {
-	if t == nil || t.Height == nil {
-		return 0
-	}
-	return *t.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetHeightOk() (int, bool) {
-	if t == nil || t.Height == nil {
-		return 0, false
-	}
-	return *t.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasHeight() bool {
-	if t != nil && t.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new t.Height and returns the pointer to it.
-func (t *TimeseriesWidget) SetHeight(v int) {
-	t.Height = &v
-}
-
-// GetLegend returns the Legend field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetLegend() bool {
-	if t == nil || t.Legend == nil {
-		return false
-	}
-	return *t.Legend
-}
-
-// GetOkLegend returns a tuple with the Legend field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetLegendOk() (bool, bool) {
-	if t == nil || t.Legend == nil {
-		return false, false
-	}
-	return *t.Legend, true
-}
-
-// HasLegend returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasLegend() bool {
-	if t != nil && t.Legend != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegend allocates a new t.Legend and returns the pointer to it.
-func (t *TimeseriesWidget) SetLegend(v bool) {
-	t.Legend = &v
-}
-
-// GetTileDef returns the TileDef field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetTileDef() TileDef {
-	if t == nil || t.TileDef == nil {
-		return TileDef{}
-	}
-	return *t.TileDef
-}
-
-// GetOkTileDef returns a tuple with the TileDef field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTileDefOk() (TileDef, bool) {
-	if t == nil || t.TileDef == nil {
-		return TileDef{}, false
-	}
-	return *t.TileDef, true
-}
-
-// HasTileDef returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasTileDef() bool {
-	if t != nil && t.TileDef != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTileDef allocates a new t.TileDef and returns the pointer to it.
-func (t *TimeseriesWidget) SetTileDef(v TileDef) {
-	t.TileDef = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetTimeframe() string {
-	if t == nil || t.Timeframe == nil {
-		return ""
-	}
-	return *t.Timeframe
-}
-
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTimeframeOk() (string, bool) {
-	if t == nil || t.Timeframe == nil {
-		return "", false
-	}
-	return *t.Timeframe, true
-}
-
-// HasTimeframe returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasTimeframe() bool {
-	if t != nil && t.Timeframe != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTimeframe allocates a new t.Timeframe and returns the pointer to it.
-func (t *TimeseriesWidget) SetTimeframe(v string) {
-	t.Timeframe = &v
-}
-
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetTitle() bool {
-	if t == nil || t.Title == nil {
-		return false
-	}
-	return *t.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTitleOk() (bool, bool) {
-	if t == nil || t.Title == nil {
-		return false, false
-	}
-	return *t.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasTitle() bool {
-	if t != nil && t.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new t.Title and returns the pointer to it.
-func (t *TimeseriesWidget) SetTitle(v bool) {
-	t.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetTitleAlign() string {
-	if t == nil || t.TitleAlign == nil {
-		return ""
-	}
-	return *t.TitleAlign
-}
-
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTitleAlignOk() (string, bool) {
-	if t == nil || t.TitleAlign == nil {
-		return "", false
-	}
-	return *t.TitleAlign, true
-}
-
-// HasTitleAlign returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasTitleAlign() bool {
-	if t != nil && t.TitleAlign != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleAlign allocates a new t.TitleAlign and returns the pointer to it.
-func (t *TimeseriesWidget) SetTitleAlign(v string) {
-	t.TitleAlign = &v
-}
-
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetTitleSize() TextSize {
-	if t == nil || t.TitleSize == nil {
-		return TextSize{}
-	}
-	return *t.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTitleSizeOk() (TextSize, bool) {
-	if t == nil || t.TitleSize == nil {
-		return TextSize{}, false
-	}
-	return *t.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasTitleSize() bool {
-	if t != nil && t.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new t.TitleSize and returns the pointer to it.
-func (t *TimeseriesWidget) SetTitleSize(v TextSize) {
-	t.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetTitleText() string {
-	if t == nil || t.TitleText == nil {
-		return ""
-	}
-	return *t.TitleText
-}
-
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTitleTextOk() (string, bool) {
-	if t == nil || t.TitleText == nil {
-		return "", false
-	}
-	return *t.TitleText, true
-}
-
-// HasTitleText returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasTitleText() bool {
-	if t != nil && t.TitleText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleText allocates a new t.TitleText and returns the pointer to it.
-func (t *TimeseriesWidget) SetTitleText(v string) {
-	t.TitleText = &v
-}
-
 // GetType returns the Type field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetType() string {
+func (t *TileDefRequestStyle) GetType() string {
 	if t == nil || t.Type == nil {
 		return ""
 	}
@@ -11927,7 +7091,7 @@ func (t *TimeseriesWidget) GetType() string {
 
 // GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetTypeOk() (string, bool) {
+func (t *TileDefRequestStyle) GetTypeOk() (string, bool) {
 	if t == nil || t.Type == nil {
 		return "", false
 	}
@@ -11935,7 +7099,7 @@ func (t *TimeseriesWidget) GetTypeOk() (string, bool) {
 }
 
 // HasType returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasType() bool {
+func (t *TileDefRequestStyle) HasType() bool {
 	if t != nil && t.Type != nil {
 		return true
 	}
@@ -11944,29 +7108,29 @@ func (t *TimeseriesWidget) HasType() bool {
 }
 
 // SetType allocates a new t.Type and returns the pointer to it.
-func (t *TimeseriesWidget) SetType(v string) {
+func (t *TileDefRequestStyle) SetType(v string) {
 	t.Type = &v
 }
 
 // GetWidth returns the Width field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetWidth() int {
+func (t *TileDefRequestStyle) GetWidth() string {
 	if t == nil || t.Width == nil {
-		return 0
+		return ""
 	}
 	return *t.Width
 }
 
 // GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetWidthOk() (int, bool) {
+func (t *TileDefRequestStyle) GetWidthOk() (string, bool) {
 	if t == nil || t.Width == nil {
-		return 0, false
+		return "", false
 	}
 	return *t.Width, true
 }
 
 // HasWidth returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasWidth() bool {
+func (t *TileDefRequestStyle) HasWidth() bool {
 	if t != nil && t.Width != nil {
 		return true
 	}
@@ -11975,473 +7139,163 @@ func (t *TimeseriesWidget) HasWidth() bool {
 }
 
 // SetWidth allocates a new t.Width and returns the pointer to it.
-func (t *TimeseriesWidget) SetWidth(v int) {
+func (t *TileDefRequestStyle) SetWidth(v string) {
 	t.Width = &v
 }
 
-// GetX returns the X field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetX() int {
-	if t == nil || t.X == nil {
-		return 0
-	}
-	return *t.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetXOk() (int, bool) {
-	if t == nil || t.X == nil {
-		return 0, false
-	}
-	return *t.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasX() bool {
-	if t != nil && t.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new t.X and returns the pointer to it.
-func (t *TimeseriesWidget) SetX(v int) {
-	t.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (t *TimeseriesWidget) GetY() int {
-	if t == nil || t.Y == nil {
-		return 0
-	}
-	return *t.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *TimeseriesWidget) GetYOk() (int, bool) {
-	if t == nil || t.Y == nil {
-		return 0, false
-	}
-	return *t.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (t *TimeseriesWidget) HasY() bool {
-	if t != nil && t.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new t.Y and returns the pointer to it.
-func (t *TimeseriesWidget) SetY(v int) {
-	t.Y = &v
-}
-
-// GetHeight returns the Height field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetHeight() int {
-	if t == nil || t.Height == nil {
-		return 0
-	}
-	return *t.Height
-}
-
-// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetHeightOk() (int, bool) {
-	if t == nil || t.Height == nil {
-		return 0, false
-	}
-	return *t.Height, true
-}
-
-// HasHeight returns a boolean if a field has been set.
-func (t *ToplistWidget) HasHeight() bool {
-	if t != nil && t.Height != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHeight allocates a new t.Height and returns the pointer to it.
-func (t *ToplistWidget) SetHeight(v int) {
-	t.Height = &v
-}
-
-// GetLegend returns the Legend field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetLegend() bool {
-	if t == nil || t.Legend == nil {
-		return false
-	}
-	return *t.Legend
-}
-
-// GetOkLegend returns a tuple with the Legend field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetLegendOk() (bool, bool) {
-	if t == nil || t.Legend == nil {
-		return false, false
-	}
-	return *t.Legend, true
-}
-
-// HasLegend returns a boolean if a field has been set.
-func (t *ToplistWidget) HasLegend() bool {
-	if t != nil && t.Legend != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegend allocates a new t.Legend and returns the pointer to it.
-func (t *ToplistWidget) SetLegend(v bool) {
-	t.Legend = &v
-}
-
-// GetLegendSize returns the LegendSize field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetLegendSize() int {
-	if t == nil || t.LegendSize == nil {
-		return 0
-	}
-	return *t.LegendSize
-}
-
-// GetOkLegendSize returns a tuple with the LegendSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetLegendSizeOk() (int, bool) {
-	if t == nil || t.LegendSize == nil {
-		return 0, false
-	}
-	return *t.LegendSize, true
-}
-
-// HasLegendSize returns a boolean if a field has been set.
-func (t *ToplistWidget) HasLegendSize() bool {
-	if t != nil && t.LegendSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLegendSize allocates a new t.LegendSize and returns the pointer to it.
-func (t *ToplistWidget) SetLegendSize(v int) {
-	t.LegendSize = &v
-}
-
-// GetTileDef returns the TileDef field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetTileDef() TileDef {
-	if t == nil || t.TileDef == nil {
-		return TileDef{}
-	}
-	return *t.TileDef
-}
-
-// GetOkTileDef returns a tuple with the TileDef field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTileDefOk() (TileDef, bool) {
-	if t == nil || t.TileDef == nil {
-		return TileDef{}, false
-	}
-	return *t.TileDef, true
-}
-
-// HasTileDef returns a boolean if a field has been set.
-func (t *ToplistWidget) HasTileDef() bool {
-	if t != nil && t.TileDef != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTileDef allocates a new t.TileDef and returns the pointer to it.
-func (t *ToplistWidget) SetTileDef(v TileDef) {
-	t.TileDef = &v
-}
-
-// GetTimeframe returns the Timeframe field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetTimeframe() string {
-	if t == nil || t.Timeframe == nil {
+// GetFillMax returns the FillMax field if non-nil, zero value otherwise.
+func (t *TileDefStyle) GetFillMax() string {
+	if t == nil || t.FillMax == nil {
 		return ""
 	}
-	return *t.Timeframe
+	return *t.FillMax
 }
 
-// GetOkTimeframe returns a tuple with the Timeframe field if it's non-nil, zero value otherwise
+// GetOkFillMax returns a tuple with the FillMax field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTimeframeOk() (string, bool) {
-	if t == nil || t.Timeframe == nil {
+func (t *TileDefStyle) GetFillMaxOk() (string, bool) {
+	if t == nil || t.FillMax == nil {
 		return "", false
 	}
-	return *t.Timeframe, true
+	return *t.FillMax, true
 }
 
-// HasTimeframe returns a boolean if a field has been set.
-func (t *ToplistWidget) HasTimeframe() bool {
-	if t != nil && t.Timeframe != nil {
+// HasFillMax returns a boolean if a field has been set.
+func (t *TileDefStyle) HasFillMax() bool {
+	if t != nil && t.FillMax != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetTimeframe allocates a new t.Timeframe and returns the pointer to it.
-func (t *ToplistWidget) SetTimeframe(v string) {
-	t.Timeframe = &v
+// SetFillMax allocates a new t.FillMax and returns the pointer to it.
+func (t *TileDefStyle) SetFillMax(v string) {
+	t.FillMax = &v
 }
 
-// GetTitle returns the Title field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetTitle() bool {
-	if t == nil || t.Title == nil {
-		return false
-	}
-	return *t.Title
-}
-
-// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTitleOk() (bool, bool) {
-	if t == nil || t.Title == nil {
-		return false, false
-	}
-	return *t.Title, true
-}
-
-// HasTitle returns a boolean if a field has been set.
-func (t *ToplistWidget) HasTitle() bool {
-	if t != nil && t.Title != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitle allocates a new t.Title and returns the pointer to it.
-func (t *ToplistWidget) SetTitle(v bool) {
-	t.Title = &v
-}
-
-// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetTitleAlign() string {
-	if t == nil || t.TitleAlign == nil {
+// GetFillMin returns the FillMin field if non-nil, zero value otherwise.
+func (t *TileDefStyle) GetFillMin() string {
+	if t == nil || t.FillMin == nil {
 		return ""
 	}
-	return *t.TitleAlign
+	return *t.FillMin
 }
 
-// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
+// GetOkFillMin returns a tuple with the FillMin field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTitleAlignOk() (string, bool) {
-	if t == nil || t.TitleAlign == nil {
+func (t *TileDefStyle) GetFillMinOk() (string, bool) {
+	if t == nil || t.FillMin == nil {
 		return "", false
 	}
-	return *t.TitleAlign, true
+	return *t.FillMin, true
 }
 
-// HasTitleAlign returns a boolean if a field has been set.
-func (t *ToplistWidget) HasTitleAlign() bool {
-	if t != nil && t.TitleAlign != nil {
+// HasFillMin returns a boolean if a field has been set.
+func (t *TileDefStyle) HasFillMin() bool {
+	if t != nil && t.FillMin != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetTitleAlign allocates a new t.TitleAlign and returns the pointer to it.
-func (t *ToplistWidget) SetTitleAlign(v string) {
-	t.TitleAlign = &v
+// SetFillMin allocates a new t.FillMin and returns the pointer to it.
+func (t *TileDefStyle) SetFillMin(v string) {
+	t.FillMin = &v
 }
 
-// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetTitleSize() TextSize {
-	if t == nil || t.TitleSize == nil {
-		return TextSize{}
-	}
-	return *t.TitleSize
-}
-
-// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTitleSizeOk() (TextSize, bool) {
-	if t == nil || t.TitleSize == nil {
-		return TextSize{}, false
-	}
-	return *t.TitleSize, true
-}
-
-// HasTitleSize returns a boolean if a field has been set.
-func (t *ToplistWidget) HasTitleSize() bool {
-	if t != nil && t.TitleSize != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetTitleSize allocates a new t.TitleSize and returns the pointer to it.
-func (t *ToplistWidget) SetTitleSize(v TextSize) {
-	t.TitleSize = &v
-}
-
-// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetTitleText() string {
-	if t == nil || t.TitleText == nil {
+// GetPalette returns the Palette field if non-nil, zero value otherwise.
+func (t *TileDefStyle) GetPalette() string {
+	if t == nil || t.Palette == nil {
 		return ""
 	}
-	return *t.TitleText
+	return *t.Palette
 }
 
-// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
+// GetOkPalette returns a tuple with the Palette field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTitleTextOk() (string, bool) {
-	if t == nil || t.TitleText == nil {
+func (t *TileDefStyle) GetPaletteOk() (string, bool) {
+	if t == nil || t.Palette == nil {
 		return "", false
 	}
-	return *t.TitleText, true
+	return *t.Palette, true
 }
 
-// HasTitleText returns a boolean if a field has been set.
-func (t *ToplistWidget) HasTitleText() bool {
-	if t != nil && t.TitleText != nil {
+// HasPalette returns a boolean if a field has been set.
+func (t *TileDefStyle) HasPalette() bool {
+	if t != nil && t.Palette != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetTitleText allocates a new t.TitleText and returns the pointer to it.
-func (t *ToplistWidget) SetTitleText(v string) {
-	t.TitleText = &v
+// SetPalette allocates a new t.Palette and returns the pointer to it.
+func (t *TileDefStyle) SetPalette(v string) {
+	t.Palette = &v
 }
 
-// GetType returns the Type field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetType() string {
-	if t == nil || t.Type == nil {
+// GetPaletteFlip returns the PaletteFlip field if non-nil, zero value otherwise.
+func (t *TileDefStyle) GetPaletteFlip() string {
+	if t == nil || t.PaletteFlip == nil {
 		return ""
 	}
-	return *t.Type
+	return *t.PaletteFlip
 }
 
-// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
+// GetOkPaletteFlip returns a tuple with the PaletteFlip field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetTypeOk() (string, bool) {
-	if t == nil || t.Type == nil {
+func (t *TileDefStyle) GetPaletteFlipOk() (string, bool) {
+	if t == nil || t.PaletteFlip == nil {
 		return "", false
 	}
-	return *t.Type, true
+	return *t.PaletteFlip, true
 }
 
-// HasType returns a boolean if a field has been set.
-func (t *ToplistWidget) HasType() bool {
-	if t != nil && t.Type != nil {
+// HasPaletteFlip returns a boolean if a field has been set.
+func (t *TileDefStyle) HasPaletteFlip() bool {
+	if t != nil && t.PaletteFlip != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetType allocates a new t.Type and returns the pointer to it.
-func (t *ToplistWidget) SetType(v string) {
-	t.Type = &v
+// SetPaletteFlip allocates a new t.PaletteFlip and returns the pointer to it.
+func (t *TileDefStyle) SetPaletteFlip(v string) {
+	t.PaletteFlip = &v
 }
 
-// GetWidth returns the Width field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetWidth() int {
-	if t == nil || t.Width == nil {
-		return 0
+// GetLiveSpan returns the LiveSpan field if non-nil, zero value otherwise.
+func (t *Time) GetLiveSpan() string {
+	if t == nil || t.LiveSpan == nil {
+		return ""
 	}
-	return *t.Width
+	return *t.LiveSpan
 }
 
-// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
+// GetOkLiveSpan returns a tuple with the LiveSpan field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetWidthOk() (int, bool) {
-	if t == nil || t.Width == nil {
-		return 0, false
+func (t *Time) GetLiveSpanOk() (string, bool) {
+	if t == nil || t.LiveSpan == nil {
+		return "", false
 	}
-	return *t.Width, true
+	return *t.LiveSpan, true
 }
 
-// HasWidth returns a boolean if a field has been set.
-func (t *ToplistWidget) HasWidth() bool {
-	if t != nil && t.Width != nil {
+// HasLiveSpan returns a boolean if a field has been set.
+func (t *Time) HasLiveSpan() bool {
+	if t != nil && t.LiveSpan != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetWidth allocates a new t.Width and returns the pointer to it.
-func (t *ToplistWidget) SetWidth(v int) {
-	t.Width = &v
-}
-
-// GetX returns the X field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetX() int {
-	if t == nil || t.X == nil {
-		return 0
-	}
-	return *t.X
-}
-
-// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetXOk() (int, bool) {
-	if t == nil || t.X == nil {
-		return 0, false
-	}
-	return *t.X, true
-}
-
-// HasX returns a boolean if a field has been set.
-func (t *ToplistWidget) HasX() bool {
-	if t != nil && t.X != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetX allocates a new t.X and returns the pointer to it.
-func (t *ToplistWidget) SetX(v int) {
-	t.X = &v
-}
-
-// GetY returns the Y field if non-nil, zero value otherwise.
-func (t *ToplistWidget) GetY() int {
-	if t == nil || t.Y == nil {
-		return 0
-	}
-	return *t.Y
-}
-
-// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (t *ToplistWidget) GetYOk() (int, bool) {
-	if t == nil || t.Y == nil {
-		return 0, false
-	}
-	return *t.Y, true
-}
-
-// HasY returns a boolean if a field has been set.
-func (t *ToplistWidget) HasY() bool {
-	if t != nil && t.Y != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetY allocates a new t.Y and returns the pointer to it.
-func (t *ToplistWidget) SetY(v int) {
-	t.Y = &v
+// SetLiveSpan allocates a new t.LiveSpan and returns the pointer to it.
+func (t *Time) SetLiveSpan(v string) {
+	t.LiveSpan = &v
 }
 
 // GetAccessRole returns the AccessRole field if non-nil, zero value otherwise.
@@ -12692,562 +7546,1802 @@ func (u *User) SetVerified(v bool) {
 	u.Verified = &v
 }
 
-// GetAlertGraphWidget returns the AlertGraphWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetAlertGraphWidget() AlertGraphWidget {
-	if w == nil || w.AlertGraphWidget == nil {
-		return AlertGraphWidget{}
+// GetAlertID returns the AlertID field if non-nil, zero value otherwise.
+func (w *Widget) GetAlertID() int {
+	if w == nil || w.AlertID == nil {
+		return 0
 	}
-	return *w.AlertGraphWidget
+	return *w.AlertID
 }
 
-// GetOkAlertGraphWidget returns a tuple with the AlertGraphWidget field if it's non-nil, zero value otherwise
+// GetOkAlertID returns a tuple with the AlertID field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetAlertGraphWidgetOk() (AlertGraphWidget, bool) {
-	if w == nil || w.AlertGraphWidget == nil {
-		return AlertGraphWidget{}, false
+func (w *Widget) GetAlertIDOk() (int, bool) {
+	if w == nil || w.AlertID == nil {
+		return 0, false
 	}
-	return *w.AlertGraphWidget, true
+	return *w.AlertID, true
 }
 
-// HasAlertGraphWidget returns a boolean if a field has been set.
-func (w *Widget) HasAlertGraphWidget() bool {
-	if w != nil && w.AlertGraphWidget != nil {
+// HasAlertID returns a boolean if a field has been set.
+func (w *Widget) HasAlertID() bool {
+	if w != nil && w.AlertID != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetAlertGraphWidget allocates a new w.AlertGraphWidget and returns the pointer to it.
-func (w *Widget) SetAlertGraphWidget(v AlertGraphWidget) {
-	w.AlertGraphWidget = &v
+// SetAlertID allocates a new w.AlertID and returns the pointer to it.
+func (w *Widget) SetAlertID(v int) {
+	w.AlertID = &v
 }
 
-// GetAlertValueWidget returns the AlertValueWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetAlertValueWidget() AlertValueWidget {
-	if w == nil || w.AlertValueWidget == nil {
-		return AlertValueWidget{}
+// GetAutoRefresh returns the AutoRefresh field if non-nil, zero value otherwise.
+func (w *Widget) GetAutoRefresh() bool {
+	if w == nil || w.AutoRefresh == nil {
+		return false
 	}
-	return *w.AlertValueWidget
+	return *w.AutoRefresh
 }
 
-// GetOkAlertValueWidget returns a tuple with the AlertValueWidget field if it's non-nil, zero value otherwise
+// GetOkAutoRefresh returns a tuple with the AutoRefresh field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetAlertValueWidgetOk() (AlertValueWidget, bool) {
-	if w == nil || w.AlertValueWidget == nil {
-		return AlertValueWidget{}, false
+func (w *Widget) GetAutoRefreshOk() (bool, bool) {
+	if w == nil || w.AutoRefresh == nil {
+		return false, false
 	}
-	return *w.AlertValueWidget, true
+	return *w.AutoRefresh, true
 }
 
-// HasAlertValueWidget returns a boolean if a field has been set.
-func (w *Widget) HasAlertValueWidget() bool {
-	if w != nil && w.AlertValueWidget != nil {
+// HasAutoRefresh returns a boolean if a field has been set.
+func (w *Widget) HasAutoRefresh() bool {
+	if w != nil && w.AutoRefresh != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetAlertValueWidget allocates a new w.AlertValueWidget and returns the pointer to it.
-func (w *Widget) SetAlertValueWidget(v AlertValueWidget) {
-	w.AlertValueWidget = &v
+// SetAutoRefresh allocates a new w.AutoRefresh and returns the pointer to it.
+func (w *Widget) SetAutoRefresh(v bool) {
+	w.AutoRefresh = &v
 }
 
-// GetChangeWidget returns the ChangeWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetChangeWidget() ChangeWidget {
-	if w == nil || w.ChangeWidget == nil {
-		return ChangeWidget{}
-	}
-	return *w.ChangeWidget
-}
-
-// GetOkChangeWidget returns a tuple with the ChangeWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetChangeWidgetOk() (ChangeWidget, bool) {
-	if w == nil || w.ChangeWidget == nil {
-		return ChangeWidget{}, false
-	}
-	return *w.ChangeWidget, true
-}
-
-// HasChangeWidget returns a boolean if a field has been set.
-func (w *Widget) HasChangeWidget() bool {
-	if w != nil && w.ChangeWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetChangeWidget allocates a new w.ChangeWidget and returns the pointer to it.
-func (w *Widget) SetChangeWidget(v ChangeWidget) {
-	w.ChangeWidget = &v
-}
-
-// GetCheckStatusWidget returns the CheckStatusWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetCheckStatusWidget() CheckStatusWidget {
-	if w == nil || w.CheckStatusWidget == nil {
-		return CheckStatusWidget{}
-	}
-	return *w.CheckStatusWidget
-}
-
-// GetOkCheckStatusWidget returns a tuple with the CheckStatusWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetCheckStatusWidgetOk() (CheckStatusWidget, bool) {
-	if w == nil || w.CheckStatusWidget == nil {
-		return CheckStatusWidget{}, false
-	}
-	return *w.CheckStatusWidget, true
-}
-
-// HasCheckStatusWidget returns a boolean if a field has been set.
-func (w *Widget) HasCheckStatusWidget() bool {
-	if w != nil && w.CheckStatusWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetCheckStatusWidget allocates a new w.CheckStatusWidget and returns the pointer to it.
-func (w *Widget) SetCheckStatusWidget(v CheckStatusWidget) {
-	w.CheckStatusWidget = &v
-}
-
-// GetDefault returns the Default field if non-nil, zero value otherwise.
-func (w *Widget) GetDefault() string {
-	if w == nil || w.Default == nil {
+// GetBgcolor returns the Bgcolor field if non-nil, zero value otherwise.
+func (w *Widget) GetBgcolor() string {
+	if w == nil || w.Bgcolor == nil {
 		return ""
 	}
-	return *w.Default
+	return *w.Bgcolor
 }
 
-// GetOkDefault returns a tuple with the Default field if it's non-nil, zero value otherwise
+// GetOkBgcolor returns a tuple with the Bgcolor field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetDefaultOk() (string, bool) {
-	if w == nil || w.Default == nil {
+func (w *Widget) GetBgcolorOk() (string, bool) {
+	if w == nil || w.Bgcolor == nil {
 		return "", false
 	}
-	return *w.Default, true
+	return *w.Bgcolor, true
 }
 
-// HasDefault returns a boolean if a field has been set.
-func (w *Widget) HasDefault() bool {
-	if w != nil && w.Default != nil {
+// HasBgcolor returns a boolean if a field has been set.
+func (w *Widget) HasBgcolor() bool {
+	if w != nil && w.Bgcolor != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetDefault allocates a new w.Default and returns the pointer to it.
-func (w *Widget) SetDefault(v string) {
-	w.Default = &v
+// SetBgcolor allocates a new w.Bgcolor and returns the pointer to it.
+func (w *Widget) SetBgcolor(v string) {
+	w.Bgcolor = &v
 }
 
-// GetEventStreamWidget returns the EventStreamWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetEventStreamWidget() EventStreamWidget {
-	if w == nil || w.EventStreamWidget == nil {
-		return EventStreamWidget{}
-	}
-	return *w.EventStreamWidget
-}
-
-// GetOkEventStreamWidget returns a tuple with the EventStreamWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetEventStreamWidgetOk() (EventStreamWidget, bool) {
-	if w == nil || w.EventStreamWidget == nil {
-		return EventStreamWidget{}, false
-	}
-	return *w.EventStreamWidget, true
-}
-
-// HasEventStreamWidget returns a boolean if a field has been set.
-func (w *Widget) HasEventStreamWidget() bool {
-	if w != nil && w.EventStreamWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetEventStreamWidget allocates a new w.EventStreamWidget and returns the pointer to it.
-func (w *Widget) SetEventStreamWidget(v EventStreamWidget) {
-	w.EventStreamWidget = &v
-}
-
-// GetEventTimelineWidget returns the EventTimelineWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetEventTimelineWidget() EventTimelineWidget {
-	if w == nil || w.EventTimelineWidget == nil {
-		return EventTimelineWidget{}
-	}
-	return *w.EventTimelineWidget
-}
-
-// GetOkEventTimelineWidget returns a tuple with the EventTimelineWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetEventTimelineWidgetOk() (EventTimelineWidget, bool) {
-	if w == nil || w.EventTimelineWidget == nil {
-		return EventTimelineWidget{}, false
-	}
-	return *w.EventTimelineWidget, true
-}
-
-// HasEventTimelineWidget returns a boolean if a field has been set.
-func (w *Widget) HasEventTimelineWidget() bool {
-	if w != nil && w.EventTimelineWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetEventTimelineWidget allocates a new w.EventTimelineWidget and returns the pointer to it.
-func (w *Widget) SetEventTimelineWidget(v EventTimelineWidget) {
-	w.EventTimelineWidget = &v
-}
-
-// GetFreeTextWidget returns the FreeTextWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetFreeTextWidget() FreeTextWidget {
-	if w == nil || w.FreeTextWidget == nil {
-		return FreeTextWidget{}
-	}
-	return *w.FreeTextWidget
-}
-
-// GetOkFreeTextWidget returns a tuple with the FreeTextWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetFreeTextWidgetOk() (FreeTextWidget, bool) {
-	if w == nil || w.FreeTextWidget == nil {
-		return FreeTextWidget{}, false
-	}
-	return *w.FreeTextWidget, true
-}
-
-// HasFreeTextWidget returns a boolean if a field has been set.
-func (w *Widget) HasFreeTextWidget() bool {
-	if w != nil && w.FreeTextWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetFreeTextWidget allocates a new w.FreeTextWidget and returns the pointer to it.
-func (w *Widget) SetFreeTextWidget(v FreeTextWidget) {
-	w.FreeTextWidget = &v
-}
-
-// GetGraphWidget returns the GraphWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetGraphWidget() GraphWidget {
-	if w == nil || w.GraphWidget == nil {
-		return GraphWidget{}
-	}
-	return *w.GraphWidget
-}
-
-// GetOkGraphWidget returns a tuple with the GraphWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetGraphWidgetOk() (GraphWidget, bool) {
-	if w == nil || w.GraphWidget == nil {
-		return GraphWidget{}, false
-	}
-	return *w.GraphWidget, true
-}
-
-// HasGraphWidget returns a boolean if a field has been set.
-func (w *Widget) HasGraphWidget() bool {
-	if w != nil && w.GraphWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetGraphWidget allocates a new w.GraphWidget and returns the pointer to it.
-func (w *Widget) SetGraphWidget(v GraphWidget) {
-	w.GraphWidget = &v
-}
-
-// GetHostMapWidget returns the HostMapWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetHostMapWidget() HostMapWidget {
-	if w == nil || w.HostMapWidget == nil {
-		return HostMapWidget{}
-	}
-	return *w.HostMapWidget
-}
-
-// GetOkHostMapWidget returns a tuple with the HostMapWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetHostMapWidgetOk() (HostMapWidget, bool) {
-	if w == nil || w.HostMapWidget == nil {
-		return HostMapWidget{}, false
-	}
-	return *w.HostMapWidget, true
-}
-
-// HasHostMapWidget returns a boolean if a field has been set.
-func (w *Widget) HasHostMapWidget() bool {
-	if w != nil && w.HostMapWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHostMapWidget allocates a new w.HostMapWidget and returns the pointer to it.
-func (w *Widget) SetHostMapWidget(v HostMapWidget) {
-	w.HostMapWidget = &v
-}
-
-// GetIFrameWidget returns the IFrameWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetIFrameWidget() IFrameWidget {
-	if w == nil || w.IFrameWidget == nil {
-		return IFrameWidget{}
-	}
-	return *w.IFrameWidget
-}
-
-// GetOkIFrameWidget returns a tuple with the IFrameWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetIFrameWidgetOk() (IFrameWidget, bool) {
-	if w == nil || w.IFrameWidget == nil {
-		return IFrameWidget{}, false
-	}
-	return *w.IFrameWidget, true
-}
-
-// HasIFrameWidget returns a boolean if a field has been set.
-func (w *Widget) HasIFrameWidget() bool {
-	if w != nil && w.IFrameWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetIFrameWidget allocates a new w.IFrameWidget and returns the pointer to it.
-func (w *Widget) SetIFrameWidget(v IFrameWidget) {
-	w.IFrameWidget = &v
-}
-
-// GetImageWidget returns the ImageWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetImageWidget() ImageWidget {
-	if w == nil || w.ImageWidget == nil {
-		return ImageWidget{}
-	}
-	return *w.ImageWidget
-}
-
-// GetOkImageWidget returns a tuple with the ImageWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetImageWidgetOk() (ImageWidget, bool) {
-	if w == nil || w.ImageWidget == nil {
-		return ImageWidget{}, false
-	}
-	return *w.ImageWidget, true
-}
-
-// HasImageWidget returns a boolean if a field has been set.
-func (w *Widget) HasImageWidget() bool {
-	if w != nil && w.ImageWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetImageWidget allocates a new w.ImageWidget and returns the pointer to it.
-func (w *Widget) SetImageWidget(v ImageWidget) {
-	w.ImageWidget = &v
-}
-
-// GetName returns the Name field if non-nil, zero value otherwise.
-func (w *Widget) GetName() string {
-	if w == nil || w.Name == nil {
+// GetCheck returns the Check field if non-nil, zero value otherwise.
+func (w *Widget) GetCheck() string {
+	if w == nil || w.Check == nil {
 		return ""
 	}
-	return *w.Name
+	return *w.Check
 }
 
-// GetOkName returns a tuple with the Name field if it's non-nil, zero value otherwise
+// GetOkCheck returns a tuple with the Check field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetNameOk() (string, bool) {
-	if w == nil || w.Name == nil {
+func (w *Widget) GetCheckOk() (string, bool) {
+	if w == nil || w.Check == nil {
 		return "", false
 	}
-	return *w.Name, true
+	return *w.Check, true
 }
 
-// HasName returns a boolean if a field has been set.
-func (w *Widget) HasName() bool {
-	if w != nil && w.Name != nil {
+// HasCheck returns a boolean if a field has been set.
+func (w *Widget) HasCheck() bool {
+	if w != nil && w.Check != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetName allocates a new w.Name and returns the pointer to it.
-func (w *Widget) SetName(v string) {
-	w.Name = &v
+// SetCheck allocates a new w.Check and returns the pointer to it.
+func (w *Widget) SetCheck(v string) {
+	w.Check = &v
 }
 
-// GetNoteWidget returns the NoteWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetNoteWidget() NoteWidget {
-	if w == nil || w.NoteWidget == nil {
-		return NoteWidget{}
-	}
-	return *w.NoteWidget
-}
-
-// GetOkNoteWidget returns a tuple with the NoteWidget field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetNoteWidgetOk() (NoteWidget, bool) {
-	if w == nil || w.NoteWidget == nil {
-		return NoteWidget{}, false
-	}
-	return *w.NoteWidget, true
-}
-
-// HasNoteWidget returns a boolean if a field has been set.
-func (w *Widget) HasNoteWidget() bool {
-	if w != nil && w.NoteWidget != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetNoteWidget allocates a new w.NoteWidget and returns the pointer to it.
-func (w *Widget) SetNoteWidget(v NoteWidget) {
-	w.NoteWidget = &v
-}
-
-// GetPrefix returns the Prefix field if non-nil, zero value otherwise.
-func (w *Widget) GetPrefix() string {
-	if w == nil || w.Prefix == nil {
+// GetColor returns the Color field if non-nil, zero value otherwise.
+func (w *Widget) GetColor() string {
+	if w == nil || w.Color == nil {
 		return ""
 	}
-	return *w.Prefix
+	return *w.Color
 }
 
-// GetOkPrefix returns a tuple with the Prefix field if it's non-nil, zero value otherwise
+// GetOkColor returns a tuple with the Color field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetPrefixOk() (string, bool) {
-	if w == nil || w.Prefix == nil {
+func (w *Widget) GetColorOk() (string, bool) {
+	if w == nil || w.Color == nil {
 		return "", false
 	}
-	return *w.Prefix, true
+	return *w.Color, true
 }
 
-// HasPrefix returns a boolean if a field has been set.
-func (w *Widget) HasPrefix() bool {
-	if w != nil && w.Prefix != nil {
+// HasColor returns a boolean if a field has been set.
+func (w *Widget) HasColor() bool {
+	if w != nil && w.Color != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetPrefix allocates a new w.Prefix and returns the pointer to it.
-func (w *Widget) SetPrefix(v string) {
-	w.Prefix = &v
+// SetColor allocates a new w.Color and returns the pointer to it.
+func (w *Widget) SetColor(v string) {
+	w.Color = &v
 }
 
-// GetQueryValueWidget returns the QueryValueWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetQueryValueWidget() QueryValueWidget {
-	if w == nil || w.QueryValueWidget == nil {
-		return QueryValueWidget{}
+// GetColorPreference returns the ColorPreference field if non-nil, zero value otherwise.
+func (w *Widget) GetColorPreference() string {
+	if w == nil || w.ColorPreference == nil {
+		return ""
 	}
-	return *w.QueryValueWidget
+	return *w.ColorPreference
 }
 
-// GetOkQueryValueWidget returns a tuple with the QueryValueWidget field if it's non-nil, zero value otherwise
+// GetOkColorPreference returns a tuple with the ColorPreference field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetQueryValueWidgetOk() (QueryValueWidget, bool) {
-	if w == nil || w.QueryValueWidget == nil {
-		return QueryValueWidget{}, false
+func (w *Widget) GetColorPreferenceOk() (string, bool) {
+	if w == nil || w.ColorPreference == nil {
+		return "", false
 	}
-	return *w.QueryValueWidget, true
+	return *w.ColorPreference, true
 }
 
-// HasQueryValueWidget returns a boolean if a field has been set.
-func (w *Widget) HasQueryValueWidget() bool {
-	if w != nil && w.QueryValueWidget != nil {
+// HasColorPreference returns a boolean if a field has been set.
+func (w *Widget) HasColorPreference() bool {
+	if w != nil && w.ColorPreference != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetQueryValueWidget allocates a new w.QueryValueWidget and returns the pointer to it.
-func (w *Widget) SetQueryValueWidget(v QueryValueWidget) {
-	w.QueryValueWidget = &v
+// SetColorPreference allocates a new w.ColorPreference and returns the pointer to it.
+func (w *Widget) SetColorPreference(v string) {
+	w.ColorPreference = &v
 }
 
-// GetTimeseriesWidget returns the TimeseriesWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetTimeseriesWidget() TimeseriesWidget {
-	if w == nil || w.TimeseriesWidget == nil {
-		return TimeseriesWidget{}
+// GetColumns returns the Columns field if non-nil, zero value otherwise.
+func (w *Widget) GetColumns() string {
+	if w == nil || w.Columns == nil {
+		return ""
 	}
-	return *w.TimeseriesWidget
+	return *w.Columns
 }
 
-// GetOkTimeseriesWidget returns a tuple with the TimeseriesWidget field if it's non-nil, zero value otherwise
+// GetOkColumns returns a tuple with the Columns field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetTimeseriesWidgetOk() (TimeseriesWidget, bool) {
-	if w == nil || w.TimeseriesWidget == nil {
-		return TimeseriesWidget{}, false
+func (w *Widget) GetColumnsOk() (string, bool) {
+	if w == nil || w.Columns == nil {
+		return "", false
 	}
-	return *w.TimeseriesWidget, true
+	return *w.Columns, true
 }
 
-// HasTimeseriesWidget returns a boolean if a field has been set.
-func (w *Widget) HasTimeseriesWidget() bool {
-	if w != nil && w.TimeseriesWidget != nil {
+// HasColumns returns a boolean if a field has been set.
+func (w *Widget) HasColumns() bool {
+	if w != nil && w.Columns != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetTimeseriesWidget allocates a new w.TimeseriesWidget and returns the pointer to it.
-func (w *Widget) SetTimeseriesWidget(v TimeseriesWidget) {
-	w.TimeseriesWidget = &v
+// SetColumns allocates a new w.Columns and returns the pointer to it.
+func (w *Widget) SetColumns(v string) {
+	w.Columns = &v
 }
 
-// GetToplistWidget returns the ToplistWidget field if non-nil, zero value otherwise.
-func (w *Widget) GetToplistWidget() ToplistWidget {
-	if w == nil || w.ToplistWidget == nil {
-		return ToplistWidget{}
+// GetDisplayFormat returns the DisplayFormat field if non-nil, zero value otherwise.
+func (w *Widget) GetDisplayFormat() string {
+	if w == nil || w.DisplayFormat == nil {
+		return ""
 	}
-	return *w.ToplistWidget
+	return *w.DisplayFormat
 }
 
-// GetOkToplistWidget returns a tuple with the ToplistWidget field if it's non-nil, zero value otherwise
+// GetOkDisplayFormat returns a tuple with the DisplayFormat field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetToplistWidgetOk() (ToplistWidget, bool) {
-	if w == nil || w.ToplistWidget == nil {
-		return ToplistWidget{}, false
+func (w *Widget) GetDisplayFormatOk() (string, bool) {
+	if w == nil || w.DisplayFormat == nil {
+		return "", false
 	}
-	return *w.ToplistWidget, true
+	return *w.DisplayFormat, true
 }
 
-// HasToplistWidget returns a boolean if a field has been set.
-func (w *Widget) HasToplistWidget() bool {
-	if w != nil && w.ToplistWidget != nil {
+// HasDisplayFormat returns a boolean if a field has been set.
+func (w *Widget) HasDisplayFormat() bool {
+	if w != nil && w.DisplayFormat != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetToplistWidget allocates a new w.ToplistWidget and returns the pointer to it.
-func (w *Widget) SetToplistWidget(v ToplistWidget) {
-	w.ToplistWidget = &v
+// SetDisplayFormat allocates a new w.DisplayFormat and returns the pointer to it.
+func (w *Widget) SetDisplayFormat(v string) {
+	w.DisplayFormat = &v
+}
+
+// GetEnv returns the Env field if non-nil, zero value otherwise.
+func (w *Widget) GetEnv() string {
+	if w == nil || w.Env == nil {
+		return ""
+	}
+	return *w.Env
+}
+
+// GetOkEnv returns a tuple with the Env field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetEnvOk() (string, bool) {
+	if w == nil || w.Env == nil {
+		return "", false
+	}
+	return *w.Env, true
+}
+
+// HasEnv returns a boolean if a field has been set.
+func (w *Widget) HasEnv() bool {
+	if w != nil && w.Env != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEnv allocates a new w.Env and returns the pointer to it.
+func (w *Widget) SetEnv(v string) {
+	w.Env = &v
+}
+
+// GetEventSize returns the EventSize field if non-nil, zero value otherwise.
+func (w *Widget) GetEventSize() string {
+	if w == nil || w.EventSize == nil {
+		return ""
+	}
+	return *w.EventSize
+}
+
+// GetOkEventSize returns a tuple with the EventSize field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetEventSizeOk() (string, bool) {
+	if w == nil || w.EventSize == nil {
+		return "", false
+	}
+	return *w.EventSize, true
+}
+
+// HasEventSize returns a boolean if a field has been set.
+func (w *Widget) HasEventSize() bool {
+	if w != nil && w.EventSize != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEventSize allocates a new w.EventSize and returns the pointer to it.
+func (w *Widget) SetEventSize(v string) {
+	w.EventSize = &v
+}
+
+// GetFontSize returns the FontSize field if non-nil, zero value otherwise.
+func (w *Widget) GetFontSize() string {
+	if w == nil || w.FontSize == nil {
+		return ""
+	}
+	return *w.FontSize
+}
+
+// GetOkFontSize returns a tuple with the FontSize field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetFontSizeOk() (string, bool) {
+	if w == nil || w.FontSize == nil {
+		return "", false
+	}
+	return *w.FontSize, true
+}
+
+// HasFontSize returns a boolean if a field has been set.
+func (w *Widget) HasFontSize() bool {
+	if w != nil && w.FontSize != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFontSize allocates a new w.FontSize and returns the pointer to it.
+func (w *Widget) SetFontSize(v string) {
+	w.FontSize = &v
+}
+
+// GetGroup returns the Group field if non-nil, zero value otherwise.
+func (w *Widget) GetGroup() string {
+	if w == nil || w.Group == nil {
+		return ""
+	}
+	return *w.Group
+}
+
+// GetOkGroup returns a tuple with the Group field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetGroupOk() (string, bool) {
+	if w == nil || w.Group == nil {
+		return "", false
+	}
+	return *w.Group, true
+}
+
+// HasGroup returns a boolean if a field has been set.
+func (w *Widget) HasGroup() bool {
+	if w != nil && w.Group != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetGroup allocates a new w.Group and returns the pointer to it.
+func (w *Widget) SetGroup(v string) {
+	w.Group = &v
+}
+
+// GetGrouping returns the Grouping field if non-nil, zero value otherwise.
+func (w *Widget) GetGrouping() string {
+	if w == nil || w.Grouping == nil {
+		return ""
+	}
+	return *w.Grouping
+}
+
+// GetOkGrouping returns a tuple with the Grouping field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetGroupingOk() (string, bool) {
+	if w == nil || w.Grouping == nil {
+		return "", false
+	}
+	return *w.Grouping, true
+}
+
+// HasGrouping returns a boolean if a field has been set.
+func (w *Widget) HasGrouping() bool {
+	if w != nil && w.Grouping != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetGrouping allocates a new w.Grouping and returns the pointer to it.
+func (w *Widget) SetGrouping(v string) {
+	w.Grouping = &v
+}
+
+// GetHeight returns the Height field if non-nil, zero value otherwise.
+func (w *Widget) GetHeight() int {
+	if w == nil || w.Height == nil {
+		return 0
+	}
+	return *w.Height
+}
+
+// GetOkHeight returns a tuple with the Height field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetHeightOk() (int, bool) {
+	if w == nil || w.Height == nil {
+		return 0, false
+	}
+	return *w.Height, true
+}
+
+// HasHeight returns a boolean if a field has been set.
+func (w *Widget) HasHeight() bool {
+	if w != nil && w.Height != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHeight allocates a new w.Height and returns the pointer to it.
+func (w *Widget) SetHeight(v int) {
+	w.Height = &v
+}
+
+// GetHideZeroCounts returns the HideZeroCounts field if non-nil, zero value otherwise.
+func (w *Widget) GetHideZeroCounts() bool {
+	if w == nil || w.HideZeroCounts == nil {
+		return false
+	}
+	return *w.HideZeroCounts
+}
+
+// GetOkHideZeroCounts returns a tuple with the HideZeroCounts field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetHideZeroCountsOk() (bool, bool) {
+	if w == nil || w.HideZeroCounts == nil {
+		return false, false
+	}
+	return *w.HideZeroCounts, true
+}
+
+// HasHideZeroCounts returns a boolean if a field has been set.
+func (w *Widget) HasHideZeroCounts() bool {
+	if w != nil && w.HideZeroCounts != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHideZeroCounts allocates a new w.HideZeroCounts and returns the pointer to it.
+func (w *Widget) SetHideZeroCounts(v bool) {
+	w.HideZeroCounts = &v
+}
+
+// GetHTML returns the HTML field if non-nil, zero value otherwise.
+func (w *Widget) GetHTML() string {
+	if w == nil || w.HTML == nil {
+		return ""
+	}
+	return *w.HTML
+}
+
+// GetOkHTML returns a tuple with the HTML field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetHTMLOk() (string, bool) {
+	if w == nil || w.HTML == nil {
+		return "", false
+	}
+	return *w.HTML, true
+}
+
+// HasHTML returns a boolean if a field has been set.
+func (w *Widget) HasHTML() bool {
+	if w != nil && w.HTML != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHTML allocates a new w.HTML and returns the pointer to it.
+func (w *Widget) SetHTML(v string) {
+	w.HTML = &v
+}
+
+// GetLayoutVersion returns the LayoutVersion field if non-nil, zero value otherwise.
+func (w *Widget) GetLayoutVersion() string {
+	if w == nil || w.LayoutVersion == nil {
+		return ""
+	}
+	return *w.LayoutVersion
+}
+
+// GetOkLayoutVersion returns a tuple with the LayoutVersion field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetLayoutVersionOk() (string, bool) {
+	if w == nil || w.LayoutVersion == nil {
+		return "", false
+	}
+	return *w.LayoutVersion, true
+}
+
+// HasLayoutVersion returns a boolean if a field has been set.
+func (w *Widget) HasLayoutVersion() bool {
+	if w != nil && w.LayoutVersion != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLayoutVersion allocates a new w.LayoutVersion and returns the pointer to it.
+func (w *Widget) SetLayoutVersion(v string) {
+	w.LayoutVersion = &v
+}
+
+// GetLegend returns the Legend field if non-nil, zero value otherwise.
+func (w *Widget) GetLegend() bool {
+	if w == nil || w.Legend == nil {
+		return false
+	}
+	return *w.Legend
+}
+
+// GetOkLegend returns a tuple with the Legend field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetLegendOk() (bool, bool) {
+	if w == nil || w.Legend == nil {
+		return false, false
+	}
+	return *w.Legend, true
+}
+
+// HasLegend returns a boolean if a field has been set.
+func (w *Widget) HasLegend() bool {
+	if w != nil && w.Legend != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLegend allocates a new w.Legend and returns the pointer to it.
+func (w *Widget) SetLegend(v bool) {
+	w.Legend = &v
+}
+
+// GetLegendSize returns the LegendSize field if non-nil, zero value otherwise.
+func (w *Widget) GetLegendSize() string {
+	if w == nil || w.LegendSize == nil {
+		return ""
+	}
+	return *w.LegendSize
+}
+
+// GetOkLegendSize returns a tuple with the LegendSize field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetLegendSizeOk() (string, bool) {
+	if w == nil || w.LegendSize == nil {
+		return "", false
+	}
+	return *w.LegendSize, true
+}
+
+// HasLegendSize returns a boolean if a field has been set.
+func (w *Widget) HasLegendSize() bool {
+	if w != nil && w.LegendSize != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLegendSize allocates a new w.LegendSize and returns the pointer to it.
+func (w *Widget) SetLegendSize(v string) {
+	w.LegendSize = &v
+}
+
+// GetLogset returns the Logset field if non-nil, zero value otherwise.
+func (w *Widget) GetLogset() string {
+	if w == nil || w.Logset == nil {
+		return ""
+	}
+	return *w.Logset
+}
+
+// GetOkLogset returns a tuple with the Logset field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetLogsetOk() (string, bool) {
+	if w == nil || w.Logset == nil {
+		return "", false
+	}
+	return *w.Logset, true
+}
+
+// HasLogset returns a boolean if a field has been set.
+func (w *Widget) HasLogset() bool {
+	if w != nil && w.Logset != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLogset allocates a new w.Logset and returns the pointer to it.
+func (w *Widget) SetLogset(v string) {
+	w.Logset = &v
+}
+
+// GetManageStatusShowTitle returns the ManageStatusShowTitle field if non-nil, zero value otherwise.
+func (w *Widget) GetManageStatusShowTitle() bool {
+	if w == nil || w.ManageStatusShowTitle == nil {
+		return false
+	}
+	return *w.ManageStatusShowTitle
+}
+
+// GetOkManageStatusShowTitle returns a tuple with the ManageStatusShowTitle field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetManageStatusShowTitleOk() (bool, bool) {
+	if w == nil || w.ManageStatusShowTitle == nil {
+		return false, false
+	}
+	return *w.ManageStatusShowTitle, true
+}
+
+// HasManageStatusShowTitle returns a boolean if a field has been set.
+func (w *Widget) HasManageStatusShowTitle() bool {
+	if w != nil && w.ManageStatusShowTitle != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetManageStatusShowTitle allocates a new w.ManageStatusShowTitle and returns the pointer to it.
+func (w *Widget) SetManageStatusShowTitle(v bool) {
+	w.ManageStatusShowTitle = &v
+}
+
+// GetManageStatusTitleAlign returns the ManageStatusTitleAlign field if non-nil, zero value otherwise.
+func (w *Widget) GetManageStatusTitleAlign() string {
+	if w == nil || w.ManageStatusTitleAlign == nil {
+		return ""
+	}
+	return *w.ManageStatusTitleAlign
+}
+
+// GetOkManageStatusTitleAlign returns a tuple with the ManageStatusTitleAlign field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetManageStatusTitleAlignOk() (string, bool) {
+	if w == nil || w.ManageStatusTitleAlign == nil {
+		return "", false
+	}
+	return *w.ManageStatusTitleAlign, true
+}
+
+// HasManageStatusTitleAlign returns a boolean if a field has been set.
+func (w *Widget) HasManageStatusTitleAlign() bool {
+	if w != nil && w.ManageStatusTitleAlign != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetManageStatusTitleAlign allocates a new w.ManageStatusTitleAlign and returns the pointer to it.
+func (w *Widget) SetManageStatusTitleAlign(v string) {
+	w.ManageStatusTitleAlign = &v
+}
+
+// GetManageStatusTitleSize returns the ManageStatusTitleSize field if non-nil, zero value otherwise.
+func (w *Widget) GetManageStatusTitleSize() string {
+	if w == nil || w.ManageStatusTitleSize == nil {
+		return ""
+	}
+	return *w.ManageStatusTitleSize
+}
+
+// GetOkManageStatusTitleSize returns a tuple with the ManageStatusTitleSize field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetManageStatusTitleSizeOk() (string, bool) {
+	if w == nil || w.ManageStatusTitleSize == nil {
+		return "", false
+	}
+	return *w.ManageStatusTitleSize, true
+}
+
+// HasManageStatusTitleSize returns a boolean if a field has been set.
+func (w *Widget) HasManageStatusTitleSize() bool {
+	if w != nil && w.ManageStatusTitleSize != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetManageStatusTitleSize allocates a new w.ManageStatusTitleSize and returns the pointer to it.
+func (w *Widget) SetManageStatusTitleSize(v string) {
+	w.ManageStatusTitleSize = &v
+}
+
+// GetManageStatusTitleText returns the ManageStatusTitleText field if non-nil, zero value otherwise.
+func (w *Widget) GetManageStatusTitleText() string {
+	if w == nil || w.ManageStatusTitleText == nil {
+		return ""
+	}
+	return *w.ManageStatusTitleText
+}
+
+// GetOkManageStatusTitleText returns a tuple with the ManageStatusTitleText field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetManageStatusTitleTextOk() (string, bool) {
+	if w == nil || w.ManageStatusTitleText == nil {
+		return "", false
+	}
+	return *w.ManageStatusTitleText, true
+}
+
+// HasManageStatusTitleText returns a boolean if a field has been set.
+func (w *Widget) HasManageStatusTitleText() bool {
+	if w != nil && w.ManageStatusTitleText != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetManageStatusTitleText allocates a new w.ManageStatusTitleText and returns the pointer to it.
+func (w *Widget) SetManageStatusTitleText(v string) {
+	w.ManageStatusTitleText = &v
+}
+
+// GetMargin returns the Margin field if non-nil, zero value otherwise.
+func (w *Widget) GetMargin() string {
+	if w == nil || w.Margin == nil {
+		return ""
+	}
+	return *w.Margin
+}
+
+// GetOkMargin returns a tuple with the Margin field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMarginOk() (string, bool) {
+	if w == nil || w.Margin == nil {
+		return "", false
+	}
+	return *w.Margin, true
+}
+
+// HasMargin returns a boolean if a field has been set.
+func (w *Widget) HasMargin() bool {
+	if w != nil && w.Margin != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMargin allocates a new w.Margin and returns the pointer to it.
+func (w *Widget) SetMargin(v string) {
+	w.Margin = &v
+}
+
+// GetMonitor returns the Monitor field if non-nil, zero value otherwise.
+func (w *Widget) GetMonitor() ScreenboardMonitor {
+	if w == nil || w.Monitor == nil {
+		return ScreenboardMonitor{}
+	}
+	return *w.Monitor
+}
+
+// GetOkMonitor returns a tuple with the Monitor field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMonitorOk() (ScreenboardMonitor, bool) {
+	if w == nil || w.Monitor == nil {
+		return ScreenboardMonitor{}, false
+	}
+	return *w.Monitor, true
+}
+
+// HasMonitor returns a boolean if a field has been set.
+func (w *Widget) HasMonitor() bool {
+	if w != nil && w.Monitor != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMonitor allocates a new w.Monitor and returns the pointer to it.
+func (w *Widget) SetMonitor(v ScreenboardMonitor) {
+	w.Monitor = &v
+}
+
+// GetMustShowBreakdown returns the MustShowBreakdown field if non-nil, zero value otherwise.
+func (w *Widget) GetMustShowBreakdown() bool {
+	if w == nil || w.MustShowBreakdown == nil {
+		return false
+	}
+	return *w.MustShowBreakdown
+}
+
+// GetOkMustShowBreakdown returns a tuple with the MustShowBreakdown field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMustShowBreakdownOk() (bool, bool) {
+	if w == nil || w.MustShowBreakdown == nil {
+		return false, false
+	}
+	return *w.MustShowBreakdown, true
+}
+
+// HasMustShowBreakdown returns a boolean if a field has been set.
+func (w *Widget) HasMustShowBreakdown() bool {
+	if w != nil && w.MustShowBreakdown != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMustShowBreakdown allocates a new w.MustShowBreakdown and returns the pointer to it.
+func (w *Widget) SetMustShowBreakdown(v bool) {
+	w.MustShowBreakdown = &v
+}
+
+// GetMustShowDistribution returns the MustShowDistribution field if non-nil, zero value otherwise.
+func (w *Widget) GetMustShowDistribution() bool {
+	if w == nil || w.MustShowDistribution == nil {
+		return false
+	}
+	return *w.MustShowDistribution
+}
+
+// GetOkMustShowDistribution returns a tuple with the MustShowDistribution field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMustShowDistributionOk() (bool, bool) {
+	if w == nil || w.MustShowDistribution == nil {
+		return false, false
+	}
+	return *w.MustShowDistribution, true
+}
+
+// HasMustShowDistribution returns a boolean if a field has been set.
+func (w *Widget) HasMustShowDistribution() bool {
+	if w != nil && w.MustShowDistribution != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMustShowDistribution allocates a new w.MustShowDistribution and returns the pointer to it.
+func (w *Widget) SetMustShowDistribution(v bool) {
+	w.MustShowDistribution = &v
+}
+
+// GetMustShowErrors returns the MustShowErrors field if non-nil, zero value otherwise.
+func (w *Widget) GetMustShowErrors() bool {
+	if w == nil || w.MustShowErrors == nil {
+		return false
+	}
+	return *w.MustShowErrors
+}
+
+// GetOkMustShowErrors returns a tuple with the MustShowErrors field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMustShowErrorsOk() (bool, bool) {
+	if w == nil || w.MustShowErrors == nil {
+		return false, false
+	}
+	return *w.MustShowErrors, true
+}
+
+// HasMustShowErrors returns a boolean if a field has been set.
+func (w *Widget) HasMustShowErrors() bool {
+	if w != nil && w.MustShowErrors != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMustShowErrors allocates a new w.MustShowErrors and returns the pointer to it.
+func (w *Widget) SetMustShowErrors(v bool) {
+	w.MustShowErrors = &v
+}
+
+// GetMustShowHits returns the MustShowHits field if non-nil, zero value otherwise.
+func (w *Widget) GetMustShowHits() bool {
+	if w == nil || w.MustShowHits == nil {
+		return false
+	}
+	return *w.MustShowHits
+}
+
+// GetOkMustShowHits returns a tuple with the MustShowHits field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMustShowHitsOk() (bool, bool) {
+	if w == nil || w.MustShowHits == nil {
+		return false, false
+	}
+	return *w.MustShowHits, true
+}
+
+// HasMustShowHits returns a boolean if a field has been set.
+func (w *Widget) HasMustShowHits() bool {
+	if w != nil && w.MustShowHits != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMustShowHits allocates a new w.MustShowHits and returns the pointer to it.
+func (w *Widget) SetMustShowHits(v bool) {
+	w.MustShowHits = &v
+}
+
+// GetMustShowLatency returns the MustShowLatency field if non-nil, zero value otherwise.
+func (w *Widget) GetMustShowLatency() bool {
+	if w == nil || w.MustShowLatency == nil {
+		return false
+	}
+	return *w.MustShowLatency
+}
+
+// GetOkMustShowLatency returns a tuple with the MustShowLatency field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMustShowLatencyOk() (bool, bool) {
+	if w == nil || w.MustShowLatency == nil {
+		return false, false
+	}
+	return *w.MustShowLatency, true
+}
+
+// HasMustShowLatency returns a boolean if a field has been set.
+func (w *Widget) HasMustShowLatency() bool {
+	if w != nil && w.MustShowLatency != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMustShowLatency allocates a new w.MustShowLatency and returns the pointer to it.
+func (w *Widget) SetMustShowLatency(v bool) {
+	w.MustShowLatency = &v
+}
+
+// GetMustShowResourceList returns the MustShowResourceList field if non-nil, zero value otherwise.
+func (w *Widget) GetMustShowResourceList() bool {
+	if w == nil || w.MustShowResourceList == nil {
+		return false
+	}
+	return *w.MustShowResourceList
+}
+
+// GetOkMustShowResourceList returns a tuple with the MustShowResourceList field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetMustShowResourceListOk() (bool, bool) {
+	if w == nil || w.MustShowResourceList == nil {
+		return false, false
+	}
+	return *w.MustShowResourceList, true
+}
+
+// HasMustShowResourceList returns a boolean if a field has been set.
+func (w *Widget) HasMustShowResourceList() bool {
+	if w != nil && w.MustShowResourceList != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMustShowResourceList allocates a new w.MustShowResourceList and returns the pointer to it.
+func (w *Widget) SetMustShowResourceList(v bool) {
+	w.MustShowResourceList = &v
+}
+
+// GetParams returns the Params field if non-nil, zero value otherwise.
+func (w *Widget) GetParams() Params {
+	if w == nil || w.Params == nil {
+		return Params{}
+	}
+	return *w.Params
+}
+
+// GetOkParams returns a tuple with the Params field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetParamsOk() (Params, bool) {
+	if w == nil || w.Params == nil {
+		return Params{}, false
+	}
+	return *w.Params, true
+}
+
+// HasParams returns a boolean if a field has been set.
+func (w *Widget) HasParams() bool {
+	if w != nil && w.Params != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetParams allocates a new w.Params and returns the pointer to it.
+func (w *Widget) SetParams(v Params) {
+	w.Params = &v
+}
+
+// GetPrecision returns the Precision field if non-nil, zero value otherwise.
+func (w *Widget) GetPrecision() string {
+	if w == nil || w.Precision == nil {
+		return ""
+	}
+	return *w.Precision
+}
+
+// GetOkPrecision returns a tuple with the Precision field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetPrecisionOk() (string, bool) {
+	if w == nil || w.Precision == nil {
+		return "", false
+	}
+	return *w.Precision, true
+}
+
+// HasPrecision returns a boolean if a field has been set.
+func (w *Widget) HasPrecision() bool {
+	if w != nil && w.Precision != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPrecision allocates a new w.Precision and returns the pointer to it.
+func (w *Widget) SetPrecision(v string) {
+	w.Precision = &v
+}
+
+// GetQuery returns the Query field if non-nil, zero value otherwise.
+func (w *Widget) GetQuery() string {
+	if w == nil || w.Query == nil {
+		return ""
+	}
+	return *w.Query
+}
+
+// GetOkQuery returns a tuple with the Query field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetQueryOk() (string, bool) {
+	if w == nil || w.Query == nil {
+		return "", false
+	}
+	return *w.Query, true
+}
+
+// HasQuery returns a boolean if a field has been set.
+func (w *Widget) HasQuery() bool {
+	if w != nil && w.Query != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetQuery allocates a new w.Query and returns the pointer to it.
+func (w *Widget) SetQuery(v string) {
+	w.Query = &v
+}
+
+// GetServiceName returns the ServiceName field if non-nil, zero value otherwise.
+func (w *Widget) GetServiceName() string {
+	if w == nil || w.ServiceName == nil {
+		return ""
+	}
+	return *w.ServiceName
+}
+
+// GetOkServiceName returns a tuple with the ServiceName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetServiceNameOk() (string, bool) {
+	if w == nil || w.ServiceName == nil {
+		return "", false
+	}
+	return *w.ServiceName, true
+}
+
+// HasServiceName returns a boolean if a field has been set.
+func (w *Widget) HasServiceName() bool {
+	if w != nil && w.ServiceName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceName allocates a new w.ServiceName and returns the pointer to it.
+func (w *Widget) SetServiceName(v string) {
+	w.ServiceName = &v
+}
+
+// GetServiceService returns the ServiceService field if non-nil, zero value otherwise.
+func (w *Widget) GetServiceService() string {
+	if w == nil || w.ServiceService == nil {
+		return ""
+	}
+	return *w.ServiceService
+}
+
+// GetOkServiceService returns a tuple with the ServiceService field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetServiceServiceOk() (string, bool) {
+	if w == nil || w.ServiceService == nil {
+		return "", false
+	}
+	return *w.ServiceService, true
+}
+
+// HasServiceService returns a boolean if a field has been set.
+func (w *Widget) HasServiceService() bool {
+	if w != nil && w.ServiceService != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceService allocates a new w.ServiceService and returns the pointer to it.
+func (w *Widget) SetServiceService(v string) {
+	w.ServiceService = &v
+}
+
+// GetSizeVersion returns the SizeVersion field if non-nil, zero value otherwise.
+func (w *Widget) GetSizeVersion() string {
+	if w == nil || w.SizeVersion == nil {
+		return ""
+	}
+	return *w.SizeVersion
+}
+
+// GetOkSizeVersion returns a tuple with the SizeVersion field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetSizeVersionOk() (string, bool) {
+	if w == nil || w.SizeVersion == nil {
+		return "", false
+	}
+	return *w.SizeVersion, true
+}
+
+// HasSizeVersion returns a boolean if a field has been set.
+func (w *Widget) HasSizeVersion() bool {
+	if w != nil && w.SizeVersion != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSizeVersion allocates a new w.SizeVersion and returns the pointer to it.
+func (w *Widget) SetSizeVersion(v string) {
+	w.SizeVersion = &v
+}
+
+// GetSizing returns the Sizing field if non-nil, zero value otherwise.
+func (w *Widget) GetSizing() string {
+	if w == nil || w.Sizing == nil {
+		return ""
+	}
+	return *w.Sizing
+}
+
+// GetOkSizing returns a tuple with the Sizing field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetSizingOk() (string, bool) {
+	if w == nil || w.Sizing == nil {
+		return "", false
+	}
+	return *w.Sizing, true
+}
+
+// HasSizing returns a boolean if a field has been set.
+func (w *Widget) HasSizing() bool {
+	if w != nil && w.Sizing != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSizing allocates a new w.Sizing and returns the pointer to it.
+func (w *Widget) SetSizing(v string) {
+	w.Sizing = &v
+}
+
+// GetText returns the Text field if non-nil, zero value otherwise.
+func (w *Widget) GetText() string {
+	if w == nil || w.Text == nil {
+		return ""
+	}
+	return *w.Text
+}
+
+// GetOkText returns a tuple with the Text field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTextOk() (string, bool) {
+	if w == nil || w.Text == nil {
+		return "", false
+	}
+	return *w.Text, true
+}
+
+// HasText returns a boolean if a field has been set.
+func (w *Widget) HasText() bool {
+	if w != nil && w.Text != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetText allocates a new w.Text and returns the pointer to it.
+func (w *Widget) SetText(v string) {
+	w.Text = &v
+}
+
+// GetTextAlign returns the TextAlign field if non-nil, zero value otherwise.
+func (w *Widget) GetTextAlign() string {
+	if w == nil || w.TextAlign == nil {
+		return ""
+	}
+	return *w.TextAlign
+}
+
+// GetOkTextAlign returns a tuple with the TextAlign field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTextAlignOk() (string, bool) {
+	if w == nil || w.TextAlign == nil {
+		return "", false
+	}
+	return *w.TextAlign, true
+}
+
+// HasTextAlign returns a boolean if a field has been set.
+func (w *Widget) HasTextAlign() bool {
+	if w != nil && w.TextAlign != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTextAlign allocates a new w.TextAlign and returns the pointer to it.
+func (w *Widget) SetTextAlign(v string) {
+	w.TextAlign = &v
+}
+
+// GetTextSize returns the TextSize field if non-nil, zero value otherwise.
+func (w *Widget) GetTextSize() string {
+	if w == nil || w.TextSize == nil {
+		return ""
+	}
+	return *w.TextSize
+}
+
+// GetOkTextSize returns a tuple with the TextSize field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTextSizeOk() (string, bool) {
+	if w == nil || w.TextSize == nil {
+		return "", false
+	}
+	return *w.TextSize, true
+}
+
+// HasTextSize returns a boolean if a field has been set.
+func (w *Widget) HasTextSize() bool {
+	if w != nil && w.TextSize != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTextSize allocates a new w.TextSize and returns the pointer to it.
+func (w *Widget) SetTextSize(v string) {
+	w.TextSize = &v
+}
+
+// GetTick returns the Tick field if non-nil, zero value otherwise.
+func (w *Widget) GetTick() bool {
+	if w == nil || w.Tick == nil {
+		return false
+	}
+	return *w.Tick
+}
+
+// GetOkTick returns a tuple with the Tick field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTickOk() (bool, bool) {
+	if w == nil || w.Tick == nil {
+		return false, false
+	}
+	return *w.Tick, true
+}
+
+// HasTick returns a boolean if a field has been set.
+func (w *Widget) HasTick() bool {
+	if w != nil && w.Tick != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTick allocates a new w.Tick and returns the pointer to it.
+func (w *Widget) SetTick(v bool) {
+	w.Tick = &v
+}
+
+// GetTickEdge returns the TickEdge field if non-nil, zero value otherwise.
+func (w *Widget) GetTickEdge() string {
+	if w == nil || w.TickEdge == nil {
+		return ""
+	}
+	return *w.TickEdge
+}
+
+// GetOkTickEdge returns a tuple with the TickEdge field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTickEdgeOk() (string, bool) {
+	if w == nil || w.TickEdge == nil {
+		return "", false
+	}
+	return *w.TickEdge, true
+}
+
+// HasTickEdge returns a boolean if a field has been set.
+func (w *Widget) HasTickEdge() bool {
+	if w != nil && w.TickEdge != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTickEdge allocates a new w.TickEdge and returns the pointer to it.
+func (w *Widget) SetTickEdge(v string) {
+	w.TickEdge = &v
+}
+
+// GetTickPos returns the TickPos field if non-nil, zero value otherwise.
+func (w *Widget) GetTickPos() string {
+	if w == nil || w.TickPos == nil {
+		return ""
+	}
+	return *w.TickPos
+}
+
+// GetOkTickPos returns a tuple with the TickPos field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTickPosOk() (string, bool) {
+	if w == nil || w.TickPos == nil {
+		return "", false
+	}
+	return *w.TickPos, true
+}
+
+// HasTickPos returns a boolean if a field has been set.
+func (w *Widget) HasTickPos() bool {
+	if w != nil && w.TickPos != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTickPos allocates a new w.TickPos and returns the pointer to it.
+func (w *Widget) SetTickPos(v string) {
+	w.TickPos = &v
+}
+
+// GetTileDef returns the TileDef field if non-nil, zero value otherwise.
+func (w *Widget) GetTileDef() TileDef {
+	if w == nil || w.TileDef == nil {
+		return TileDef{}
+	}
+	return *w.TileDef
+}
+
+// GetOkTileDef returns a tuple with the TileDef field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTileDefOk() (TileDef, bool) {
+	if w == nil || w.TileDef == nil {
+		return TileDef{}, false
+	}
+	return *w.TileDef, true
+}
+
+// HasTileDef returns a boolean if a field has been set.
+func (w *Widget) HasTileDef() bool {
+	if w != nil && w.TileDef != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTileDef allocates a new w.TileDef and returns the pointer to it.
+func (w *Widget) SetTileDef(v TileDef) {
+	w.TileDef = &v
+}
+
+// GetTime returns the Time field if non-nil, zero value otherwise.
+func (w *Widget) GetTime() Time {
+	if w == nil || w.Time == nil {
+		return Time{}
+	}
+	return *w.Time
+}
+
+// GetOkTime returns a tuple with the Time field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTimeOk() (Time, bool) {
+	if w == nil || w.Time == nil {
+		return Time{}, false
+	}
+	return *w.Time, true
+}
+
+// HasTime returns a boolean if a field has been set.
+func (w *Widget) HasTime() bool {
+	if w != nil && w.Time != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTime allocates a new w.Time and returns the pointer to it.
+func (w *Widget) SetTime(v Time) {
+	w.Time = &v
+}
+
+// GetTitle returns the Title field if non-nil, zero value otherwise.
+func (w *Widget) GetTitle() bool {
+	if w == nil || w.Title == nil {
+		return false
+	}
+	return *w.Title
+}
+
+// GetOkTitle returns a tuple with the Title field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTitleOk() (bool, bool) {
+	if w == nil || w.Title == nil {
+		return false, false
+	}
+	return *w.Title, true
+}
+
+// HasTitle returns a boolean if a field has been set.
+func (w *Widget) HasTitle() bool {
+	if w != nil && w.Title != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTitle allocates a new w.Title and returns the pointer to it.
+func (w *Widget) SetTitle(v bool) {
+	w.Title = &v
+}
+
+// GetTitleAlign returns the TitleAlign field if non-nil, zero value otherwise.
+func (w *Widget) GetTitleAlign() string {
+	if w == nil || w.TitleAlign == nil {
+		return ""
+	}
+	return *w.TitleAlign
+}
+
+// GetOkTitleAlign returns a tuple with the TitleAlign field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTitleAlignOk() (string, bool) {
+	if w == nil || w.TitleAlign == nil {
+		return "", false
+	}
+	return *w.TitleAlign, true
+}
+
+// HasTitleAlign returns a boolean if a field has been set.
+func (w *Widget) HasTitleAlign() bool {
+	if w != nil && w.TitleAlign != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTitleAlign allocates a new w.TitleAlign and returns the pointer to it.
+func (w *Widget) SetTitleAlign(v string) {
+	w.TitleAlign = &v
+}
+
+// GetTitleSize returns the TitleSize field if non-nil, zero value otherwise.
+func (w *Widget) GetTitleSize() int {
+	if w == nil || w.TitleSize == nil {
+		return 0
+	}
+	return *w.TitleSize
+}
+
+// GetOkTitleSize returns a tuple with the TitleSize field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTitleSizeOk() (int, bool) {
+	if w == nil || w.TitleSize == nil {
+		return 0, false
+	}
+	return *w.TitleSize, true
+}
+
+// HasTitleSize returns a boolean if a field has been set.
+func (w *Widget) HasTitleSize() bool {
+	if w != nil && w.TitleSize != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTitleSize allocates a new w.TitleSize and returns the pointer to it.
+func (w *Widget) SetTitleSize(v int) {
+	w.TitleSize = &v
+}
+
+// GetTitleText returns the TitleText field if non-nil, zero value otherwise.
+func (w *Widget) GetTitleText() string {
+	if w == nil || w.TitleText == nil {
+		return ""
+	}
+	return *w.TitleText
+}
+
+// GetOkTitleText returns a tuple with the TitleText field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTitleTextOk() (string, bool) {
+	if w == nil || w.TitleText == nil {
+		return "", false
+	}
+	return *w.TitleText, true
+}
+
+// HasTitleText returns a boolean if a field has been set.
+func (w *Widget) HasTitleText() bool {
+	if w != nil && w.TitleText != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTitleText allocates a new w.TitleText and returns the pointer to it.
+func (w *Widget) SetTitleText(v string) {
+	w.TitleText = &v
+}
+
+// GetType returns the Type field if non-nil, zero value otherwise.
+func (w *Widget) GetType() string {
+	if w == nil || w.Type == nil {
+		return ""
+	}
+	return *w.Type
+}
+
+// GetOkType returns a tuple with the Type field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetTypeOk() (string, bool) {
+	if w == nil || w.Type == nil {
+		return "", false
+	}
+	return *w.Type, true
+}
+
+// HasType returns a boolean if a field has been set.
+func (w *Widget) HasType() bool {
+	if w != nil && w.Type != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetType allocates a new w.Type and returns the pointer to it.
+func (w *Widget) SetType(v string) {
+	w.Type = &v
+}
+
+// GetUnit returns the Unit field if non-nil, zero value otherwise.
+func (w *Widget) GetUnit() string {
+	if w == nil || w.Unit == nil {
+		return ""
+	}
+	return *w.Unit
+}
+
+// GetOkUnit returns a tuple with the Unit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetUnitOk() (string, bool) {
+	if w == nil || w.Unit == nil {
+		return "", false
+	}
+	return *w.Unit, true
+}
+
+// HasUnit returns a boolean if a field has been set.
+func (w *Widget) HasUnit() bool {
+	if w != nil && w.Unit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUnit allocates a new w.Unit and returns the pointer to it.
+func (w *Widget) SetUnit(v string) {
+	w.Unit = &v
+}
+
+// GetURL returns the URL field if non-nil, zero value otherwise.
+func (w *Widget) GetURL() string {
+	if w == nil || w.URL == nil {
+		return ""
+	}
+	return *w.URL
+}
+
+// GetOkURL returns a tuple with the URL field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetURLOk() (string, bool) {
+	if w == nil || w.URL == nil {
+		return "", false
+	}
+	return *w.URL, true
+}
+
+// HasURL returns a boolean if a field has been set.
+func (w *Widget) HasURL() bool {
+	if w != nil && w.URL != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetURL allocates a new w.URL and returns the pointer to it.
+func (w *Widget) SetURL(v string) {
+	w.URL = &v
+}
+
+// GetVizType returns the VizType field if non-nil, zero value otherwise.
+func (w *Widget) GetVizType() string {
+	if w == nil || w.VizType == nil {
+		return ""
+	}
+	return *w.VizType
+}
+
+// GetOkVizType returns a tuple with the VizType field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetVizTypeOk() (string, bool) {
+	if w == nil || w.VizType == nil {
+		return "", false
+	}
+	return *w.VizType, true
+}
+
+// HasVizType returns a boolean if a field has been set.
+func (w *Widget) HasVizType() bool {
+	if w != nil && w.VizType != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetVizType allocates a new w.VizType and returns the pointer to it.
+func (w *Widget) SetVizType(v string) {
+	w.VizType = &v
+}
+
+// GetWidth returns the Width field if non-nil, zero value otherwise.
+func (w *Widget) GetWidth() int {
+	if w == nil || w.Width == nil {
+		return 0
+	}
+	return *w.Width
+}
+
+// GetOkWidth returns a tuple with the Width field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetWidthOk() (int, bool) {
+	if w == nil || w.Width == nil {
+		return 0, false
+	}
+	return *w.Width, true
+}
+
+// HasWidth returns a boolean if a field has been set.
+func (w *Widget) HasWidth() bool {
+	if w != nil && w.Width != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetWidth allocates a new w.Width and returns the pointer to it.
+func (w *Widget) SetWidth(v int) {
+	w.Width = &v
+}
+
+// GetX returns the X field if non-nil, zero value otherwise.
+func (w *Widget) GetX() int {
+	if w == nil || w.X == nil {
+		return 0
+	}
+	return *w.X
+}
+
+// GetOkX returns a tuple with the X field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetXOk() (int, bool) {
+	if w == nil || w.X == nil {
+		return 0, false
+	}
+	return *w.X, true
+}
+
+// HasX returns a boolean if a field has been set.
+func (w *Widget) HasX() bool {
+	if w != nil && w.X != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetX allocates a new w.X and returns the pointer to it.
+func (w *Widget) SetX(v int) {
+	w.X = &v
+}
+
+// GetY returns the Y field if non-nil, zero value otherwise.
+func (w *Widget) GetY() int {
+	if w == nil || w.Y == nil {
+		return 0
+	}
+	return *w.Y
+}
+
+// GetOkY returns a tuple with the Y field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetYOk() (int, bool) {
+	if w == nil || w.Y == nil {
+		return 0, false
+	}
+	return *w.Y, true
+}
+
+// HasY returns a boolean if a field has been set.
+func (w *Widget) HasY() bool {
+	if w != nil && w.Y != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetY allocates a new w.Y and returns the pointer to it.
+func (w *Widget) SetY(v int) {
+	w.Y = &v
 }
 
 // GetMax returns the Max field if non-nil, zero value otherwise.

--- a/vendor/github.com/zorkian/go-datadog-api/monitors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/monitors.go
@@ -60,14 +60,15 @@ type Options struct {
 // Monitor allows watching a metric or check that you care about,
 // notifying your team when some defined threshold is exceeded
 type Monitor struct {
-	Creator *Creator `json:"creator,omitempty"`
-	Id      *int     `json:"id,omitempty"`
-	Type    *string  `json:"type,omitempty"`
-	Query   *string  `json:"query,omitempty"`
-	Name    *string  `json:"name,omitempty"`
-	Message *string  `json:"message,omitempty"`
-	Tags    []string `json:"tags"`
-	Options *Options `json:"options,omitempty"`
+	Creator      *Creator `json:"creator,omitempty"`
+	Id           *int     `json:"id,omitempty"`
+	Type         *string  `json:"type,omitempty"`
+	Query        *string  `json:"query,omitempty"`
+	Name         *string  `json:"name,omitempty"`
+	Message      *string  `json:"message,omitempty"`
+	OverallState *string  `json:"overall_state,omitempty"`
+	Tags         []string `json:"tags"`
+	Options      *Options `json:"options,omitempty"`
 }
 
 // Creator contains the creator of the monitor

--- a/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
@@ -1,287 +1,201 @@
 package datadog
 
-type TextSize struct {
-	Size *int
-	Auto *bool
-}
-
 type TileDef struct {
-	Events   []TileDefEvent      `json:"events,omitempty"`
-	Markers  []TimeseriesMarker  `json:"markers,omitempty"`
-	Requests []TimeseriesRequest `json:"requests,omitempty"`
-	Viz      *string             `json:"viz,omitempty"`
-}
+	Events     []TileDefEvent   `json:"events,omitempty"`
+	Markers    []TileDefMarker  `json:"markers,omitempty"`
+	Requests   []TileDefRequest `json:"requests,omitempty"`
+	Viz        *string          `json:"viz,omitempty"`
+	CustomUnit *string          `json:"custom_unit,omitempty"`
+	Autoscale  *bool            `json:"autoscale,omitempty"`
+	Precision  *string          `json:"precision,omitempty"`
+	TextAlign  *string          `json:"text_align,omitempty"`
 
-type TimeseriesRequest struct {
-	Query              *string                 `json:"q,omitempty"`
-	Type               *string                 `json:"type,omitempty"`
-	ConditionalFormats []ConditionalFormat     `json:"conditional_formats,omitempty"`
-	Style              *TimeseriesRequestStyle `json:"style,omitempty"`
-}
-
-type TimeseriesRequestStyle struct {
-	Palette *string `json:"palette,omitempty"`
-}
-
-type TimeseriesMarker struct {
-	Label *string `json:"label,omitempty"`
-	Type  *string `json:"type,omitempty"`
-	Value *string `json:"value,omitempty"`
+	// For hostmap
+	NodeType      *string       `json:"nodeType,omitempty"`
+	Scope         []*string     `json:"scope,omitempty"`
+	Group         []*string     `json:"group,omitempty"`
+	NoGroupHosts  *bool         `json:"noGroupHosts,omitempty"`
+	NoMetricHosts *bool         `json:"noMetricHosts,omitempty"`
+	Style         *TileDefStyle `json:"style,omitempty"`
 }
 
 type TileDefEvent struct {
 	Query *string `json:"q"`
 }
 
-type AlertValueWidget struct {
-	TitleSize    *int    `json:"title_size,omitempty"`
-	Title        *bool   `json:"title,omitempty"`
-	TitleAlign   *string `json:"title_align,omitempty"`
-	TextAlign    *string `json:"text_align,omitempty"`
-	TitleText    *string `json:"title_text,omitempty"`
-	Precision    *int    `json:"precision,omitempty"`
-	AlertId      *int    `json:"alert_id,omitempty"`
-	Timeframe    *string `json:"timeframe,omitempty"`
-	AddTimeframe *bool   `json:"add_timeframe,omitempty"`
-	Y            *int    `json:"y,omitempty"`
-	X            *int    `json:"x,omitempty"`
-	TextSize     *string `json:"text_size,omitempty"`
-	Height       *int    `json:"height,omitempty"`
-	Width        *int    `json:"width,omitempty"`
-	Type         *string `json:"type,omitempty"`
-	Unit         *string `json:"unit,omitempty"`
+type TileDefMarker struct {
+	Label *string `json:"label,omitempty"`
+	Type  *string `json:"type,omitempty"`
+	Value *string `json:"value,omitempty"`
 }
 
-type ChangeWidget struct {
-	TitleSize  *int     `json:"title_size,omitempty"`
-	Title      *bool    `json:"title,omitempty"`
-	TitleAlign *string  `json:"title_align,omitempty"`
-	TitleText  *string  `json:"title_text,omitempty"`
-	Height     *int     `json:"height,omitempty"`
-	Width      *int     `json:"width,omitempty"`
-	X          *int     `json:"y,omitempty"`
-	Y          *int     `json:"x,omitempty"`
-	Aggregator *string  `json:"aggregator,omitempty"`
-	TileDef    *TileDef `json:"tile_def,omitempty"`
+type TileDefRequest struct {
+	Query *string `json:"q,omitempty"`
+
+	// For Hostmap
+	Type *string `json:"type,omitempty"`
+
+	// For Process
+	QueryType  *string   `json:"query_type,omitempty"`
+	Metric     *string   `json:"metric,omitempty"`
+	TextFilter *string   `json:"text_filter,omitempty"`
+	TagFilters []*string `json:"tag_filters"`
+	Limit      *int      `json:"limit,omitempty"`
+
+	ConditionalFormats []ConditionalFormat  `json:"conditional_formats,omitempty"`
+	Style              *TileDefRequestStyle `json:"style,omitempty"`
+	Aggregator         *string              `json:"aggregator,omitempty"`
+	CompareTo          *string              `json:"compare_to,omitempty"`
+	ChangeType         *string              `json:"change_type,omitempty"`
+	OrderBy            *string              `json:"order_by,omitempty"`
+	OrderDir           *string              `json:"order_dir,omitempty"`
+	ExtraCol           *string              `json:"extra_col,omitempty"`
+	IncreaseGood       *bool                `json:"increase_good,omitempty"`
 }
 
-type GraphWidget struct {
-	TitleSize  *int     `json:"title_size,omitempty"`
-	Title      *bool    `json:"title,omitempty"`
-	TitleAlign *string  `json:"title_align,omitempty"`
-	TitleText  *string  `json:"title_text,omitempty"`
-	Height     *int     `json:"height,omitempty"`
-	Width      *int     `json:"width,omitempty"`
-	X          *int     `json:"y,omitempty"`
-	Y          *int     `json:"x,omitempty"`
-	Type       *string  `json:"type,omitempty"`
-	Timeframe  *string  `json:"timeframe,omitempty"`
-	LegendSize *int     `json:"legend_size,omitempty"`
-	Legend     *bool    `json:"legend,omitempty"`
-	TileDef    *TileDef `json:"tile_def,omitempty"`
-}
-
-type EventTimelineWidget struct {
-	TitleSize  *int    `json:"title_size,omitempty"`
-	Title      *bool   `json:"title,omitempty"`
-	TitleAlign *string `json:"title_align,omitempty"`
-	TitleText  *string `json:"title_text,omitempty"`
-	Height     *int    `json:"height,omitempty"`
-	Width      *int    `json:"width,omitempty"`
-	X          *int    `json:"y,omitempty"`
-	Y          *int    `json:"x,omitempty"`
-	Type       *string `json:"type,omitempty"`
-	Timeframe  *string `json:"timeframe,omitempty"`
-	Query      *string `json:"query,omitempty"`
-}
-
-type AlertGraphWidget struct {
-	TitleSize    *int    `json:"title_size,omitempty"`
-	VizType      *string `json:"timeseries,omitempty"`
-	Title        *bool   `json:"title,omitempty"`
-	TitleAlign   *string `json:"title_align,omitempty"`
-	TitleText    *string `json:"title_text,omitempty"`
-	Height       *int    `json:"height,omitempty"`
-	Width        *int    `json:"width,omitempty"`
-	X            *int    `json:"y,omitempty"`
-	Y            *int    `json:"x,omitempty"`
-	AlertId      *int    `json:"alert_id,omitempty"`
-	Timeframe    *string `json:"timeframe,omitempty"`
-	Type         *string `json:"type,omitempty"`
-	AddTimeframe *bool   `json:"add_timeframe,omitempty"`
-}
-
-type HostMapWidget struct {
-	TitleSize  *int     `json:"title_size,omitempty"`
-	Title      *bool    `json:"title,omitempty"`
-	TitleAlign *string  `json:"title_align,omitempty"`
-	TitleText  *string  `json:"title_text,omitempty"`
-	Height     *int     `json:"height,omitempty"`
-	Width      *int     `json:"width,omitempty"`
-	X          *int     `json:"y,omitempty"`
-	Y          *int     `json:"x,omitempty"`
-	Query      *string  `json:"query,omitempty"`
-	Timeframe  *string  `json:"timeframe,omitempty"`
-	LegendSize *int     `json:"legend_size,omitempty"`
-	Type       *string  `json:"type,omitempty"`
-	Legend     *bool    `json:"legend,omitempty"`
-	TileDef    *TileDef `json:"tile_def,omitempty"`
-}
-
-type CheckStatusWidget struct {
-	TitleSize  *int    `json:"title_size,omitempty"`
-	Title      *bool   `json:"title,omitempty"`
-	TitleAlign *string `json:"title_align,omitempty"`
-	TextAlign  *string `json:"text_align,omitempty"`
-	TitleText  *string `json:"title_text,omitempty"`
-	Height     *int    `json:"height,omitempty"`
-	Width      *int    `json:"width,omitempty"`
-	X          *int    `json:"y,omitempty"`
-	Y          *int    `json:"x,omitempty"`
-	Tags       *string `json:"tags,omitempty"`
-	Timeframe  *string `json:"timeframe,omitempty"`
-	TextSize   *string `json:"text_size,omitempty"`
-	Type       *string `json:"type,omitempty"`
-	Check      *string `json:"check,omitempty"`
-	Group      *string `json:"group,omitempty"`
-	Grouping   *string `json:"grouping,omitempty"`
-}
-
-type IFrameWidget struct {
-	TitleSize  *int    `json:"title_size,omitempty"`
-	Title      *bool   `json:"title,omitempty"`
-	Url        *string `json:"url,omitempty"`
-	TitleAlign *string `json:"title_align,omitempty"`
-	TitleText  *string `json:"title_text,omitempty"`
-	Height     *int    `json:"height,omitempty"`
-	Width      *int    `json:"width,omitempty"`
-	X          *int    `json:"y,omitempty"`
-	Y          *int    `json:"x,omitempty"`
-	Type       *string `json:"type,omitempty"`
-}
-
-type NoteWidget struct {
-	TitleSize    *int    `json:"title_size,omitempty"`
-	Title        *bool   `json:"title,omitempty"`
-	RefreshEvery *int    `json:"refresh_every,omitempty"`
-	TickPos      *string `json:"tick_pos,omitempty"`
-	TitleAlign   *string `json:"title_align,omitempty"`
-	TickEdge     *string `json:"tick_edge,omitempty"`
-	TextAlign    *string `json:"text_align,omitempty"`
-	TitleText    *string `json:"title_text,omitempty"`
-	Height       *int    `json:"height,omitempty"`
-	Color        *string `json:"bgcolor,omitempty"`
-	Html         *string `json:"html,omitempty"`
-	Y            *int    `json:"y,omitempty"`
-	X            *int    `json:"x,omitempty"`
-	FontSize     *int    `json:"font_size,omitempty"`
-	Tick         *bool   `json:"tick,omitempty"`
-	Note         *string `json:"type,omitempty"`
-	Width        *int    `json:"width,omitempty"`
-	AutoRefresh  *bool   `json:"auto_refresh,omitempty"`
-}
-
-type TimeseriesWidget struct {
-	Height     *int      `json:"height,omitempty"`
-	Legend     *bool     `json:"legend,omitempty"`
-	TileDef    *TileDef  `json:"tile_def,omitempty"`
-	Timeframe  *string   `json:"timeframe,omitempty"`
-	Title      *bool     `json:"title,omitempty"`
-	TitleAlign *string   `json:"title_align,omitempty"`
-	TitleSize  *TextSize `json:"title_size,omitempty"`
-	TitleText  *string   `json:"title_text,omitempty"`
-	Type       *string   `json:"type,omitempty"`
-	Width      *int      `json:"width,omitempty"`
-	X          *int      `json:"x,omitempty"`
-	Y          *int      `json:"y,omitempty"`
-}
-
-type QueryValueWidget struct {
-	Timeframe           *string             `json:"timeframe,omitempty"`
-	TimeframeAggregator *string             `json:"aggr,omitempty"`
-	Aggregator          *string             `json:"aggregator,omitempty"`
-	CalcFunc            *string             `json:"calc_func,omitempty"`
-	ConditionalFormats  []ConditionalFormat `json:"conditional_formats,omitempty"`
-	Height              *int                `json:"height,omitempty"`
-	IsValidQuery        *bool               `json:"is_valid_query,omitempty,omitempty"`
-	Metric              *string             `json:"metric,omitempty"`
-	MetricType          *string             `json:"metric_type,omitempty"`
-	Precision           *int                `json:"precision,omitempty"`
-	Query               *string             `json:"query,omitempty"`
-	ResultCalcFunc      *string             `json:"res_calc_func,omitempty"`
-	Tags                []string            `json:"tags,omitempty"`
-	TextAlign           *string             `json:"text_align,omitempty"`
-	TextSize            *TextSize           `json:"text_size,omitempty"`
-	Title               *bool               `json:"title,omitempty"`
-	TitleAlign          *string             `json:"title_align,omitempty"`
-	TitleSize           *TextSize           `json:"title_size,omitempty"`
-	TitleText           *string             `json:"title_text,omitempty"`
-	Type                *string             `json:"type,omitempty"`
-	Unit                *string             `json:"auto,omitempty"`
-	Width               *int                `json:"width,omitempty"`
-	X                   *int                `json:"x,omitempty"`
-	Y                   *int                `json:"y,omitempty"`
-}
 type ConditionalFormat struct {
 	Color      *string `json:"color,omitempty"`
+	Palette    *string `json:"palette,omitempty"`
 	Comparator *string `json:"comparator,omitempty"`
-	Inverted   *bool   `json:"invert,omitempty"`
-	Value      *int    `json:"value,omitempty"`
+	Invert     *bool   `json:"invert,omitempty"`
+	Value      *string `json:"value,omitempty"`
+	ImageURL   *string `json:"image_url,omitempty"`
 }
 
-type ToplistWidget struct {
-	Height     *int      `json:"height,omitempty"`
-	Legend     *bool     `json:"legend,omitempty"`
-	LegendSize *int      `json:"legend_size,omitempty"`
-	TileDef    *TileDef  `json:"tile_def,omitempty"`
-	Timeframe  *string   `json:"timeframe,omitempty"`
-	Title      *bool     `json:"title,omitempty"`
-	TitleAlign *string   `json:"title_align,omitempty"`
-	TitleSize  *TextSize `json:"title_size,omitempty"`
-	TitleText  *string   `json:"title_text,omitempty"`
-	Type       *string   `json:"type,omitempty"`
-	Width      *int      `json:"width,omitempty"`
-	X          *int      `json:"x,omitempty"`
-	Y          *int      `json:"y,omitempty"`
+type TileDefRequestStyle struct {
+	Palette *string `json:"palette,omitempty"`
+	Type    *string `json:"type,omitempty"`
+	Width   *string `json:"width,omitempty"`
 }
 
-type EventStreamWidget struct {
-	EventSize  *string   `json:"event_size,omitempty"`
-	Height     *int      `json:"height,omitempty"`
-	Query      *string   `json:"query,omitempty"`
-	Timeframe  *string   `json:"timeframe,omitempty"`
-	Title      *bool     `json:"title,omitempty"`
-	TitleAlign *string   `json:"title_align,omitempty"`
-	TitleSize  *TextSize `json:"title_size,omitempty"`
-	TitleText  *string   `json:"title_text,omitempty"`
-	Type       *string   `json:"type,omitempty"`
-	Width      *int      `json:"width,omitempty"`
-	X          *int      `json:"x,omitempty"`
-	Y          *int      `json:"y,omitempty"`
+type TileDefStyle struct {
+	Palette     *string `json:"palette,omitempty"`
+	PaletteFlip *string `json:"paletteFlip,omitempty"`
+	FillMin     *string `json:"fillMin,omitempty"`
+	FillMax     *string `json:"fillMax,omitempty"`
 }
 
-type FreeTextWidget struct {
-	Color     *string `json:"color,omitempty"`
-	FontSize  *string `json:"font_size,omitempty"`
-	Height    *int    `json:"height,omitempty"`
-	Text      *string `json:"text,omitempty"`
+type Time struct {
+	LiveSpan *string `json:"live_span,omitempty"`
+}
+
+type Widget struct {
+	// Common attributes
+	Type       *string `json:"type,omitempty"`
+	Title      *bool   `json:"title,omitempty"`
+	TitleText  *string `json:"title_text,omitempty"`
+	TitleAlign *string `json:"title_align,omitempty"`
+	TitleSize  *int    `json:"title_size,omitempty"`
+	Height     *int    `json:"height,omitempty"`
+	Width      *int    `json:"width,omitempty"`
+	X          *int    `json:"y,omitempty"`
+	Y          *int    `json:"x,omitempty"`
+
+	// For Timeseries, TopList, EventTimeline, EvenStream, AlertGraph, CheckStatus, ServiceSummary, LogStream widgets
+	Time *Time `json:"time,omitempty"`
+
+	// For Timeseries, QueryValue, HostMap, Change, Toplist, Process widgets
+	TileDef *TileDef `json:"tile_def,omitempty"`
+
+	// For FreeText widget
+	Text  *string `json:"text,omitempty"`
+	Color *string `json:"color,omitempty"`
+
+	// For AlertValue widget
+	TextSize  *string `json:"text_size,omitempty"`
+	Unit      *string `json:"unit,omitempty"`
+	Precision *string `json:"precision,omitempty"`
+
+	// AlertGraph widget
+	VizType *string `json:"viz_type,omitempty"`
+
+	// For AlertValue, QueryValue, FreeText, Note widgets
 	TextAlign *string `json:"text_align,omitempty"`
-	Type      *string `json:"type,omitempty"`
-	Width     *int    `json:"width,omitempty"`
-	X         *int    `json:"x,omitempty"`
-	Y         *int    `json:"y,omitempty"`
+
+	// For FreeText, Note widgets
+	FontSize *string `json:"font_size,omitempty"`
+
+	// For AlertValue, AlertGraph widgets
+	AlertID     *int  `json:"alert_id,omitempty"`
+	AutoRefresh *bool `json:"auto_refresh,omitempty"`
+
+	// For Timeseries, QueryValue, Toplist widgets
+	Legend     *bool   `json:"legend,omitempty"`
+	LegendSize *string `json:"legend_size,omitempty"`
+
+	// For EventTimeline, EventStream, Hostmap, LogStream widgets
+	Query *string `json:"query,omitempty"`
+
+	// For Image, IFrame widgets
+	URL *string `json:"url,omitempty"`
+
+	// For CheckStatus widget
+	Tags     []*string `json:"tags,omitempty"`
+	Check    *string   `json:"check,omitempty"`
+	Grouping *string   `json:"grouping,omitempty"`
+	GroupBy  []*string `json:"group_by,omitempty"`
+	Group    *string   `json:"group,omitempty"`
+
+	// Note widget
+	TickPos  *string `json:"tick_pos,omitempty"`
+	TickEdge *string `json:"tick_edge,omitempty"`
+	HTML     *string `json:"html,omitempty"`
+	Tick     *bool   `json:"tick,omitempty"`
+	Bgcolor  *string `json:"bgcolor,omitempty"`
+
+	// EventStream widget
+	EventSize *string `json:"event_size,omitempty"`
+
+	// Image widget
+	Sizing *string `json:"sizing,omitempty"`
+	Margin *string `json:"margin,omitempty"`
+
+	// For ServiceSummary (trace_service) widget
+	Env                  *string `json:"env,omitempty"`
+	ServiceService       *string `json:"serviceService,omitempty"`
+	ServiceName          *string `json:"serviceName,omitempty"`
+	SizeVersion          *string `json:"sizeVersion,omitempty"`
+	LayoutVersion        *string `json:"layoutVersion,omitempty"`
+	MustShowHits         *bool   `json:"mustShowHits,omitempty"`
+	MustShowErrors       *bool   `json:"mustShowErrors,omitempty"`
+	MustShowLatency      *bool   `json:"mustShowLatency,omitempty"`
+	MustShowBreakdown    *bool   `json:"mustShowBreakdown,omitempty"`
+	MustShowDistribution *bool   `json:"mustShowDistribution,omitempty"`
+	MustShowResourceList *bool   `json:"mustShowResourceList,omitempty"`
+
+	// For MonitorSummary (manage_status) widget
+	DisplayFormat          *string `json:"displayFormat,omitempty"`
+	ColorPreference        *string `json:"colorPreference,omitempty"`
+	HideZeroCounts         *bool   `json:"hideZeroCounts,omitempty"`
+	ManageStatusShowTitle  *bool   `json:"showTitle,omitempty"`
+	ManageStatusTitleText  *string `json:"titleText,omitempty"`
+	ManageStatusTitleSize  *string `json:"titleSize,omitempty"`
+	ManageStatusTitleAlign *string `json:"titleAlign,omitempty"`
+	Params                 *Params `json:"params,omitempty"`
+
+	// For LogStream widget
+	Columns *string `json:"columns,omitempty"`
+	Logset  *string `json:"logset,omitempty"`
+
+	// For Uptime
+	Timeframes []*string           `json:"timeframes,omitempty"`
+	Rules      map[string]*Rule    `json:"rules,omitempty"`
+	Monitor    *ScreenboardMonitor `json:"monitor,omitempty"`
 }
 
-type ImageWidget struct {
-	Height     *int      `json:"height,omitempty"`
-	Sizing     *string   `json:"sizing,omitempty"`
-	Title      *bool     `json:"title,omitempty"`
-	TitleAlign *string   `json:"title_align,omitempty"`
-	TitleSize  *TextSize `json:"title_size,omitempty"`
-	TitleText  *string   `json:"title_text,omitempty"`
-	Type       *string   `json:"type,omitempty"`
-	Url        *string   `json:"url,omitempty"`
-	Width      *int      `json:"width,omitempty"`
-	X          *int      `json:"x,omitempty"`
-	Y          *int      `json:"y,omitempty"`
+type Params struct {
+	Sort  *string `json:"sort,omitempty"`
+	Text  *string `json:"text,omitempty"`
+	Count *string `json:"count,omitempty"`
+	Start *string `json:"start,omitempty"`
+}
+
+type Rule struct {
+	Threshold *int    `json:"threshold,omitempty"`
+	Timeframe *string `json:"timeframe,omitempty"`
+	Color     *string `json:"color,omitempty"`
+}
+
+type ScreenboardMonitor struct {
+	Id *int `json:"id,omitempty"`
 }

--- a/vendor/github.com/zorkian/go-datadog-api/screenboards.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screenboards.go
@@ -20,32 +20,9 @@ type Screenboard struct {
 	Height            *string            `json:"height,omitempty"`
 	Width             *string            `json:"width,omitempty"`
 	Shared            *bool              `json:"shared,omitempty"`
-	Templated         *bool              `json:"templated,omitempty"`
 	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
 	Widgets           []Widget           `json:"widgets"`
 	ReadOnly          *bool              `json:"read_only,omitempty"`
-}
-
-//type Widget struct {
-type Widget struct {
-	Default             *string              `json:"default,omitempty"`
-	Name                *string              `json:"name,omitempty"`
-	Prefix              *string              `json:"prefix,omitempty"`
-	TimeseriesWidget    *TimeseriesWidget    `json:"timeseries,omitempty"`
-	QueryValueWidget    *QueryValueWidget    `json:"query_value,omitempty"`
-	EventStreamWidget   *EventStreamWidget   `json:"event_stream,omitempty"`
-	FreeTextWidget      *FreeTextWidget      `json:"free_text,omitempty"`
-	ToplistWidget       *ToplistWidget       `json:"toplist,omitempty"`
-	ImageWidget         *ImageWidget         `json:"image,omitempty"`
-	ChangeWidget        *ChangeWidget        `json:"change,omitempty"`
-	GraphWidget         *GraphWidget         `json:"graph,omitempty"`
-	EventTimelineWidget *EventTimelineWidget `json:"event_timeline,omitempty"`
-	AlertValueWidget    *AlertValueWidget    `json:"alert_value,omitempty"`
-	AlertGraphWidget    *AlertGraphWidget    `json:"alert_graph,omitempty"`
-	HostMapWidget       *HostMapWidget       `json:"hostmap,omitempty"`
-	CheckStatusWidget   *CheckStatusWidget   `json:"check_status,omitempty"`
-	IFrameWidget        *IFrameWidget        `json:"iframe,omitempty"`
-	NoteWidget          *NoteWidget          `json:"frame,omitempty"`
 }
 
 // ScreenboardLite represents a user created screenboard. This is the mini

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -574,12 +574,12 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "pS5615UBfIMbuO+xZPtxpMOz50Y=",
+			"checksumSHA1": "UDw9d5BEEc4WvdL71IlDuu9AA4o=",
 			"path": "github.com/zorkian/go-datadog-api",
-			"revision": "114bbae3eb718f241d7d8e55c96d75dfedefb8b3",
-			"revisionTime": "2018-08-05T21:58:11Z",
-			"version": "=v2.11.0",
-			"versionExact": "v2.11.0"
+			"revision": "05fc4ddce70eb5e917af1c4453fd50694ce10964",
+			"revisionTime": "2018-09-04T22:35:51Z",
+			"version": "v2.13.0",
+			"versionExact": "v2.13.0"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
* v2.13.0 of go-datadog-api library adds a custom unmarshaller for Yaxis
struct, which can properly handle the issue where strings (e.g. "99")
for yaxis.max would cause the tf provider to bail out.