### PR TITLE
Re-order doc links, and add synthetics link

### DIFF
--- a/website/datadog.erb
+++ b/website/datadog.erb
@@ -16,26 +16,26 @@
             <li<%= sidebar_current("docs-datadog-resource-downtime") %>>
               <a href="/docs/providers/datadog/r/downtime.html">datadog_downtime</a>
             </li>
-            <li<%= sidebar_current("docs-datadog-resource-monitor") %>>
-              <a href="/docs/providers/datadog/r/monitor.html">datadog_monitor</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-timeboard") %>>
-              <a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-screenboard") %>>
-              <a href="/docs/providers/datadog/r/screenboard.html">datadog_screenboard</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-metric_metadata") %>>
-              <a href="/docs/providers/datadog/r/metric_metadata.html">datadog_metric_metadata</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-user") %>>
-              <a href="/docs/providers/datadog/r/user.html">datadog_user</a>
+            <li<%= sidebar_current("docs-datadog-resource-integration_aws") %>>
+              <a href="/docs/providers/datadog/r/integration_aws.html">datadog_integration_aws</a>
             </li>
             <li<%= sidebar_current("docs-datadog-resource-integration_gcp") %>>
               <a href="/docs/providers/datadog/r/integration_gcp.html">datadog_integration_gcp</a>
             </li>
-            <li<%= sidebar_current("docs-datadog-resource-integration_aws") %>>
-              <a href="/docs/providers/datadog/r/integration_aws.html">datadog_integration_aws</a>
+            <li<%= sidebar_current("docs-datadog-resource-metric_metadata") %>>
+              <a href="/docs/providers/datadog/r/metric_metadata.html">datadog_metric_metadata</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-monitor") %>>
+              <a href="/docs/providers/datadog/r/monitor.html">datadog_monitor</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-screenboard") %>>
+              <a href="/docs/providers/datadog/r/screenboard.html">datadog_screenboard</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-timeboard") %>>
+              <a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-user") %>>
+              <a href="/docs/providers/datadog/r/user.html">datadog_user</a>
             </li>
           </ul>
         </li>

--- a/website/datadog.erb
+++ b/website/datadog.erb
@@ -31,6 +31,9 @@
             <li<%= sidebar_current("docs-datadog-resource-screenboard") %>>
               <a href="/docs/providers/datadog/r/screenboard.html">datadog_screenboard</a>
             </li>
+            <li<%= sidebar_current("docs-datadog-resource-synthetics") %>>
+              <a href="/docs/providers/datadog/r/synthetics.html">datadog_synthetics</a>
+            </li>
             <li<%= sidebar_current("docs-datadog-resource-timeboard") %>>
               <a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
             </li>


### PR DESCRIPTION
Re-order the links by alphabetical order (like eg. AWS does), and add the link to the datadog_synthetics docs page.