### PR TITLE
Changelog and tidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 1.8.1 (Unreleased)
+## 1.9.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* `datadog_downtime`:  Add `monitor_tags` getting and setting [GH-167]
+* `datadog_monitor`: Add support for `enable_logs` in log monitors [GH-151]
+* Support importing dashboards using the new string ID [GH-184]
+* Various documentation fixes and improvements [GH-152, GH-171, GH-176, GH-178, GH-180, GH-183]
+
 ## 1.8.0 (April 15, 2019)
 
 INTERNAL:

--- a/go.sum
+++ b/go.sum
@@ -9,14 +9,6 @@ github.com/Azure/go-ntlmssp v0.0.0-20170803034930-c92175d54006/go.mod h1:chxPXzS
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290 h1:K9I21XUHNbYD3GNMmJBN0UKJCpdP+glftwNZ7Bo8kqY=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DHowett/go-plist v0.0.0-20180609054337-500bd5b9081b/go.mod h1:5paT5ZDrOm8eAJPem2Bd+q3FTi3Gxm/U4tb2tH8YIUQ=
-github.com/DataDog/go-datadog-api v0.0.0-20190402145118-e4672b7066ac h1:2lpq/xj2C5pKzMPDRSLaakf7BomK3InPfcq42S/vAf4=
-github.com/DataDog/go-datadog-api v0.0.0-20190402145118-e4672b7066ac/go.mod h1:M39kErhCx5HcdIQ1FA2NHJSWPA6qvUGkJ/Bhz6MAOa4=
-github.com/DataDog/go-datadog-api v0.0.0-20190403100613-64d00d08241a h1:xutdLApqBruGT3dYCw+18pDWiYXRaHZxf94SaOB97Vc=
-github.com/DataDog/go-datadog-api v0.0.0-20190403100613-64d00d08241a/go.mod h1:M39kErhCx5HcdIQ1FA2NHJSWPA6qvUGkJ/Bhz6MAOa4=
-github.com/DataDog/go-datadog-api v0.0.0-20190409090430-627e185509df h1:hUKMb79rABpaespgHpSekKoALS47XPID/Ni6fRfmivo=
-github.com/DataDog/go-datadog-api v0.0.0-20190409090430-627e185509df/go.mod h1:M39kErhCx5HcdIQ1FA2NHJSWPA6qvUGkJ/Bhz6MAOa4=
-github.com/DataDog/go-datadog-api v0.0.0-20190409155204-5497235f061d h1:qWou04uTL243M06V6n7CB4LadBxNPGhv/TREJa9OVik=
-github.com/DataDog/go-datadog-api v0.0.0-20190409155204-5497235f061d/go.mod h1:M39kErhCx5HcdIQ1FA2NHJSWPA6qvUGkJ/Bhz6MAOa4=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
@@ -144,8 +136,6 @@ github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoD
 github.com/hashicorp/go-slug v0.2.0 h1:MVdZAkTmDsUi1AT+3NQDsn8n3ssnVSIHwiM6RcUHvE8=
 github.com/hashicorp/go-slug v0.2.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-tfe v0.3.10 h1:6uPnPHNPxXDe3k/Vt6fovygYTaWJ8f/7zdHc++f7NJU=
-github.com/hashicorp/go-tfe v0.3.10/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-tfe v0.3.11/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -164,8 +154,6 @@ github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3/go.mod h1:QIAnN
 github.com/hashicorp/memberlist v0.0.0-20170208211506-23ad4b7d7b38/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.8.2-0.20171022020050-c20a0b1b1ea9 h1:SYvpFFTluyu7KQoR1vFbk72jMMeXa8TedEo9VihOiI4=
 github.com/hashicorp/serf v0.8.2-0.20171022020050-c20a0b1b1ea9/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
-github.com/hashicorp/terraform v0.11.12-beta1.0.20190227065421-fc531f54a878 h1:BEtsPcwrOE8gFSU/SPbY9mdr1CHsKAvEeZqh2PWNVqo=
-github.com/hashicorp/terraform v0.11.12-beta1.0.20190227065421-fc531f54a878/go.mod h1:pR/Ri/puIH6hcylTZLaCDDS/16fCkjGr+/VGfHdb9zk=
 github.com/hashicorp/terraform v0.11.13 h1:1Ka1IPqYNCu3yIZUW1OAnZjQaacNnnZne2AEmWRCm0o=
 github.com/hashicorp/terraform v0.11.13/go.mod h1:aSdr9xVNED8nCdH3naa31VNUaWo63itXzRBe4f1q5HM=
 github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4 h1:SGDekHLK2IRoVS7Fb4olLyWvc2VmwKgyFC05j6X3NII=
@@ -304,8 +292,6 @@ github.com/zclconf/go-cty v0.0.0-20180302160414-49fa5e03c418/go.mod h1:LnDKxj8gN
 github.com/zclconf/go-cty v0.0.0-20180815031001-58bb2bc0302a/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 h1:Y9SzKuDy2J5QLFPmFk7/ZIzbu4/FrQK9Zwv4vjivNiM=
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zorkian/go-datadog-api v2.19.1-0.20190415084127-efa96fedb363+incompatible h1:uQBFFHBO8CiSo/Gp4E7vzE6cj2TTtZ/SuGO4nDyCY3g=
-github.com/zorkian/go-datadog-api v2.19.1-0.20190415084127-efa96fedb363+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 github.com/zorkian/go-datadog-api v2.20.0+incompatible h1:zfITezz+b9lZuYghMXTdAXBdJe7HRAyU72kKnx876k8=
 github.com/zorkian/go-datadog-api v2.20.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 golang.org/x/crypto v0.0.0-20180211211603-9de5f2eaf759/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
This PR contains two commits that I wanted to do before 1.9.0 release:

* tidy up the `go.sum` file (I just ran `go mod tidy`)
* update of `CHANGELOG.md`