### PR TITLE
Add monitor_tags getting and setting to downtime resource

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -116,6 +116,11 @@ func resourceDatadogDowntime() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"monitor_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -173,6 +178,11 @@ func buildDowntimeStruct(d *schema.ResourceData) *datadog.Downtime {
 		scope = append(scope, s.(string))
 	}
 	dt.Scope = scope
+	tags := []string{}
+	for _, mt := range d.Get("monitor_tags").([]interface{}) {
+		tags = append(tags, mt.(string))
+	}
+	dt.MonitorTags = tags
 	if attr, ok := d.GetOk("start_date"); ok {
 		if t, err := time.Parse(time.RFC3339, attr.(string)); err == nil {
 			dt.SetStart(int(t.Unix()))
@@ -276,6 +286,7 @@ func resourceDatadogDowntimeRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("recurrence", recurrenceList)
 	}
 	d.Set("scope", dt.Scope)
+	d.Set("monitor_tags", dt.MonitorTags)
 	d.Set("start", dt.GetStart())
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 // indirect
-  github.com/zorkian/go-datadog-api v2.20.0+incompatible
+	github.com/zorkian/go-datadog-api v2.20.0+incompatible
 	golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519 // indirect
 	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,8 @@ github.com/zclconf/go-cty v0.0.0-20180302160414-49fa5e03c418/go.mod h1:LnDKxj8gN
 github.com/zclconf/go-cty v0.0.0-20180815031001-58bb2bc0302a/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 h1:Y9SzKuDy2J5QLFPmFk7/ZIzbu4/FrQK9Zwv4vjivNiM=
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zorkian/go-datadog-api v2.19.0+incompatible h1:G17NtfeHwrsQ2degevkwiVEirZENSOjbGOjLLT/kwa4=
-github.com/zorkian/go-datadog-api v2.19.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.19.1-0.20190415084127-efa96fedb363+incompatible h1:uQBFFHBO8CiSo/Gp4E7vzE6cj2TTtZ/SuGO4nDyCY3g=
+github.com/zorkian/go-datadog-api v2.19.1-0.20190415084127-efa96fedb363+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 github.com/zorkian/go-datadog-api v2.20.0+incompatible h1:zfITezz+b9lZuYghMXTdAXBdJe7HRAyU72kKnx876k8=
 github.com/zorkian/go-datadog-api v2.20.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 golang.org/x/crypto v0.0.0-20180211211603-9de5f2eaf759/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -7333,7 +7333,6 @@ func (h *HostActionMute) SetOverride(v bool) {
 // GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 func (h *HostmapDefinition) GetNodeType() string {
 	if h == nil || h.NodeType == nil {
-
 		return ""
 	}
 	return *h.NodeType
@@ -8761,7 +8760,6 @@ func (i *IntegrationGCPUpdateRequest) SetClientEmail(v string) {
 func (i *IntegrationGCPUpdateRequest) GetHostFilters() string {
 	if i == nil || i.HostFilters == nil {
 		return ""
-
 	}
 	return *i.HostFilters
 }


### PR DESCRIPTION
Add monitor tags to the downtime resource to address https://github.com/terraform-providers/terraform-provider-datadog/issues/162.

My first real foray into go and terraform, so let me know if I did anything wrong. Mostly copied a bunch of stuff.

The tests pass locally, but I refrained from running the acceptance tests locally because of the note mentioning that it costs money to run them. I'm hoping CI will catch any issues there.

However, things are gonna fail until https://github.com/zorkian/go-datadog-api/pull/227 gets merged in.