### PR TITLE
Add examples section to docs

### DIFF
--- a/website/datadog.erb
+++ b/website/datadog.erb
@@ -42,6 +42,17 @@
             </li>
           </ul>
         </li>
+
+        <li<%= sidebar_current("docs-datadog-examples") %>>
+        <a href="#">Examples</a>
+        <ul class="nav nav-visible">
+          <li<%= sidebar_current("docs-datadog-monitor-examples") %>>
+            <a href="/docs/providers/datadog/r/examples/monitors.html">monitors</a>
+          </li>
+        </ul>
+      </li>
+
+
       </ul>
     </div>
   <% end %>

--- a/website/docs/r/examples/monitors.html.markdown
+++ b/website/docs/r/examples/monitors.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "datadog"
+page_title: "Datadog: monitor_examples"
+sidebar_current: "docs-datadog-monitor-examples"
+description: |-
+  Provides examples for the different types of Datadog monitors. This list isn't exhaustive but serves as a reference for some examples.
+---
+
+## Watchdog Monitors
+
+```
+resource "datadog_monitor" "Watchdog_Monitor" {
+  name               = "Watchdog Monitor TF"
+  type               = "event alert"
+  message            = "Check out this Watchdog Service Monitor"
+  escalation_message = "Escalation message"
+
+  query = "events('priority:all sources:watchdog tags:story_type:service,env:test_env,service:test_service:_aggregate').by('service,resource_name').rollup('count').last('30m') > 0"
+
+  notify_no_data    = false
+  renotify_interval = 60
+
+  notify_audit = false
+  timeout_h    = 60
+  include_tags = true
+
+  tags = ["foo:bar", "baz"]
+}
+```

--- a/website/docs/r/examples/monitors.html.markdown
+++ b/website/docs/r/examples/monitors.html.markdown
@@ -6,6 +6,9 @@ description: |-
   Provides examples for the different types of Datadog monitors. This list isn't exhaustive but serves as a reference for some examples.
 ---
 
+## MOnitor Examples
+This page lists examples of how to create different Datadog monitor types within Terraform. This list is non exhaustive and will be updated over time to provide more examples.
+
 ## Watchdog Monitors
 
 ```


### PR DESCRIPTION
A quick POC to adding an `examples` section to the Provider website docs. The idea being that we could do this for each complex resource we have where the number of examples needed wouldn't really fit on the resource page directly. 

![image](https://user-images.githubusercontent.com/8941884/58360489-1456d400-7e57-11e9-8af1-5904f8757c5a.png)
