### PR TITLE
Add custum_bg_color to screenboard

### DIFF
--- a/datadog/resource_datadog_screenboard.go
+++ b/datadog/resource_datadog_screenboard.go
@@ -74,6 +74,11 @@ func resourceDatadogScreenboard() *schema.Resource {
 					Optional:    true,
 					Description: "Value that is threshold for conditional format",
 				},
+				"custom_bg_color": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Custom  background color (e.g., #205081)",
+				},
 				"invert": {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -694,6 +699,7 @@ func buildTileDefRequestsConditionalFormats(source interface{}) []datadog.Condit
 				{"palette", &d.Palette},
 				{"color", &d.Color},
 				{"value", &d.Value},
+				{"custom_bg_color", &d.CustomBgColor},
 				{"invert", &d.Invert},
 			}})
 
@@ -1114,6 +1120,7 @@ func buildTFTileDefRequestConditionalFormats(d []datadog.ConditionalFormat) []in
 				{"palette", ddConditionalFormat.Palette},
 				{"color", ddConditionalFormat.Color},
 				{"value", ddConditionalFormat.Value},
+				{"custom_bg_color", ddConditionalFormat.CustomBgColor},
 				{"invert", ddConditionalFormat.Invert},
 			}})
 		r[i] = tfConditionalFormat

--- a/datadog/resource_datadog_screenboard_test.go
+++ b/datadog/resource_datadog_screenboard_test.go
@@ -104,15 +104,17 @@ resource "datadog_screenboard" "acceptance_test" {
 				}
 
 				conditional_format {
-					comparator = ">"
-					value      = "1"
-					palette    = "white_on_red"
+					comparator      = ">"
+					value           = "1"
+					custom_bg_color = "#205081"
+					palette         = "white_on_red"
 				}
 
 				conditional_format {
-					comparator = ">="
-					value      = "2"
-					palette    = "white_on_yellow"
+					comparator      = ">="
+					value           = "2"
+					custom_bg_color = "#205081"
+					palette         = "white_on_yellow"
 				}
 
 				aggregator = "max"
