### PR TITLE
Allow new_host_delay to be unset

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -387,7 +387,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	NewHostDelay := d.Get("new_host_delay")
+	newHostDelay := d.Get("new_host_delay")
 	o.SetNewHostDelay(NewHostDelay.(int))
 
 	if attr, ok := d.GetOk("evaluation_delay"); ok {

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -387,9 +387,9 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if attr, ok := d.GetOk("new_host_delay"); ok {
-		o.SetNewHostDelay(attr.(int))
-	}
+	NewHostDelay := d.Get("new_host_delay")
+	o.SetNewHostDelay(NewHostDelay.(int))
+
 	if attr, ok := d.GetOk("evaluation_delay"); ok {
 		o.SetEvaluationDelay(attr.(int))
 	}

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -388,7 +388,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	newHostDelay := d.Get("new_host_delay")
-	o.SetNewHostDelay(NewHostDelay.(int))
+	o.SetNewHostDelay(newHostDelay.(int))
 
 	if attr, ok := d.GetOk("evaluation_delay"); ok {
 		o.SetEvaluationDelay(attr.(int))


### PR DESCRIPTION
Stops using the [`GetOk`](https://godoc.org/github.com/hashicorp/terraform/helper/schema#ResourceData.GetOk) method when updating the monitor struct for the `new_host_delay` parameter. 

The GetOk method does a check both to see if the key is specified in the schema configuration AND is **not** the golang zero value for that type. So Using the GetOk function, specifying a `new_host_delay: 0` would actually cause the default to be used.

It seems like GetOk shouldn't be used for an int type that has a default value if `0` is an allowed value for that key. 

Get-ing the key (the change introduced in this PR), you can specify a 0 value to mean `0` or specify no value to fallback to the default. 

Alternatively, we could use the `GetOkExists` function, but that is only available starting with Terraform 0.10.1 and this provider currently pins the helpers library at 0.10.0