### PR TITLE
Change monitor element schema to TypeString

### DIFF
--- a/datadog/resource_datadog_screenboard.go
+++ b/datadog/resource_datadog_screenboard.go
@@ -499,7 +499,7 @@ func resourceDatadogScreenboard() *schema.Resource {
 				"monitor": {
 					Type:     schema.TypeMap,
 					Optional: true,
-					Elem:     &schema.Schema{Type: schema.TypeInt},
+					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
 			},
 		},


### PR DESCRIPTION
The element type is set to `schema.TypeInt`, which does not allow us to
do interpolation. By changing this type to string all seem to work
correctly.

Our terraform configuration
```
monitor {
  id = "${module.poller_latency.id}"
}
```

The error we are seeing is this:
```
widget.0.monitor (id): cannot parse '' as int: strconv.ParseInt: parsing "${module.poller_latency.id}": invalid syntax
```

Feel free to close this PR if this is a not relevant / breaking change, i could be missing context here.