### PR TITLE
Fix various acceptance tests failures

### DIFF
--- a/datadog/import_datadog_downtime_test.go
+++ b/datadog/import_datadog_downtime_test.go
@@ -33,5 +33,6 @@ resource "datadog_downtime" "foo" {
   end   = 1735765200
 
   message = "Example Datadog downtime message."
+  monitor_tags = ["*"]
 }
 `

--- a/datadog/resource_datadog_downtime_test.go
+++ b/datadog/resource_datadog_downtime_test.go
@@ -35,6 +35,8 @@ func TestAccDatadogDowntime_Basic(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -107,6 +109,8 @@ func TestAccDatadogDowntime_BasicMultiScope(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -131,6 +135,8 @@ func TestAccDatadogDowntime_BasicNoRecurrence(t *testing.T) {
 						"datadog_downtime.foo", "end", "1735765200"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -161,6 +167,8 @@ func TestAccDatadogDowntime_BasicUntilDateRecurrence(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.until_date", "1736226000"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -191,6 +199,8 @@ func TestAccDatadogDowntime_BasicUntilOccurrencesRecurrence(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.until_occurrences", "5"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -223,6 +233,8 @@ func TestAccDatadogDowntime_WeekDayRecurring(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.week_days.1", "Sun"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -251,6 +263,8 @@ func TestAccDatadogDowntime_Updated(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 			{
@@ -269,6 +283,8 @@ func TestAccDatadogDowntime_Updated(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "3"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -297,6 +313,8 @@ func TestAccDatadogDowntime_TrimWhitespace(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -344,6 +362,8 @@ func TestAccDatadogDowntimeDates(t *testing.T) {
 						"datadog_downtime.foo", "recurrence.0.period", "1"),
 					resource.TestCheckResourceAttr(
 						"datadog_downtime.foo", "message", "Example Datadog downtime message."),
+					resource.TestCheckResourceAttr(
+						"datadog_downtime.foo", "monitor_tags.0", "*"),
 				),
 			},
 		},
@@ -379,7 +399,8 @@ resource "datadog_downtime" "foo" {
     period = 1
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+  monitor_tags = ["*"]
 }
 `
 
@@ -396,7 +417,8 @@ resource "datadog_downtime" "foo" {
     period = 1
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+  monitor_tags = ["*"]
 }
 `
 
@@ -411,7 +433,8 @@ resource "datadog_downtime" "foo" {
     period = 1
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+  monitor_tags = ["*"]
 }
 `
 
@@ -442,7 +465,8 @@ resource "datadog_downtime" "foo" {
   end   = %d
 
   message = "Example Datadog downtime message."
-  monitor_id = "${datadog_monitor.downtime_monitor.id}"
+	monitor_id = "${datadog_monitor.downtime_monitor.id}"
+  monitor_tags = ["*"]
 }
 `, end, start, end)
 }
@@ -491,7 +515,8 @@ resource "datadog_downtime" "foo" {
     period = 1
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+	monitor_tags = ["*"]
 }
 `
 
@@ -500,7 +525,8 @@ resource "datadog_downtime" "foo" {
   scope = ["host:NoRecurrence"]
   start = 1735707600
   end   = 1735765200
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+	monitor_tags = ["*"]
 }
 `
 
@@ -516,7 +542,8 @@ resource "datadog_downtime" "foo" {
 	until_date = 1736226000
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+	monitor_tags = ["*"]
 }
 `
 
@@ -532,7 +559,8 @@ resource "datadog_downtime" "foo" {
 	until_occurrences = 5
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+	monitor_tags = ["*"]
 }
 `
 
@@ -549,6 +577,7 @@ resource "datadog_downtime" "foo" {
   }
 
 	message = "Example Datadog downtime message."
+	monitor_tags = ["*"]
 }
 `
 
@@ -563,7 +592,8 @@ resource "datadog_downtime" "foo" {
     period = 3
   }
 
