### PR TITLE
Add documentation for downtime monitor_tags

### DIFF
--- a/website/docs/r/downtime.html.markdown
+++ b/website/docs/r/downtime.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
     * `until_occurrences` - (Optional) How many times the downtime will be rescheduled. `until_occurrences` and `until_date` are mutually exclusive.
     * `until_date` - (Optional) The date at which the recurrence should end as a POSIX timestamp. `until_occurrences` and `until_date` are mutually exclusive.
 * `message` - (Optional) A message to include with notifications for this downtime.
+* `monitor_tags` - (Optional) A list of monitor tags to match. The resulting downtime applies to monitors that match **all** provided monitor tags.
 * `monitor_id` - (Optional) Reference to which monitor this downtime is applied. When scheduling downtime for a given monitor, datadog changes `silenced` property of the monitor to match the `end` POSIX timestamp. **Note:** this will effectively change the `silenced` attribute of the referenced monitor. If that monitor is also tracked by Terraform and you don't want it to be unmuted on the next `terraform apply`, see [details](/docs/providers/datadog/r/monitor.html#silencing-by-hand-and-by-downtimes) in the monitor resource documentation.
 
 ## Attributes Reference


### PR DESCRIPTION
Adding documentation for resource `datadog_downtime` attribute `monitor_tags` as requested in https://github.com/terraform-providers/terraform-provider-datadog/pull/167#issuecomment-492186676