### PR TITLE
Fixes #182 - Monitor Tags are not sorted

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -294,6 +295,7 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 		for _, s := range attr.([]interface{}) {
 			tags = append(tags, s.(string))
 		}
+		sort.Strings(tags)
 		m.Tags = tags
 	}
 
@@ -377,6 +379,7 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 	for _, s := range m.Tags {
 		tags = append(tags, s)
 	}
+	sort.Strings(tags)
 
 	log.Printf("[DEBUG] monitor: %v", m)
 	d.Set("name", m.GetName())
@@ -443,6 +446,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		for _, v := range attr.([]interface{}) {
 			s = append(s, v.(string))
 		}
+		sort.Strings(s)
 		m.Tags = s
 	}
 

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -49,10 +49,11 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					// Tags are sorted
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "foo:bar"),
+						"datadog_monitor.foo", "tags.0", "baz"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "baz"),
+						"datadog_monitor.foo", "tags.1", "foo:bar"),
 				),
 			},
 		},
@@ -97,10 +98,11 @@ func TestAccDatadogMonitorServiceCheck_Basic(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					// Tags are sorted
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "foo:bar"),
+						"datadog_monitor.foo", "tags.0", "baz"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "baz"),
+						"datadog_monitor.foo", "tags.1", "foo:bar"),
 				),
 			},
 		},
@@ -133,10 +135,11 @@ func TestAccDatadogMonitor_BasicNoTreshold(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					// Tags are sorted
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "foo:bar"),
+						"datadog_monitor.foo", "tags.0", "bar:baz"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "bar:baz"),
+						"datadog_monitor.foo", "tags.1", "foo:bar"),
 				),
 			},
 		},
@@ -189,10 +192,11 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					// Tags are sorted
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "foo:bar"),
+						"datadog_monitor.foo", "tags.0", "baz"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "baz"),
+						"datadog_monitor.foo", "tags.1", "foo:bar"),
 				),
 			},
 			{
@@ -241,6 +245,7 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "true"),
+					// Tags are sorted
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "tags.0", "baz:qux"),
 					resource.TestCheckResourceAttr(
@@ -313,10 +318,11 @@ func TestAccDatadogMonitor_UpdatedToRemoveTags(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
+					// Tags are sorted
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "foo:bar"),
+						"datadog_monitor.foo", "tags.0", "baz"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "baz"),
+						"datadog_monitor.foo", "tags.1", "foo:bar"),
 				),
 			},
 			{


### PR DESCRIPTION
Fixes #182 as monitor tags order has no meaning and are not guaranteed to be in the same order