### PR TITLE
Bump go client to include type fix in widget struct

### DIFF
--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -4,7 +4,7 @@
  *
  * Please see the included LICENSE file for licensing information.
  *
- * Copyright 2018 by authors and contributors.
+ * Copyright 2019 by authors and contributors.
 */
 
 package datadog
@@ -8601,7 +8601,7 @@ func (t *TileDefRequestStyle) SetWidth(v string) {
 }
 
 // GetFillMax returns the FillMax field if non-nil, zero value otherwise.
-func (t *TileDefStyle) GetFillMax() string {
+func (t *TileDefStyle) GetFillMax() json.Number {
 	if t == nil || t.FillMax == nil {
 		return ""
 	}
@@ -8610,7 +8610,7 @@ func (t *TileDefStyle) GetFillMax() string {
 
 // GetFillMaxOk returns a tuple with the FillMax field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDefStyle) GetFillMaxOk() (string, bool) {
+func (t *TileDefStyle) GetFillMaxOk() (json.Number, bool) {
 	if t == nil || t.FillMax == nil {
 		return "", false
 	}
@@ -8627,12 +8627,12 @@ func (t *TileDefStyle) HasFillMax() bool {
 }
 
 // SetFillMax allocates a new t.FillMax and returns the pointer to it.
-func (t *TileDefStyle) SetFillMax(v string) {
+func (t *TileDefStyle) SetFillMax(v json.Number) {
 	t.FillMax = &v
 }
 
 // GetFillMin returns the FillMin field if non-nil, zero value otherwise.
-func (t *TileDefStyle) GetFillMin() string {
+func (t *TileDefStyle) GetFillMin() json.Number {
 	if t == nil || t.FillMin == nil {
 		return ""
 	}
@@ -8641,7 +8641,7 @@ func (t *TileDefStyle) GetFillMin() string {
 
 // GetFillMinOk returns a tuple with the FillMin field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDefStyle) GetFillMinOk() (string, bool) {
+func (t *TileDefStyle) GetFillMinOk() (json.Number, bool) {
 	if t == nil || t.FillMin == nil {
 		return "", false
 	}
@@ -8658,7 +8658,7 @@ func (t *TileDefStyle) HasFillMin() bool {
 }
 
 // SetFillMin allocates a new t.FillMin and returns the pointer to it.
-func (t *TileDefStyle) SetFillMin(v string) {
+func (t *TileDefStyle) SetFillMin(v json.Number) {
 	t.FillMin = &v
 }
 

--- a/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
@@ -96,10 +96,10 @@ type TileDefRequestStyle struct {
 }
 
 type TileDefStyle struct {
-	Palette     *string `json:"palette,omitempty"`
-	PaletteFlip *string `json:"paletteFlip,omitempty"`
-	FillMin     *string `json:"fillMin,omitempty"`
-	FillMax     *string `json:"fillMax,omitempty"`
+	Palette     *string      `json:"palette,omitempty"`
+	PaletteFlip *string      `json:"paletteFlip,omitempty"`
+	FillMin     *json.Number `json:"fillMin,omitempty"`
+	FillMax     *json.Number `json:"fillMax,omitempty"`
 }
 
 type Time struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -932,10 +932,10 @@
 			"revisionTime": "2018-10-17T23:26:04Z"
 		},
 		{
-			"checksumSHA1": "R+mXTTMaw8ucB7pQDD0p+X13dK8=",
+			"checksumSHA1": "KqKn8fgDlP/829BxJhJTROtGsVA=",
 			"path": "github.com/zorkian/go-datadog-api",
-			"revision": "1df5bda80d16ccfa8e99c543dbeb731665acbfca",
-			"revisionTime": "2018-11-27T19:12:41Z"
+			"revision": "66f4fd4202d9d3e543608051a91a09eebc870966",
+			"revisionTime": "2019-01-08T23:45:54Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
Update the `go-datadog-api` to include https://github.com/zorkian/go-datadog-api/pull/202. 

```
govendor fetch github.com/zorkian/go-datadog-api/...@66f4fd4202d9d3e543608051a91a09eebc870966
```

Aims to fix the `cannot unmarshal number into Go struct field TileDefStyle.fillMax of type string ` when using decimal numbers in `FillMin` and/or `FillMax`