### PR TITLE
Update the stable-website with whats on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## 1.8.1 (Unreleased)
 ## 1.8.0 (April 15, 2019)
 
 INTERNAL:

--- a/website/datadog.erb
+++ b/website/datadog.erb
@@ -16,26 +16,29 @@
             <li<%= sidebar_current("docs-datadog-resource-downtime") %>>
               <a href="/docs/providers/datadog/r/downtime.html">datadog_downtime</a>
             </li>
-            <li<%= sidebar_current("docs-datadog-resource-monitor") %>>
-              <a href="/docs/providers/datadog/r/monitor.html">datadog_monitor</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-timeboard") %>>
-              <a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-screenboard") %>>
-              <a href="/docs/providers/datadog/r/screenboard.html">datadog_screenboard</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-metric_metadata") %>>
-              <a href="/docs/providers/datadog/r/metric_metadata.html">datadog_metric_metadata</a>
-            </li>
-            <li<%= sidebar_current("docs-datadog-resource-user") %>>
-              <a href="/docs/providers/datadog/r/user.html">datadog_user</a>
+            <li<%= sidebar_current("docs-datadog-resource-integration_aws") %>>
+              <a href="/docs/providers/datadog/r/integration_aws.html">datadog_integration_aws</a>
             </li>
             <li<%= sidebar_current("docs-datadog-resource-integration_gcp") %>>
               <a href="/docs/providers/datadog/r/integration_gcp.html">datadog_integration_gcp</a>
             </li>
-            <li<%= sidebar_current("docs-datadog-resource-integration_aws") %>>
-              <a href="/docs/providers/datadog/r/integration_aws.html">datadog_integration_aws</a>
+            <li<%= sidebar_current("docs-datadog-resource-metric_metadata") %>>
+              <a href="/docs/providers/datadog/r/metric_metadata.html">datadog_metric_metadata</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-monitor") %>>
+              <a href="/docs/providers/datadog/r/monitor.html">datadog_monitor</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-screenboard") %>>
+              <a href="/docs/providers/datadog/r/screenboard.html">datadog_screenboard</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-synthetics") %>>
+              <a href="/docs/providers/datadog/r/synthetics.html">datadog_synthetics</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-timeboard") %>>
+              <a href="/docs/providers/datadog/r/timeboard.html">datadog_timeboard</a>
+            </li>
+            <li<%= sidebar_current("docs-datadog-resource-user") %>>
+              <a href="/docs/providers/datadog/r/user.html">datadog_user</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
We were missing the documentation link for the new synthetics resource. 
Essentially merges this PR into the `stable-website` branch - https://github.com/terraform-providers/terraform-provider-datadog/pull/174