### PR TITLE
Add access_role to resource_datadog_user

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -40,6 +40,11 @@ func resourceDatadogUser() *schema.Resource {
 				Default:    false,
 				Deprecated: "This parameter will be replaced by `access_role` and will be removed from the next Major version",
 			},
+			"access_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Required: false,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -81,6 +86,7 @@ func resourceDatadogUserCreate(d *schema.ResourceData, meta interface{}) error {
 	u.SetHandle(d.Get("handle").(string))
 	u.SetIsAdmin(d.Get("is_admin").(bool))
 	u.SetName(d.Get("name").(string))
+	u.SetAccessRole(d.Get("access_role").(string))
 
 	// Datadog does not actually delete users, so CreateUser might return a 409.
 	// We ignore that case and proceed, likely re-enabling the user.
@@ -114,7 +120,7 @@ func resourceDatadogUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("is_admin", u.GetIsAdmin())
 	d.Set("name", u.GetName())
 	d.Set("verified", u.GetVerified())
-
+	d.Set("access_role", u.GetAccessRole())
 	return nil
 }
 
@@ -126,6 +132,7 @@ func resourceDatadogUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	u.SetHandle(d.Id())
 	u.SetIsAdmin(d.Get("is_admin").(bool))
 	u.SetName(d.Get("name").(string))
+	u.SetAccessRole(d.Get("access_role").(string))
 
 	if err := client.UpdateUser(u); err != nil {
 		return fmt.Errorf("error updating user: %s", err.Error())

--- a/datadog/resource_datadog_user_test.go
+++ b/datadog/resource_datadog_user_test.go
@@ -46,6 +46,8 @@ func TestAccDatadogUser_Updated(t *testing.T) {
 						"datadog_user.foo", "name", "Updated User"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "verified", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_user.foo", "access_role", "adm"),
 				),
 			},
 		},
@@ -73,19 +75,20 @@ func testAccCheckDatadogUserExists(n string) resource.TestCheckFunc {
 
 const testAccCheckDatadogUserConfigRequired = `
 resource "datadog_user" "foo" {
-  email  = "test@example.com"
-  handle = "test@example.com"
-  name   = "Test User"
+  email     = "test@example.com"
+  handle    = "test@example.com"
+  name      = "Test User"
 }
 `
 
 const testAccCheckDatadogUserConfigUpdated = `
 resource "datadog_user" "foo" {
-  disabled = true
-  email    = "updated@example.com"
-  handle   = "test@example.com"
-  is_admin = true
-  name     = "Updated User"
+  disabled    = true
+  email       = "updated@example.com"
+  handle      = "test@example.com"
+  is_admin    = true
+  access_role = "adm"
+  name        = "Updated User"
 }
 `
 


### PR DESCRIPTION
Datadog now can add 'access_role'  property when create Datadog users, but Terraform was not supported 'access_role' property. #4 is request of that so I added this function.