### PR TITLE
add: support for enable_logs_sample

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -145,6 +145,11 @@ func resourceDatadogMonitor() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"enable_logs_sample": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"tags": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -182,6 +187,7 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 		NotifyNoData:      datadog.Bool(d.Get("notify_no_data").(bool)),
 		RequireFullWindow: datadog.Bool(d.Get("require_full_window").(bool)),
 		IncludeTags:       datadog.Bool(d.Get("include_tags").(bool)),
+		EnableLogsSample:  datadog.Bool(d.Get("enable_logs_sample").(bool)),
 	}
 	if attr, ok := d.GetOk("silenced"); ok {
 		s := make(map[string]int)
@@ -323,6 +329,7 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("escalation_message", m.Options.GetEscalationMessage())
 	d.Set("silenced", m.Options.Silenced)
 	d.Set("include_tags", m.Options.GetIncludeTags())
+	d.Set("enable_logs_sample", m.Options.GetEnableLogsSample())
 	d.Set("tags", tags)
 	d.Set("require_full_window", m.Options.GetRequireFullWindow()) // TODO Is this one of those options that we neeed to check?
 	d.Set("locked", m.Options.GetLocked())
@@ -363,6 +370,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		NotifyNoData:      datadog.Bool(d.Get("notify_no_data").(bool)),
 		RequireFullWindow: datadog.Bool(d.Get("require_full_window").(bool)),
 		IncludeTags:       datadog.Bool(d.Get("include_tags").(bool)),
+		EnableLogsSample:  datadog.Bool(d.Get("enable_logs_sample").(bool)),
 	}
 	if attr, ok := d.GetOk("thresholds"); ok {
 		thresholds := attr.(map[string]interface{})

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -186,6 +186,8 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "include_tags", "true"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "enable_logs_sample", "true"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
@@ -235,6 +237,8 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "timeout_h", "70"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "include_tags", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "enable_logs_sample", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "silenced.*", "0"),
 					resource.TestCheckResourceAttr(
@@ -310,6 +314,8 @@ func TestAccDatadogMonitor_UpdatedToRemoveTags(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "include_tags", "true"),
 					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "enable_logs_sample", "true"),
+					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
@@ -359,6 +365,8 @@ func TestAccDatadogMonitor_UpdatedToRemoveTags(t *testing.T) {
 						"datadog_monitor.foo", "timeout_h", "70"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "include_tags", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "enable_logs_sample", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "silenced.*", "0"),
 					resource.TestCheckResourceAttr(
@@ -510,6 +518,7 @@ resource "datadog_monitor" "foo" {
   new_host_delay = 600
   evaluation_delay = 700
   include_tags = true
+  enable_logs_sample = true
   require_full_window = true
   locked = false
   tags = ["foo:bar", "baz"]
@@ -530,6 +539,7 @@ resource "datadog_monitor" "foo" {
   notify_audit = false
   timeout_h = 60
   include_tags = true
+  enable_logs_sample = true
   require_full_window = true
   locked = false
   tags = ["foo:bar", "bar:baz"]
@@ -559,6 +569,7 @@ resource "datadog_monitor" "foo" {
   new_host_delay = 600
   evaluation_delay = 700
   include_tags = true
+  enable_logs_sample = true
   require_full_window = true
   locked = false
   tags = ["foo:bar", "baz"]
@@ -587,6 +598,7 @@ resource "datadog_monitor" "foo" {
   notify_audit        = false
   timeout_h           = 60
   include_tags        = true
+  enable_logs_sample  = true
   require_full_window = true
   locked              = false
 
@@ -616,6 +628,7 @@ resource "datadog_monitor" "foo" {
   notify_audit        = false
   timeout_h           = 60
   include_tags        = true
+  enable_logs_sample  = true
   require_full_window = true
   locked              = false
 
@@ -649,6 +662,7 @@ resource "datadog_monitor" "foo" {
   notify_audit = true
   timeout_h = 70
   include_tags = false
+  enable_logs_sample = false
   require_full_window = false
   locked = true
   silenced {
@@ -684,6 +698,7 @@ resource "datadog_monitor" "foo" {
   notify_audit = true
   timeout_h = 70
   include_tags = false
+  enable_logs_sample = false
   require_full_window = false
   locked = true
   silenced {
@@ -739,6 +754,7 @@ EOF
   notify_audit = false
   timeout_h = 60
   include_tags = true
+  enable_logs_sample = true
 }
 `
 

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -109,6 +109,9 @@ The following arguments are supported:
     from a triggered state. Defaults to false.
 * `include_tags` (Optional) A boolean indicating whether notifications from this monitor will automatically insert its
     triggering tags into the title. Defaults to true.
+* `enable_logs_sample` (Optional) A boolean indicating whether notifications from this monitor will automatically 
+    add up to 10 samples of logs that triggered the monitor in the notification message. This is available for `Log` monitor 
+    `type` and for `Slack` and `email` notifications. Defaults to false.
 * `require_full_window` (Optional) A boolean indicating whether this monitor needs a full window of data before it's evaluated.
     We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.
     Default: True for "on average", "at all times" and "in total" aggregation. False otherwise.


### PR DESCRIPTION
It is possible to add samples of logs that triggered the
monitor in the notification message. To enable it enable_logs_sample can
be used.

[#139]

Signed-off-by: Krzysztof Grodzicki <kgrodzicki@gmail.com>