### PR TITLE
Set the default for graph precision

### DIFF
--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -190,6 +190,7 @@ func resourceDatadogTimeboard() *schema.Resource {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: "How many digits to show",
+					Default:     "2",
 				},
 				"custom_unit": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
This sets the default to "2" for the graph precision in dashboards. Otherwise,
the API returns a value different from our state, and we always see a
difference.

See issue #142.