### PR TITLE
Add link to documentation about monitor types

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -49,7 +49,7 @@ resource "datadog_monitor" "foo" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the monitor. The mapping from these types to the in app Monitor types can be found in our [documentation](https://docs.datadoghq.com/api/?lang=python#create-a-monitor) Available options to choose from are:
+* `type` - (Required) The type of the monitor. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/?lang=python#create-a-monitor) page. Available options to choose from are:
     * `metric alert`
     * `service check`
     * `event alert`

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -49,13 +49,13 @@ resource "datadog_monitor" "foo" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the monitor, chosen from:
+* `type` - (Required) The type of the monitor. The mapping from these types to the in app Monitor types can be found in our [documentation](https://docs.datadoghq.com/api/?lang=python#create-a-monitor) Available options to choose from are:
     * `metric alert`
     * `service check`
     * `event alert`
     * `query alert`
     * `composite`
-    * `log alert`    
+    * `log alert`
 * `name` - (Required) Name of Datadog monitor
 * `query` - (Required) The monitor query to notify on. Note this is not the same query you see in the UI and
     the syntax is different depending on the monitor `type`, please see the [API Reference](https://docs.datadoghq.com/api/?lang=python#create-a-monitor) for details. **Warning:** `terraform plan` won't perform any validation of the query contents.


### PR DESCRIPTION
Add a link to the Datadog Documentation in the monitor terraform docs that provides the mapping between API/Terraform monitor `types` and the ones that you see in the Datadog platform. 

Help make choosing a monitor type easier!