### PR TITLE
Bump datadog api to v2.18.0 and add support for include units and zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.6.0 (Unreleased)
+
+IMPROVEMENTS
+
+* Pull changes from go-datadog-api v2.18.0 ([#121](https://github.com/terraform-providers/terraform-provider-datadog/pull/121))
+
 ## 1.5.0 (November 06, 2018)
 
 IMPROVEMENTS:

--- a/datadog/resource_datadog_screenboard.go
+++ b/datadog/resource_datadog_screenboard.go
@@ -956,8 +956,8 @@ func buildScreenboard(d *schema.ResourceData) (*datadog.Screenboard, error) {
 	return &datadog.Screenboard{
 		Id:                datadog.Int(id),
 		Title:             datadog.String(d.Get("title").(string)),
-		Height:            datadog.String(d.Get("height").(string)),
-		Width:             datadog.String(d.Get("width").(string)),
+		Height:            datadog.Int(d.Get("height").(int)),
+		Width:             datadog.Int(d.Get("width").(int)),
 		Shared:            datadog.Bool(d.Get("shared").(bool)),
 		ReadOnly:          datadog.Bool(d.Get("read_only").(bool)),
 		Widgets:           buildWidgets(&terraformWidgets),

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -423,6 +423,13 @@ func buildGraphs(terraformGraphs *[]interface{}) *[]datadog.Graph {
 			if v, ok := yaxis["scale"]; ok {
 				d.Definition.Yaxis.SetScale(v.(string))
 			}
+			if v, ok := t["include_zero"]; ok {
+				d.Definition.Yaxis.SetIncludeZero(v.(bool))
+			}
+
+			if v, ok := t["include_units"]; ok {
+				d.Definition.Yaxis.SetIncludeUnits(v.(bool))
+			}
 		}
 
 		if v, ok := t["autoscale"]; ok {
@@ -658,6 +665,14 @@ func buildTerraformGraph(datadog_graph datadog.Graph) map[string]interface{} {
 
 	if v, ok := definition.Yaxis.GetScaleOk(); ok {
 		yaxis["scale"] = v
+	}
+
+	if v, ok := definition.Yaxis.GetIncludeZeroOk(); ok {
+		yaxis["include_zero"] = strconv.FormatBool(v)
+	}
+
+	if v, ok := definition.Yaxis.GetIncludeUnitsOk(); ok {
+		yaxis["include_unis"] = strconv.FormatBool(v)
 	}
 
 	graph["yaxis"] = yaxis

--- a/datadog/resource_datadog_timeboard_test.go
+++ b/datadog/resource_datadog_timeboard_test.go
@@ -84,6 +84,8 @@ resource "datadog_timeboard" "acceptance_test" {
     yaxis {
       max = "50"
       scale = "sqrt"
+			include_zero = true
+			include_units = true
     }
   }
   graph {
@@ -169,6 +171,8 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.marker.0.value", "y > 100"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.yaxis.max", "50"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.yaxis.scale", "sqrt"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.yaxis.include_units", "true"),
+			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.0.yaxis.include_zero", "true"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.1.title", "ELB Requests"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.1.viz", "query_value"),
 			resource.TestCheckResourceAttr("datadog_timeboard.acceptance_test", "graph.1.request.0.q", "sum:aws.elb.request_count{*}.as_count()"),

--- a/vendor/github.com/zorkian/go-datadog-api/dashboards.go
+++ b/vendor/github.com/zorkian/go-datadog-api/dashboards.go
@@ -52,11 +52,13 @@ type GraphEvent struct {
 }
 
 type Yaxis struct {
-	Min     *float64 `json:"min,omitempty"`
-	AutoMin bool     `json:"-"`
-	Max     *float64 `json:"max,omitempty"`
-	AutoMax bool     `json:"-"`
-	Scale   *string  `json:"scale,omitempty"`
+	Min          *float64 `json:"min,omitempty"`
+	AutoMin      bool     `json:"-"`
+	Max          *float64 `json:"max,omitempty"`
+	AutoMax      bool     `json:"-"`
+	Scale        *string  `json:"scale,omitempty"`
+	IncludeZero  *bool    `json:"includeZero,omitempty"`
+	IncludeUnits *bool    `json:"units,omitempty"`
 }
 
 // UnmarshalJSON is a Custom Unmarshal for Yaxis.Min/Yaxis.Max. If the datadog API

--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -5779,6 +5779,37 @@ func (o *Options) SetThresholds(v ThresholdCount) {
 	o.Thresholds = &v
 }
 
+// GetThresholdWindows returns the ThresholdWindows field if non-nil, zero value otherwise.
+func (o *Options) GetThresholdWindows() ThresholdWindows {
+	if o == nil || o.ThresholdWindows == nil {
+		return ThresholdWindows{}
+	}
+	return *o.ThresholdWindows
+}
+
+// GetThresholdWindowsOk returns a tuple with the ThresholdWindows field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (o *Options) GetThresholdWindowsOk() (ThresholdWindows, bool) {
+	if o == nil || o.ThresholdWindows == nil {
+		return ThresholdWindows{}, false
+	}
+	return *o.ThresholdWindows, true
+}
+
+// HasThresholdWindows returns a boolean if a field has been set.
+func (o *Options) HasThresholdWindows() bool {
+	if o != nil && o.ThresholdWindows != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetThresholdWindows allocates a new o.ThresholdWindows and returns the pointer to it.
+func (o *Options) SetThresholdWindows(v ThresholdWindows) {
+	o.ThresholdWindows = &v
+}
+
 // GetTimeoutH returns the TimeoutH field if non-nil, zero value otherwise.
 func (o *Options) GetTimeoutH() int {
 	if o == nil || o.TimeoutH == nil {
@@ -6338,18 +6369,18 @@ func (r *Rule) SetTimeframe(v string) {
 }
 
 // GetHeight returns the Height field if non-nil, zero value otherwise.
-func (s *Screenboard) GetHeight() string {
+func (s *Screenboard) GetHeight() int {
 	if s == nil || s.Height == nil {
-		return ""
+		return 0
 	}
 	return *s.Height
 }
 
 // GetHeightOk returns a tuple with the Height field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (s *Screenboard) GetHeightOk() (string, bool) {
+func (s *Screenboard) GetHeightOk() (int, bool) {
 	if s == nil || s.Height == nil {
-		return "", false
+		return 0, false
 	}
 	return *s.Height, true
 }
@@ -6364,7 +6395,7 @@ func (s *Screenboard) HasHeight() bool {
 }
 
 // SetHeight allocates a new s.Height and returns the pointer to it.
-func (s *Screenboard) SetHeight(v string) {
+func (s *Screenboard) SetHeight(v int) {
 	s.Height = &v
 }
 
@@ -6493,18 +6524,18 @@ func (s *Screenboard) SetTitle(v string) {
 }
 
 // GetWidth returns the Width field if non-nil, zero value otherwise.
-func (s *Screenboard) GetWidth() string {
+func (s *Screenboard) GetWidth() int {
 	if s == nil || s.Width == nil {
-		return ""
+		return 0
 	}
 	return *s.Width
 }
 
 // GetWidthOk returns a tuple with the Width field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (s *Screenboard) GetWidthOk() (string, bool) {
+func (s *Screenboard) GetWidthOk() (int, bool) {
 	if s == nil || s.Width == nil {
-		return "", false
+		return 0, false
 	}
 	return *s.Width, true
 }
@@ -6519,7 +6550,7 @@ func (s *Screenboard) HasWidth() bool {
 }
 
 // SetWidth allocates a new s.Width and returns the pointer to it.
-func (s *Screenboard) SetWidth(v string) {
+func (s *Screenboard) SetWidth(v int) {
 	s.Width = &v
 }
 
@@ -7544,6 +7575,68 @@ func (t *ThresholdCount) HasWarningRecovery() bool {
 // SetWarningRecovery allocates a new t.WarningRecovery and returns the pointer to it.
 func (t *ThresholdCount) SetWarningRecovery(v json.Number) {
 	t.WarningRecovery = &v
+}
+
+// GetRecoveryWindow returns the RecoveryWindow field if non-nil, zero value otherwise.
+func (t *ThresholdWindows) GetRecoveryWindow() string {
+	if t == nil || t.RecoveryWindow == nil {
+		return ""
+	}
+	return *t.RecoveryWindow
+}
+
+// GetRecoveryWindowOk returns a tuple with the RecoveryWindow field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *ThresholdWindows) GetRecoveryWindowOk() (string, bool) {
+	if t == nil || t.RecoveryWindow == nil {
+		return "", false
+	}
+	return *t.RecoveryWindow, true
+}
+
+// HasRecoveryWindow returns a boolean if a field has been set.
+func (t *ThresholdWindows) HasRecoveryWindow() bool {
+	if t != nil && t.RecoveryWindow != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRecoveryWindow allocates a new t.RecoveryWindow and returns the pointer to it.
+func (t *ThresholdWindows) SetRecoveryWindow(v string) {
+	t.RecoveryWindow = &v
+}
+
+// GetTriggerWindow returns the TriggerWindow field if non-nil, zero value otherwise.
+func (t *ThresholdWindows) GetTriggerWindow() string {
+	if t == nil || t.TriggerWindow == nil {
+		return ""
+	}
+	return *t.TriggerWindow
+}
+
+// GetTriggerWindowOk returns a tuple with the TriggerWindow field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *ThresholdWindows) GetTriggerWindowOk() (string, bool) {
+	if t == nil || t.TriggerWindow == nil {
+		return "", false
+	}
+	return *t.TriggerWindow, true
+}
+
+// HasTriggerWindow returns a boolean if a field has been set.
+func (t *ThresholdWindows) HasTriggerWindow() bool {
+	if t != nil && t.TriggerWindow != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTriggerWindow allocates a new t.TriggerWindow and returns the pointer to it.
+func (t *ThresholdWindows) SetTriggerWindow(v string) {
+	t.TriggerWindow = &v
 }
 
 // GetAutoscale returns the Autoscale field if non-nil, zero value otherwise.
@@ -10768,6 +10861,68 @@ func (w *Widget) HasY() bool {
 // SetY allocates a new w.Y and returns the pointer to it.
 func (w *Widget) SetY(v int) {
 	w.Y = &v
+}
+
+// GetIncludeUnits returns the IncludeUnits field if non-nil, zero value otherwise.
+func (y *Yaxis) GetIncludeUnits() bool {
+	if y == nil || y.IncludeUnits == nil {
+		return false
+	}
+	return *y.IncludeUnits
+}
+
+// GetIncludeUnitsOk returns a tuple with the IncludeUnits field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (y *Yaxis) GetIncludeUnitsOk() (bool, bool) {
+	if y == nil || y.IncludeUnits == nil {
+		return false, false
+	}
+	return *y.IncludeUnits, true
+}
+
+// HasIncludeUnits returns a boolean if a field has been set.
+func (y *Yaxis) HasIncludeUnits() bool {
+	if y != nil && y.IncludeUnits != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIncludeUnits allocates a new y.IncludeUnits and returns the pointer to it.
+func (y *Yaxis) SetIncludeUnits(v bool) {
+	y.IncludeUnits = &v
+}
+
+// GetIncludeZero returns the IncludeZero field if non-nil, zero value otherwise.
+func (y *Yaxis) GetIncludeZero() bool {
+	if y == nil || y.IncludeZero == nil {
+		return false
+	}
+	return *y.IncludeZero
+}
+
+// GetIncludeZeroOk returns a tuple with the IncludeZero field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (y *Yaxis) GetIncludeZeroOk() (bool, bool) {
+	if y == nil || y.IncludeZero == nil {
+		return false, false
+	}
+	return *y.IncludeZero, true
+}
+
+// HasIncludeZero returns a boolean if a field has been set.
+func (y *Yaxis) HasIncludeZero() bool {
+	if y != nil && y.IncludeZero != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIncludeZero allocates a new y.IncludeZero and returns the pointer to it.
+func (y *Yaxis) SetIncludeZero(v bool) {
+	y.IncludeZero = &v
 }
 
 // GetMax returns the Max field if non-nil, zero value otherwise.

--- a/vendor/github.com/zorkian/go-datadog-api/monitors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/monitors.go
@@ -25,6 +25,11 @@ type ThresholdCount struct {
 	WarningRecovery  *json.Number `json:"warning_recovery,omitempty"`
 }
 
+type ThresholdWindows struct {
+	RecoveryWindow *string `json:"recovery_window,omitempty"`
+	TriggerWindow  *string `json:"trigger_window,omitempty"`
+}
+
 type NoDataTimeframe int
 
 func (tf *NoDataTimeframe) UnmarshalJSON(data []byte) error {
@@ -42,19 +47,20 @@ func (tf *NoDataTimeframe) UnmarshalJSON(data []byte) error {
 }
 
 type Options struct {
-	NoDataTimeframe   NoDataTimeframe `json:"no_data_timeframe,omitempty"`
-	NotifyAudit       *bool           `json:"notify_audit,omitempty"`
-	NotifyNoData      *bool           `json:"notify_no_data,omitempty"`
-	RenotifyInterval  *int            `json:"renotify_interval,omitempty"`
-	NewHostDelay      *int            `json:"new_host_delay,omitempty"`
-	EvaluationDelay   *int            `json:"evaluation_delay,omitempty"`
-	Silenced          map[string]int  `json:"silenced,omitempty"`
-	TimeoutH          *int            `json:"timeout_h,omitempty"`
-	EscalationMessage *string         `json:"escalation_message,omitempty"`
-	Thresholds        *ThresholdCount `json:"thresholds,omitempty"`
-	IncludeTags       *bool           `json:"include_tags,omitempty"`
-	RequireFullWindow *bool           `json:"require_full_window,omitempty"`
-	Locked            *bool           `json:"locked,omitempty"`
+	NoDataTimeframe   NoDataTimeframe   `json:"no_data_timeframe,omitempty"`
+	NotifyAudit       *bool             `json:"notify_audit,omitempty"`
+	NotifyNoData      *bool             `json:"notify_no_data,omitempty"`
+	RenotifyInterval  *int              `json:"renotify_interval,omitempty"`
+	NewHostDelay      *int              `json:"new_host_delay,omitempty"`
+	EvaluationDelay   *int              `json:"evaluation_delay,omitempty"`
+	Silenced          map[string]int    `json:"silenced,omitempty"`
+	TimeoutH          *int              `json:"timeout_h,omitempty"`
+	EscalationMessage *string           `json:"escalation_message,omitempty"`
+	Thresholds        *ThresholdCount   `json:"thresholds,omitempty"`
+	ThresholdWindows  *ThresholdWindows `json:"threshold_windows,omitempty"`
+	IncludeTags       *bool             `json:"include_tags,omitempty"`
+	RequireFullWindow *bool             `json:"require_full_window,omitempty"`
+	Locked            *bool             `json:"locked,omitempty"`
 }
 
 type TriggeringValue struct {

--- a/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
@@ -90,8 +90,8 @@ type Widget struct {
 	TitleSize  *int    `json:"title_size,omitempty"`
 	Height     *int    `json:"height,omitempty"`
 	Width      *int    `json:"width,omitempty"`
-	X          *int    `json:"y,omitempty"`
-	Y          *int    `json:"x,omitempty"`
+	X          *int    `json:"x,omitempty"`
+	Y          *int    `json:"y,omitempty"`
 
 	// For Timeseries, TopList, EventTimeline, EvenStream, AlertGraph, CheckStatus, ServiceSummary, LogStream widgets
 	Time *Time `json:"time,omitempty"`

--- a/vendor/github.com/zorkian/go-datadog-api/screenboards.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screenboards.go
@@ -17,8 +17,8 @@ import (
 type Screenboard struct {
 	Id                *int               `json:"id,omitempty"`
 	Title             *string            `json:"board_title,omitempty"`
-	Height            *string            `json:"height,omitempty"`
-	Width             *string            `json:"width,omitempty"`
+	Height            *int               `json:"height,omitempty"`
+	Width             *int               `json:"width,omitempty"`
 	Shared            *bool              `json:"shared,omitempty"`
 	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
 	Widgets           []Widget           `json:"widgets"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -932,12 +932,12 @@
 			"revisionTime": "2018-10-17T23:26:04Z"
 		},
 		{
-			"checksumSHA1": "ISh3RhB1MM9VhMqyT2Bf0P5OTTY=",
+			"checksumSHA1": "789joLgasdUcxF6qQy8Pn+IfGhw=",
 			"path": "github.com/zorkian/go-datadog-api",
-			"revision": "dc324c09cf05eef3e3a82bde06ae0c4dd349a767",
-			"revisionTime": "2018-10-18T20:20:04Z",
-			"version": "v2.17.0",
-			"versionExact": "v2.17.0"
+			"revision": "f3f6d2f4859047aae0cac1ce3d16689608480fd9",
+			"revisionTime": "2018-11-12T21:37:59Z",
+			"version": "v2.18.0",
+			"versionExact": "v2.18.0"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
# Summary

Bump the datadog API dep to 2.18.0 and add support for `includeZero` and `includeUnits`.

# Motivation

I want units and zeros on my axes! :smiley_cat: 

# Notes
The bump also [changed Screenboard's width and height](https://github.com/zorkian/go-datadog-api/pull/190) so there is perhaps some trouble with the use of strings here. #118 implied this wasn't an ok change to make?

This also fixes #119 

Thanks for your consideration!