-  message = "Example Datadog downtime message."
+	message = "Example Datadog downtime message."
+	monitor_tags = ["*"]
 }
 `
 
@@ -581,6 +611,7 @@ resource "datadog_downtime" "foo" {
   message = <<EOF
 Example Datadog downtime message.
 EOF
+  monitor_tags = ["*"]
 }
 `
 

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -485,13 +485,11 @@ func TestAccDatadogMonitor_Log(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "type", "log alert"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "query", "logs(\"service:foo AND type:error\").index(\"main\").rollup(\"count\").last(\"5m\") > 100"),
+						"datadog_monitor.foo", "query", "logs(\"service:foo AND type:error\").index(\"main\").rollup(\"count\").last(\"5m\") > 2"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "notify_no_data", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "renotify_interval", "60"),
-					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "thresholds.ok", "0.0"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(

--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -44,6 +44,7 @@ func resourceDatadogUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Required: false,
+				Default:  "st",
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/datadog/resource_datadog_user_test.go
+++ b/datadog/resource_datadog_user_test.go
@@ -36,8 +36,9 @@ func TestAccDatadogUser_Updated(t *testing.T) {
 					testAccCheckDatadogUserExists("datadog_user.foo"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "disabled", "true"),
+					// NOTE: it's not possible ATM to update email of another user
 					resource.TestCheckResourceAttr(
-						"datadog_user.foo", "email", "updated@example.com"),
+						"datadog_user.foo", "email", "test@example.com"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "handle", "test@example.com"),
 					resource.TestCheckResourceAttr(
@@ -84,7 +85,8 @@ resource "datadog_user" "foo" {
 const testAccCheckDatadogUserConfigUpdated = `
 resource "datadog_user" "foo" {
   disabled    = true
-  email       = "updated@example.com"
+  // NOTE: it's not possible ATM to update email of another user
+  email       = "test@example.com"
   handle      = "test@example.com"
   is_admin    = true
   access_role = "adm"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 // indirect
-	github.com/zorkian/go-datadog-api v2.20.0+incompatible
+	github.com/zorkian/go-datadog-api v2.20.1-0.20190430091414-fcf4c3b6edfd+incompatible
 	golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519 // indirect
 	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 h1:Y9SzKuDy2J5QLFPm
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zorkian/go-datadog-api v2.20.0+incompatible h1:zfITezz+b9lZuYghMXTdAXBdJe7HRAyU72kKnx876k8=
 github.com/zorkian/go-datadog-api v2.20.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.20.1-0.20190430091414-fcf4c3b6edfd+incompatible h1:nBa/g0we0spNByi38CWZNBn7sCs+vfPrWPQKzPSbnVo=
+github.com/zorkian/go-datadog-api v2.20.1-0.20190430091414-fcf4c3b6edfd+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 golang.org/x/crypto v0.0.0-20180211211603-9de5f2eaf759/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180816225734-aabede6cba87 h1:gCHhzI+1R9peHIMyiWVxoVaWlk1cYK7VThX5ptLtbXY=
 golang.org/x/crypto v0.0.0-20180816225734-aabede6cba87/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/vendor/github.com/zorkian/go-datadog-api/Makefile
+++ b/vendor/github.com/zorkian/go-datadog-api/Makefile
@@ -1,5 +1,4 @@
 TEST?=$$(go list ./... | grep -v '/go-datadog-api/vendor/')
-VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 default: test fmt
@@ -26,11 +25,8 @@ fmt:
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
-	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
-		go get golang.org/x/tools/cmd/vet; \
-	fi
-	@echo "go tool vet $(VETARGS)"
-	@go tool vet $(VETARGS) $$(ls -d */ | grep -v vendor) ; if [ $$? -eq 1 ]; then \
+	@echo "go vet"
+	@go vet; if [ $$? -ne 0 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \

--- a/vendor/github.com/zorkian/go-datadog-api/monitors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/monitors.go
@@ -49,7 +49,7 @@ type ThresholdCount struct {
 	Unknown          *json.Number `json:"unknown,omitempty"`
 	CriticalRecovery *json.Number `json:"critical_recovery,omitempty"`
 	WarningRecovery  *json.Number `json:"warning_recovery,omitempty"`
-	Period           *Period      `json:"period,omitenmpty"`
+	Period           *Period      `json:"period,omitempty"`
 	TimeAggregator   *string      `json:"timeAggregator,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -177,7 +177,7 @@ github.com/zclconf/go-cty/cty/function/stdlib
 github.com/zclconf/go-cty/cty/set
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/json
-# github.com/zorkian/go-datadog-api v2.20.0+incompatible
+# github.com/zorkian/go-datadog-api v2.20.1-0.20190430091414-fcf4c3b6edfd+incompatible
 github.com/zorkian/go-datadog-api
 # golang.org/x/crypto v0.0.0-20180816225734-aabede6cba87
 golang.org/x/crypto/openpgp


### PR DESCRIPTION
This PR fixes various minor issues in the acceptance test suite. Some of these were only tests forgotten to be updated, but some were real issues, one of which also required a fix in go-datadog-api (thus the dependency update).