### PR TITLE
Add documentation for datadog_monitor's threshold_windows

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -115,6 +115,9 @@ The following arguments are supported:
     Default: True for "on average", "at all times" and "in total" aggregation. False otherwise.
 * `locked` (Optional) A boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Defaults to False.
 * `tags` (Optional) A list of tags to associate with your monitor. This can help you categorize and filter monitors in the manage monitors page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
+* `threshold_windows` (Optional) A mapping containing `recovery_window` and `trigger_window` values, e.g. `last_15m`. Can only be used for anomaly monitors.
+  * `recovery_window` describes how long an anomalous metric must be normal before the alert recovers.
+  * `trigger_window`  describes how long a metric must be anomalous before an alert triggers.
 * `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0.
     To mute the alert completely:
 


### PR DESCRIPTION
I wanted to add this in #191 but totally forgot about it, so adding it now.