### PR TITLE
bump client to latest, fix precision and yaxis.include_* fields

### DIFF
--- a/datadog/resource_datadog_timeboard_test.go
+++ b/datadog/resource_datadog_timeboard_test.go
@@ -132,7 +132,7 @@ resource "datadog_timeboard" "acceptance_test" {
 
 func TestAccDatadogTimeboard_update(t *testing.T) {
 
-	step1 := resource.TestStep{
+	step0 := resource.TestStep{
 		Config: config1,
 		Check: resource.ComposeTestCheckFunc(
 			checkExists,
@@ -147,7 +147,7 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 		),
 	}
 
-	step2 := resource.TestStep{
+	step1 := resource.TestStep{
 		Config: config2,
 		Check: resource.ComposeTestCheckFunc(
 			checkExists,
@@ -171,7 +171,7 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 		),
 	}
 
-	step3 := resource.TestStep{
+	step2 := resource.TestStep{
 		Config: config3,
 		Check: resource.ComposeTestCheckFunc(
 			checkExists,
@@ -211,7 +211,7 @@ func TestAccDatadogTimeboard_update(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: checkDestroy,
-		Steps:        []resource.TestStep{step1, step2, step3},
+		Steps:        []resource.TestStep{step0, step1, step2},
 	})
 }
 

--- a/vendor/github.com/zorkian/go-datadog-api/dashboards.go
+++ b/vendor/github.com/zorkian/go-datadog-api/dashboards.go
@@ -123,10 +123,10 @@ type GraphDefinition struct {
 	Yaxis Yaxis `json:"yaxis,omitempty"`
 
 	// For query value type graphs
-	Autoscale  *bool        `json:"autoscale,omitempty"`
-	TextAlign  *string      `json:"text_align,omitempty"`
-	Precision  *json.Number `json:"precision,omitempty"`
-	CustomUnit *string      `json:"custom_unit,omitempty"`
+	Autoscale  *bool       `json:"autoscale,omitempty"`
+	TextAlign  *string     `json:"text_align,omitempty"`
+	Precision  *PrecisionT `json:"precision,omitempty"`
+	CustomUnit *string     `json:"custom_unit,omitempty"`
 
 	// For hostmaps
 	Style                 *Style   `json:"style,omitempty"`

--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -2897,7 +2897,7 @@ func (g *GraphDefinition) SetNodeType(v string) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (g *GraphDefinition) GetPrecision() json.Number {
+func (g *GraphDefinition) GetPrecision() PrecisionT {
 	if g == nil || g.Precision == nil {
 		return ""
 	}
@@ -2906,7 +2906,7 @@ func (g *GraphDefinition) GetPrecision() json.Number {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (g *GraphDefinition) GetPrecisionOk() (json.Number, bool) {
+func (g *GraphDefinition) GetPrecisionOk() (PrecisionT, bool) {
 	if g == nil || g.Precision == nil {
 		return "", false
 	}
@@ -2923,7 +2923,7 @@ func (g *GraphDefinition) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new g.Precision and returns the pointer to it.
-func (g *GraphDefinition) SetPrecision(v json.Number) {
+func (g *GraphDefinition) SetPrecision(v PrecisionT) {
 	g.Precision = &v
 }
 
@@ -5469,6 +5469,37 @@ func (m *Monitor) SetType(v string) {
 	m.Type = &v
 }
 
+// GetEnableLogsSample returns the EnableLogsSample field if non-nil, zero value otherwise.
+func (o *Options) GetEnableLogsSample() bool {
+	if o == nil || o.EnableLogsSample == nil {
+		return false
+	}
+	return *o.EnableLogsSample
+}
+
+// GetEnableLogsSampleOk returns a tuple with the EnableLogsSample field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (o *Options) GetEnableLogsSampleOk() (bool, bool) {
+	if o == nil || o.EnableLogsSample == nil {
+		return false, false
+	}
+	return *o.EnableLogsSample, true
+}
+
+// HasEnableLogsSample returns a boolean if a field has been set.
+func (o *Options) HasEnableLogsSample() bool {
+	if o != nil && o.EnableLogsSample != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEnableLogsSample allocates a new o.EnableLogsSample and returns the pointer to it.
+func (o *Options) SetEnableLogsSample(v bool) {
+	o.EnableLogsSample = &v
+}
+
 // GetEscalationMessage returns the EscalationMessage field if non-nil, zero value otherwise.
 func (o *Options) GetEscalationMessage() string {
 	if o == nil || o.EscalationMessage == nil {
@@ -7795,7 +7826,7 @@ func (t *TileDef) SetNoMetricHosts(v bool) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (t *TileDef) GetPrecision() json.Number {
+func (t *TileDef) GetPrecision() PrecisionT {
 	if t == nil || t.Precision == nil {
 		return ""
 	}
@@ -7804,7 +7835,7 @@ func (t *TileDef) GetPrecision() json.Number {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDef) GetPrecisionOk() (json.Number, bool) {
+func (t *TileDef) GetPrecisionOk() (PrecisionT, bool) {
 	if t == nil || t.Precision == nil {
 		return "", false
 	}
@@ -7821,7 +7852,7 @@ func (t *TileDef) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new t.Precision and returns the pointer to it.
-func (t *TileDef) SetPrecision(v json.Number) {
+func (t *TileDef) SetPrecision(v PrecisionT) {
 	t.Precision = &v
 }
 
@@ -10089,7 +10120,7 @@ func (w *Widget) SetParams(v Params) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (w *Widget) GetPrecision() string {
+func (w *Widget) GetPrecision() PrecisionT {
 	if w == nil || w.Precision == nil {
 		return ""
 	}
@@ -10098,7 +10129,7 @@ func (w *Widget) GetPrecision() string {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetPrecisionOk() (string, bool) {
+func (w *Widget) GetPrecisionOk() (PrecisionT, bool) {
 	if w == nil || w.Precision == nil {
 		return "", false
 	}
@@ -10115,7 +10146,7 @@ func (w *Widget) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new w.Precision and returns the pointer to it.
-func (w *Widget) SetPrecision(v string) {
+func (w *Widget) SetPrecision(v PrecisionT) {
 	w.Precision = &v
 }
 

--- a/vendor/github.com/zorkian/go-datadog-api/helpers.go
+++ b/vendor/github.com/zorkian/go-datadog-api/helpers.go
@@ -65,3 +65,17 @@ func GetJsonNumberOk(v *json.Number) (json.Number, bool) {
 
 	return "", false
 }
+
+// Precision is a helper routine that allocates a new precision value
+// to store v and returns a pointer to it.
+func Precision(v PrecisionT) *PrecisionT { return &v }
+
+// GetPrecision is a helper routine that returns a boolean representing
+// if a value was set, and if so, dereferences the pointer to it.
+func GetPrecision(v *PrecisionT) (PrecisionT, bool) {
+	if v != nil {
+		return *v, true
+	}
+
+	return PrecisionT(""), false
+}

--- a/vendor/github.com/zorkian/go-datadog-api/monitors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/monitors.go
@@ -61,6 +61,7 @@ type Options struct {
 	IncludeTags       *bool             `json:"include_tags,omitempty"`
 	RequireFullWindow *bool             `json:"require_full_window,omitempty"`
 	Locked            *bool             `json:"locked,omitempty"`
+	EnableLogsSample  *bool             `json:"enable_logs_sample,omitempty"`
 }
 
 type TriggeringValue struct {

--- a/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
@@ -2,6 +2,31 @@ package datadog
 
 import "encoding/json"
 
+type PrecisionT string
+
+// UnmarshalJSON is a Custom Unmarshal for PrecisionT. The Datadog API can
+// return 1 (int), "1" (number, but a string type) or something like "100%" or
+// "*" (string).
+func (p *PrecisionT) UnmarshalJSON(data []byte) error {
+	var err error
+	var precisionNum json.Number
+	if err = json.Unmarshal(data, &precisionNum); err == nil {
+		*p = PrecisionT(precisionNum)
+		return nil
+	}
+
+	var precisionStr string
+	if err = json.Unmarshal(data, &precisionStr); err == nil {
+		*p = PrecisionT(precisionStr)
+		return nil
+	}
+
+	var p0 PrecisionT
+	*p = p0
+
+	return err
+}
+
 type TileDef struct {
 	Events     []TileDefEvent   `json:"events,omitempty"`
 	Markers    []TileDefMarker  `json:"markers,omitempty"`
@@ -9,7 +34,7 @@ type TileDef struct {
 	Viz        *string          `json:"viz,omitempty"`
 	CustomUnit *string          `json:"custom_unit,omitempty"`
 	Autoscale  *bool            `json:"autoscale,omitempty"`
-	Precision  *json.Number     `json:"precision,omitempty"`
+	Precision  *PrecisionT      `json:"precision,omitempty"`
 	TextAlign  *string          `json:"text_align,omitempty"`
 
 	// For hostmap
@@ -104,9 +129,9 @@ type Widget struct {
 	Color *string `json:"color,omitempty"`
 
 	// For AlertValue widget
-	TextSize  *string `json:"text_size,omitempty"`
-	Unit      *string `json:"unit,omitempty"`
-	Precision *string `json:"precision,omitempty"`
+	TextSize  *string     `json:"text_size,omitempty"`
+	Unit      *string     `json:"unit,omitempty"`
+	Precision *PrecisionT `json:"precision,omitempty"`
 
 	// AlertGraph widget
 	VizType *string `json:"viz_type,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -932,12 +932,10 @@
 			"revisionTime": "2018-10-17T23:26:04Z"
 		},
 		{
-			"checksumSHA1": "789joLgasdUcxF6qQy8Pn+IfGhw=",
+			"checksumSHA1": "R+mXTTMaw8ucB7pQDD0p+X13dK8=",
 			"path": "github.com/zorkian/go-datadog-api",
-			"revision": "f3f6d2f4859047aae0cac1ce3d16689608480fd9",
-			"revisionTime": "2018-11-12T21:37:59Z",
-			"version": "v2.18.0",
-			"versionExact": "v2.18.0"
+			"revision": "1df5bda80d16ccfa8e99c543dbeb731665acbfca",
+			"revisionTime": "2018-11-27T19:12:41Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
Updated `go-datadog-api` to `master` in order to include https://github.com/zorkian/go-datadog-api/pull/194 and partially address #117 (one fix is still missing, see https://github.com/zorkian/go-datadog-api/pull/195):
```
govendor fetch github.com/zorkian/go-datadog-api/...@1df5bda80d16ccfa8e99c543dbeb731665acbfca
```

Also fixed a bug introduced in #121, now `include_units` and `include_zero` are fully supported.