### PR TITLE
Add support for enable_logs_sample option in log monitors

### DIFF
--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -468,6 +468,46 @@ func TestAccDatadogMonitor_Basic_float_int(t *testing.T) {
 	})
 }
 
+func TestAccDatadogMonitor_Log(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatadogMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogMonitorConfigLogAlert,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogMonitorExists("datadog_monitor.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "name", "name for monitor foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "message", "some message Notify: @hipchat-channel"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "type", "log alert"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "query", "logs(\"service:foo AND type:error\").index(\"main\").rollup(\"count\").last(\"5m\") > 100"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "notify_no_data", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "renotify_interval", "60"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.ok", "0.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning", "1.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.5"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical", "2.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "thresholds.critical_recovery", "1.5"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "enable_logs_sample", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDatadogMonitorDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*datadog.Client)
 
@@ -739,6 +779,36 @@ EOF
   notify_audit = false
   timeout_h = 60
   include_tags = true
+}
+`
+
+const testAccCheckDatadogMonitorConfigLogAlert = `
+resource "datadog_monitor" "foo" {
+  name = "name for monitor foo"
+  type = "log alert"
+  message = "some message Notify: @hipchat-channel"
+  escalation_message = "the situation has escalated @pagerduty"
+
+  query = "logs(\"service:foo AND type:error\").index(\"main\").rollup(\"count\").last(\"5m\") > 2"
+
+  thresholds {
+	warning = "1.0"
+	critical = "2.0"
+	warning_recovery = "0.5"
+	critical_recovery = "1.5"
+  }
+
+  renotify_interval = 60
+
+  notify_audit = false
+  timeout_h = 60
+  new_host_delay = 600
+  evaluation_delay = 700
+  include_tags = true
+  require_full_window = true
+  locked = false
+  tags = ["foo:bar", "baz"]
+	enable_logs_sample = true
 }
 `
 

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -108,6 +108,7 @@ The following arguments are supported:
 * `timeout_h` (Optional) The number of hours of the monitor not reporting data before it will automatically resolve
     from a triggered state. Defaults to false.
 * `include_tags` (Optional) A boolean indicating whether notifications from this monitor will automatically insert its
+* `enable_logs_sample` (Optional) A boolean indicating whether or not to include a list of log values which triggered the alert. Defaults to false. This is only used by log monitors.
     triggering tags into the title. Defaults to true.
 * `require_full_window` (Optional) A boolean indicating whether this monitor needs a full window of data before it's evaluated.
     We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.


### PR DESCRIPTION
This may need more testing 😬 

Goal is to expose the `enable_logs_sample` option for log alert monitors which corresponds to the checkbox on the UI to enable capturing log samples that triggered the alert.
<img width="376" alt="screenshot 2019-02-13 10 47 21" src="https://user-images.githubusercontent.com/7022669/52732213-e7a04000-2f7c-11e9-81b0-0228078a3e68.png">

Related issue: https://github.com/terraform-providers/terraform-provider-datadog/issues/139
