### PR TITLE
provider: Enable request/response logging

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -1,10 +1,11 @@
 package datadog
 
 import (
+	"errors"
 	"log"
 
-	"errors"
-
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	datadog "github.com/zorkian/go-datadog-api"
@@ -51,8 +52,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if apiURL := d.Get("api_url").(string); apiURL != "" {
 		client.SetBaseUrl(apiURL)
 	}
-	log.Println("[INFO] Datadog client successfully initialized, now validating...")
 
+	c := cleanhttp.DefaultClient()
+	c.Transport = logging.NewTransport("Datadog", c.Transport)
+	client.HttpClient = c
+
+	log.Println("[INFO] Datadog client successfully initialized, now validating...")
 	ok, err := client.Validate()
 	if err != nil {
 		log.Printf("[ERROR] Datadog Client validation error: %v", err)


### PR DESCRIPTION
This makes debugging for developers & users of this provider easier by exposing all requests & responses in the log (when >`DEBUG` severity is set).

Example:

```
---[ REQUEST ]---------------------------------------
GET /api/v1/validate?api_key=<redacted>&application_key=<redacted> HTTP/1.1
Host: app.datadoghq.com
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip


-----------------------------------------------------
2019/02/22 17:48:23 [DEBUG] Datadog API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Content-Length: 14
Cache-Control: no-cache
Content-Type: application/json
Date: Fri, 22 Feb 2019 17:48:23 GMT
Dd-Pool: dogweb_sameorig
Pragma: no-cache
Set-Cookie: DD-PSHARD=142; Max-Age=604800; Path=/; expires=Fri, 01-Mar-2019 17:48:23 GMT; secure; HttpOnly
Strict-Transport-Security: max-age=15724800;
X-Content-Type-Options: nosniff
X-Dd-Debug: AM8wdI5wmkcycoUV3o2mawzOJdnLoh3juxdopzF9Hy4fXsSGgSiUlZqFn3zFnz/j
X-Dd-Version: 35.1079256
X-Frame-Options: SAMEORIGIN

{
 "valid": true
}
-----------------------------------------------------
```