### PR TITLE
Adds ThresholdWindows

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -95,6 +95,22 @@ func resourceDatadogMonitor() *schema.Resource {
 				},
 				DiffSuppressFunc: suppressDataDogFloatIntDiff,
 			},
+			"threshold_windows": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"recovery_window": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"trigger_window": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"notify_no_data": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -177,8 +193,19 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 		thresholds.SetCriticalRecovery(json.Number(r.(string)))
 	}
 
+	var threshold_windows datadog.ThresholdWindows
+
+	if r, ok := d.GetOk("threshold_windows.recovery_window"); ok {
+		threshold_windows.SetRecoveryWindow(r.(string))
+	}
+
+	if r, ok := d.GetOk("threshold_windows.trigger_window"); ok {
+		threshold_windows.SetTriggerWindow(r.(string))
+	}
+
 	o := datadog.Options{
 		Thresholds:        &thresholds,
+		ThresholdWindows:  &threshold_windows,
 		NotifyNoData:      datadog.Bool(d.Get("notify_no_data").(bool)),
 		RequireFullWindow: datadog.Bool(d.Get("require_full_window").(bool)),
 		IncludeTags:       datadog.Bool(d.Get("include_tags").(bool)),
@@ -301,6 +328,16 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
+	thresholdWindows := make(map[string]string)
+	for k, v := range map[string]string{
+		"recovery_window": m.Options.ThresholdWindows.GetRecoveryWindow(),
+		"trigger_window":  m.Options.ThresholdWindows.GetTriggerWindow(),
+	} {
+		if v != "" {
+			thresholdWindows[k] = v
+		}
+	}
+
 	tags := []string{}
 	for _, s := range m.Tags {
 		tags = append(tags, s)
@@ -312,6 +349,7 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("query", m.GetQuery())
 	d.Set("type", m.GetType())
 	d.Set("thresholds", thresholds)
+	d.Set("threshold_windows", thresholdWindows)
 
 	d.Set("new_host_delay", m.Options.GetNewHostDelay())
 	d.Set("evaluation_delay", m.Options.GetEvaluationDelay())
@@ -384,6 +422,17 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 		if thresholds["critical_recovery"] != nil {
 			o.Thresholds.SetCriticalRecovery(json.Number(thresholds["critical_recovery"].(string)))
+		}
+	}
+
+	if attr, ok := d.GetOk("threshold_windows"); ok {
+		thresholdWindows := attr.(map[string]interface{})
+		o.ThresholdWindows = &datadog.ThresholdWindows{}
+		if thresholdWindows["recovery_window"] != nil {
+			o.ThresholdWindows.SetRecoveryWindow(thresholdWindows["recovery_window"].(string))
+		}
+		if thresholdWindows["trigger_window"] != nil {
+			o.ThresholdWindows.SetTriggerWindow(thresholdWindows["trigger_window"].(string))
 		}
 	}
 


### PR DESCRIPTION
Anomaly monitors allow for setting a "trigger_window" and "recovery_window" within a "threshold_windows" map, as mentioned in https://github.com/terraform-providers/terraform-provider-datadog/issues/73. This PR adds support for managing those values via Terraform.