### PR TITLE
Make sure the computed value for monitor's query_config gets stored on creation

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -332,7 +332,7 @@ func resourceDatadogMonitorCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(strconv.Itoa(m.GetId()))
 
-	return nil
+	return resourceDatadogMonitorRead(d, meta)
 }
 
 func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error {
@@ -400,6 +400,7 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("require_full_window", m.Options.GetRequireFullWindow()) // TODO Is this one of those options that we neeed to check?
 	d.Set("locked", m.Options.GetLocked())
 
+	d.Set("query_config", map[string]string{})
 	if m.GetType() == logAlertMonitorType {
 		d.Set("enable_logs_sample", m.Options.GetEnableLogsSample())
 		queryConfig := make(map[string]string)


### PR DESCRIPTION
Without this, having a monitor that's not of type `log alert` would result in not saving computed value for `query_config` on creation and thus having non-empty plan after first apply.