### PR TITLE
Document HCL limitation of key interpolation. Fixes #159

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -127,6 +127,17 @@ The following arguments are supported:
           "role:db" = 1412798116
         }
 
+    Note: due to [HCL limitations](https://github.com/hashicorp/terraform/issues/2042), it is impossible to use interpolations in keys.
+    For example, the following will result in muting the scope `role:${var:role}` (no interpolation is done):
+
+        silenced {
+            "role:${var:role}" = 0
+        }
+
+    To workaround this, you can use the [map function](https://www.terraform.io/docs/configuration/functions/map.html) of HCL:
+
+        silenced = ${map("role:${var:role}", 0)}
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This documents the limitation of key interpolation that was hit in #159 and suggests a working solution for the usecase. I don't see a better way to solve this, as it is an HCL limitation (so something that should get interpolated even before it gets passed to the provider).