### PR TITLE
Add missing AWS integration link

### DIFF
--- a/website/datadog.erb
+++ b/website/datadog.erb
@@ -34,6 +34,9 @@
             <li<%= sidebar_current("docs-datadog-resource-integration_gcp") %>>
               <a href="/docs/providers/datadog/r/integration_gcp.html">datadog_integration_gcp</a>
             </li>
+            <li<%= sidebar_current("docs-datadog-resource-integration_aws") %>>
+              <a href="/docs/providers/datadog/r/integration_aws.html">datadog_integration_aws</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
Since it was missing from https://www.terraform.io/docs/providers/datadog/index.html. 