### PR TITLE
#148 Fix log monitor UI issue: generate queryConfig.queryString from query

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -178,12 +178,12 @@ func resourceDatadogMonitor() *schema.Resource {
 			},
 			"query_config": {
 				Type:     schema.TypeMap,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"query_string": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 					},
 				},


### PR DESCRIPTION
Fix log monitor UI issue of the search query
-  generate queryConfig.queryString from the query attribute