### PR TITLE
Fix order for reading start times on downtime

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -172,12 +172,12 @@ func buildDowntimeStruct(d *schema.ResourceData) *datadog.Downtime {
 		scope = append(scope, s.(string))
 	}
 	dt.Scope = scope
-	if attr, ok := d.GetOk("start"); ok {
-		dt.SetStart(attr.(int))
-	} else if attr, ok := d.GetOk("start_date"); ok {
+	if attr, ok := d.GetOk("start_date"); ok {
 		if t, err := time.Parse(time.RFC3339, attr.(string)); err == nil {
 			dt.SetStart(int(t.Unix()))
 		}
+	} else if attr, ok := d.GetOk("start"); ok {
+		dt.SetStart(attr.(int))
 	}
 
 	return &dt

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -129,13 +129,14 @@ func buildDowntimeStruct(d *schema.ResourceData) *datadog.Downtime {
 	if attr, ok := d.GetOk("disabled"); ok {
 		dt.SetDisabled(attr.(bool))
 	}
-	if attr, ok := d.GetOk("end"); ok {
-		dt.SetEnd(attr.(int))
-	} else if attr, ok := d.GetOk("end_date"); ok {
+	if attr, ok := d.GetOk("end_date"); ok {
 		if t, err := time.Parse(time.RFC3339, attr.(string)); err == nil {
 			dt.SetEnd(int(t.Unix()))
 		}
+	} else if attr, ok := d.GetOk("end"); ok {
+		dt.SetEnd(attr.(int))
 	}
+
 	if attr, ok := d.GetOk("message"); ok {
 		dt.SetMessage(strings.TrimSpace(attr.(string)))
 	}


### PR DESCRIPTION
This PR fixes the order for reading the start dates and end dates for downtimes.

Currently, if you use `start_date` or `end_date` in your configuration file, you can create the initial downtime OK. However, when you run terraform apply, Terraform will notice that the state is different than whats in the config and attempt to update it. However, since the build downtime struct saw that the `start` field was in the state, it used that instead of the user provided start_date. This makes sure we take precedence of the start_date field. 

If the user specifies the `start` and `end` this functionality will still work as expected. 