@@ -1188,11 +1190,13 @@ func TestAccDatadogScreenboard_update(t *testing.T) {
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.0.invert", "false"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.0.palette", "white_on_red"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.0.value", "1"),
+			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.0.custom_bg_color", "#205081"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.1.color", ""),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.1.comparator", ">="),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.1.invert", "false"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.1.palette", "white_on_yellow"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.1.value", "2"),
+			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.conditional_format.1.custom_bg_color", "#205081"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.extra_col", ""),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.increase_good", "false"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.2.tile_def.0.request.0.limit", "0"),

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/terraform-providers/terraform-provider-aws v1.29.0 // indirect
 	github.com/terraform-providers/terraform-provider-template v1.0.0 // indirect
 	github.com/terraform-providers/terraform-provider-tls v1.2.0 // indirect
-	github.com/zorkian/go-datadog-api v2.20.1-0.20190513084440-9d8b2d52bc3d+incompatible
+	github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/zorkian/go-datadog-api v2.20.1-0.20190430091414-fcf4c3b6edfd+incompat
 github.com/zorkian/go-datadog-api v2.20.1-0.20190430091414-fcf4c3b6edfd+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 github.com/zorkian/go-datadog-api v2.20.1-0.20190513084440-9d8b2d52bc3d+incompatible h1:aPFEeTnGh8pTfVwnb9EJhKJulkdYN9ObEe7e/eSG3UE=
 github.com/zorkian/go-datadog-api v2.20.1-0.20190513084440-9d8b2d52bc3d+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible h1:jNXocK/Zh6e6QRF+4Eqt4d+01M1i4E7OlOMmz5uU0VU=
+github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/vendor/github.com/zorkian/go-datadog-api/dashboards.go
+++ b/vendor/github.com/zorkian/go-datadog-api/dashboards.go
@@ -30,13 +30,16 @@ type GraphDefinitionRequest struct {
 	Style              *GraphDefinitionRequestStyle `json:"style,omitempty"`
 
 	// For change type graphs
-	ChangeType     *string `json:"change_type,omitempty"`
-	OrderDirection *string `json:"order_dir,omitempty"`
-	CompareTo      *string `json:"compare_to,omitempty"`
-	IncreaseGood   *bool   `json:"increase_good,omitempty"`
-	OrderBy        *string `json:"order_by,omitempty"`
-	ExtraCol       *string `json:"extra_col,omitempty"`
+	ChangeType     *string                            `json:"change_type,omitempty"`
+	OrderDirection *string                            `json:"order_dir,omitempty"`
+	CompareTo      *string                            `json:"compare_to,omitempty"`
+	IncreaseGood   *bool                              `json:"increase_good,omitempty"`
+	OrderBy        *string                            `json:"order_by,omitempty"`
+	ExtraCol       *string                            `json:"extra_col,omitempty"`
+	Metadata       map[string]GraphDefinitionMetadata `json:"metadata,omitempty"`
 }
+
+type GraphDefinitionMetadata TileDefMetadata
 
 type GraphDefinitionMarker struct {
 	Type  *string      `json:"type,omitempty"`

--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -2711,6 +2711,37 @@ func (c *ConditionalFormat) SetComparator(v string) {
 	c.Comparator = &v
 }
 
+// GetCustomBgColor returns the CustomBgColor field if non-nil, zero value otherwise.
+func (c *ConditionalFormat) GetCustomBgColor() string {
+	if c == nil || c.CustomBgColor == nil {
+		return ""
+	}
+	return *c.CustomBgColor
+}
+
+// GetCustomBgColorOk returns a tuple with the CustomBgColor field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ConditionalFormat) GetCustomBgColorOk() (string, bool) {
+	if c == nil || c.CustomBgColor == nil {
+		return "", false
+	}
+	return *c.CustomBgColor, true
+}
+
+// HasCustomBgColor returns a boolean if a field has been set.
+func (c *ConditionalFormat) HasCustomBgColor() bool {
+	if c != nil && c.CustomBgColor != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomBgColor allocates a new c.CustomBgColor and returns the pointer to it.
+func (c *ConditionalFormat) SetCustomBgColor(v string) {
+	c.CustomBgColor = &v
+}
+
 // GetImageURL returns the ImageURL field if non-nil, zero value otherwise.
 func (c *ConditionalFormat) GetImageURL() string {
 	if c == nil || c.ImageURL == nil {
@@ -4385,6 +4416,37 @@ func (d *Downtime) SetCanceled(v int) {
 	d.Canceled = &v
 }
 
+// GetCreatorID returns the CreatorID field if non-nil, zero value otherwise.
+func (d *Downtime) GetCreatorID() int {
+	if d == nil || d.CreatorID == nil {
+		return 0
+	}
+	return *d.CreatorID
+}
+
+// GetCreatorIDOk returns a tuple with the CreatorID field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *Downtime) GetCreatorIDOk() (int, bool) {
+	if d == nil || d.CreatorID == nil {
+		return 0, false
+	}
+	return *d.CreatorID, true
+}
+
+// HasCreatorID returns a boolean if a field has been set.
+func (d *Downtime) HasCreatorID() bool {
+	if d != nil && d.CreatorID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCreatorID allocates a new d.CreatorID and returns the pointer to it.
+func (d *Downtime) SetCreatorID(v int) {
+	d.CreatorID = &v
+}
+
 // GetDisabled returns the Disabled field if non-nil, zero value otherwise.
 func (d *Downtime) GetDisabled() bool {
 	if d == nil || d.Disabled == nil {
@@ -4662,6 +4724,68 @@ func (d *Downtime) HasTimezone() bool {
 // SetTimezone allocates a new d.Timezone and returns the pointer to it.
 func (d *Downtime) SetTimezone(v string) {
 	d.Timezone = &v
+}
+
+// GetType returns the Type field if non-nil, zero value otherwise.
+func (d *Downtime) GetType() int {
+	if d == nil || d.Type == nil {
+		return 0
+	}
+	return *d.Type
+}
+
+// GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *Downtime) GetTypeOk() (int, bool) {
+	if d == nil || d.Type == nil {
+		return 0, false
+	}
+	return *d.Type, true
+}
+
+// HasType returns a boolean if a field has been set.
+func (d *Downtime) HasType() bool {
+	if d != nil && d.Type != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetType allocates a new d.Type and returns the pointer to it.
+func (d *Downtime) SetType(v int) {
+	d.Type = &v
+}
+
+// GetUpdaterID returns the UpdaterID field if non-nil, zero value otherwise.
+func (d *Downtime) GetUpdaterID() int {
+	if d == nil || d.UpdaterID == nil {
+		return 0
+	}
+	return *d.UpdaterID
+}
+
+// GetUpdaterIDOk returns a tuple with the UpdaterID field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *Downtime) GetUpdaterIDOk() (int, bool) {
+	if d == nil || d.UpdaterID == nil {
+		return 0, false
+	}
+	return *d.UpdaterID, true
+}
+
+// HasUpdaterID returns a boolean if a field has been set.
+func (d *Downtime) HasUpdaterID() bool {
+	if d != nil && d.UpdaterID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUpdaterID allocates a new d.UpdaterID and returns the pointer to it.
+func (d *Downtime) SetUpdaterID(v int) {
+	d.UpdaterID = &v
 }
 
 // GetAggregation returns the Aggregation field if non-nil, zero value otherwise.
@@ -15729,6 +15853,37 @@ func (t *TileDefMarker) HasValue() bool {
 // SetValue allocates a new t.Value and returns the pointer to it.
 func (t *TileDefMarker) SetValue(v string) {
 	t.Value = &v
+}
+
+// GetAlias returns the Alias field if non-nil, zero value otherwise.
+func (t *TileDefMetadata) GetAlias() string {
+	if t == nil || t.Alias == nil {
+		return ""
+	}
+	return *t.Alias
+}
+
+// GetAliasOk returns a tuple with the Alias field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefMetadata) GetAliasOk() (string, bool) {
+	if t == nil || t.Alias == nil {
+		return "", false
+	}
+	return *t.Alias, true
+}
+
+// HasAlias returns a boolean if a field has been set.
+func (t *TileDefMetadata) HasAlias() bool {
+	if t != nil && t.Alias != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAlias allocates a new t.Alias and returns the pointer to it.
+func (t *TileDefMetadata) SetAlias(v string) {
+	t.Alias = &v
 }
 
 // GetAggregator returns the Aggregator field if non-nil, zero value otherwise.

--- a/vendor/github.com/zorkian/go-datadog-api/downtimes.go
+++ b/vendor/github.com/zorkian/go-datadog-api/downtimes.go
@@ -10,6 +10,17 @@ package datadog
 
 import (
 	"fmt"
+	"strings"
+)
+
+// DowntimeType are a classification of a given downtime scope
+type DowntimeType int
+
+// The three downtime type classifications.
+const (
+	StarDowntimeType  DowntimeType = 0
+	HostDowntimeType  DowntimeType = 1
+	OtherDowntimeType DowntimeType = 2
 )
 
 type Recurrence struct {
@@ -34,6 +45,33 @@ type Downtime struct {
 	Recurrence  *Recurrence `json:"recurrence,omitempty"`
 	Scope       []string    `json:"scope,omitempty"`
 	Start       *int        `json:"start,omitempty"`
+	CreatorID   *int        `json:"creator_id,omitempty"`
+	UpdaterID   *int        `json:"updater_id,omitempty"`
+	Type        *int        `json:"downtime_type,omitempty"`
+}
+
+// DowntimeType returns the canonical downtime type classification.
+// This is calculated based on the provided server response, but the logic is copied down here to calculate locally.
+func (d *Downtime) DowntimeType() DowntimeType {
+	if d.Type != nil {
+		switch *d.Type {
+		case 0:
+			return StarDowntimeType
+		case 1:
+			return HostDowntimeType
+		default:
+			return OtherDowntimeType
+		}
+	}
+	if len(d.Scope) == 1 {
+		if d.Scope[0] == "*" {
+			return StarDowntimeType
+		}
+		if strings.HasPrefix(d.Scope[0], "host:") {
+			return HostDowntimeType
+		}
+	}
+	return OtherDowntimeType
 }
 
 // reqDowntimes retrieves a slice of all Downtimes.
@@ -56,7 +94,7 @@ func (client *Client) CreateDowntime(downtime *Downtime) (*Downtime, error) {
 // and sends it back to the server.
 func (client *Client) UpdateDowntime(downtime *Downtime) error {
 	return client.doJsonRequest("PUT", fmt.Sprintf("/v1/downtime/%d", *downtime.Id),
-		downtime, nil)
+		downtime, downtime)
 }
 
 // Getdowntime retrieves an downtime by identifier.

--- a/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
+++ b/vendor/github.com/zorkian/go-datadog-api/screen_widgets.go
@@ -69,24 +69,30 @@ type TileDefRequest struct {
 	TagFilters []*string `json:"tag_filters"`
 	Limit      *int      `json:"limit,omitempty"`
 
-	ConditionalFormats []ConditionalFormat  `json:"conditional_formats,omitempty"`
-	Style              *TileDefRequestStyle `json:"style,omitempty"`
-	Aggregator         *string              `json:"aggregator,omitempty"`
-	CompareTo          *string              `json:"compare_to,omitempty"`
-	ChangeType         *string              `json:"change_type,omitempty"`
-	OrderBy            *string              `json:"order_by,omitempty"`
-	OrderDir           *string              `json:"order_dir,omitempty"`
-	ExtraCol           *string              `json:"extra_col,omitempty"`
-	IncreaseGood       *bool                `json:"increase_good,omitempty"`
+	ConditionalFormats []ConditionalFormat        `json:"conditional_formats,omitempty"`
+	Style              *TileDefRequestStyle       `json:"style,omitempty"`
+	Aggregator         *string                    `json:"aggregator,omitempty"`
+	CompareTo          *string                    `json:"compare_to,omitempty"`
+	ChangeType         *string                    `json:"change_type,omitempty"`
+	OrderBy            *string                    `json:"order_by,omitempty"`
+	OrderDir           *string                    `json:"order_dir,omitempty"`
+	ExtraCol           *string                    `json:"extra_col,omitempty"`
+	IncreaseGood       *bool                      `json:"increase_good,omitempty"`
+	Metadata           map[string]TileDefMetadata `json:"metadata,omitempty"`
+}
+
+type TileDefMetadata struct {
+	Alias *string `json:"alias,omitempty"`
 }
 
 type ConditionalFormat struct {
-	Color      *string `json:"color,omitempty"`
-	Palette    *string `json:"palette,omitempty"`
-	Comparator *string `json:"comparator,omitempty"`
-	Invert     *bool   `json:"invert,omitempty"`
-	Value      *string `json:"value,omitempty"`
-	ImageURL   *string `json:"image_url,omitempty"`
+	Color         *string `json:"color,omitempty"`
+	Palette       *string `json:"palette,omitempty"`
+	Comparator    *string `json:"comparator,omitempty"`
+	Invert        *bool   `json:"invert,omitempty"`
+	CustomBgColor *string `json:"custom_bg_color,omitempty"`
+	Value         *string `json:"value,omitempty"`
+	ImageURL      *string `json:"image_url,omitempty"`
 }
 
 type TileDefRequestStyle struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -219,7 +219,7 @@ github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/set
 github.com/zclconf/go-cty/cty/function
 github.com/zclconf/go-cty/cty/function/stdlib
-# github.com/zorkian/go-datadog-api v2.20.1-0.20190513084440-9d8b2d52bc3d+incompatible
+# github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible
 github.com/zorkian/go-datadog-api
 # golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 golang.org/x/crypto/openpgp


### PR DESCRIPTION
In the documentation it is mentioned that `custom_bg` is supported for a screenboard (https://www.terraform.io/docs/providers/datadog/r/screenboard.html#palette-2). 

But no `custom_bg_color` field is available such as https://www.terraform.io/docs/providers/datadog/r/timeboard.html#custom_bg_color.

I added the field to the screenboard code.