### PR TITLE
Deprecate Silence attribute and Fix multiple terraform runs

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -443,7 +443,7 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 		if _, ok := apiSilenced[k]; !ok && configuredVal.(int) == -1 {
 			configSilenced[k] = configuredVal
 		} else if configuredVal.(int) < int(time.Now().Unix()) && configuredVal.(int) != 0 {
-			delete(configSilenced, k)
+			// delete(configSilenced, k)
 		} else if _, ok := apiSilenced[k]; !ok {
 			delete(configSilenced, k)
 		}
@@ -578,6 +578,9 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	var retval error
+	if retval = resourceDatadogMonitorRead(d, meta); retval != nil {
+		return retval
+	}
 
 	// if the silenced section was removed from the config, we unmute it via the API
 	// The API wouldn't automatically unmute the monitor if the config is just missing
@@ -594,11 +597,7 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if retval = resourceDatadogMonitorRead(d, meta); retval != nil {
-		return retval
-	}
-
-	return retval
+	return resourceDatadogMonitorRead(d, meta)
 }
 
 func resourceDatadogMonitorDelete(d *schema.ResourceData, meta interface{}) error {

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -581,8 +581,9 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 	// Similarly, if the silenced attribute is -1, lets unmute those scopes
 	unmutedScopes := getUnmutedScopes(d)
 	if len(unmutedScopes) != 0 {
-		str := strings.Join(unmutedScopes, ",")
-		retval = client.UnmuteMonitorScopes(*m.Id, &datadog.UnmuteMonitorScopes{Scope: &str})
+		for _, scope := range unmutedScopes {
+			client.UnmuteMonitorScopes(*m.Id, &datadog.UnmuteMonitorScopes{Scope: &scope})
+		}
 	}
 
 	if retval = resourceDatadogMonitorRead(d, meta); retval != nil {

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -431,6 +431,17 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("query_config", queryConfig)
 	}
 
+	// Update the state with the contents of the API + whats in the config
+	// The API won't return scopes for timestamps that are in the past/-1
+	// The API response should take precedence if it exists
+	silenced := m.Options.Silenced
+	for k, v := range d.Get("silenced").(map[string]interface{}) {
+		if _, ok := silenced[k]; !ok {
+			silenced[k] = v.(int)
+		}
+	}
+	d.Set("silenced", silenced)
+
 	return nil
 }
 

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -604,7 +604,7 @@ func testAccCheckDatadogMonitorExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func TestAccDatadogMonitor_UpdateRemoveSilence(t *testing.T) {
+func TestAccDatadogMonitor_SilencedRemove(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -642,7 +642,7 @@ func TestAccDatadogMonitor_UpdateRemoveSilence(t *testing.T) {
 	})
 }
 
-func TestAccDatadogMonitor_UpdateSameSilence(t *testing.T) {
+func TestAccDatadogMonitor_SilencedUpdateNoDiff(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -672,7 +672,7 @@ func TestAccDatadogMonitor_UpdateSameSilence(t *testing.T) {
 	})
 }
 
-func TestAccDatadogMonitor_UpdatePastTimestamp(t *testing.T) {
+func TestAccDatadogMonitor_SilencedUpdatePastTimestamp(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -118,7 +118,8 @@ The following arguments are supported:
 * `threshold_windows` (Optional) A mapping containing `recovery_window` and `trigger_window` values, e.g. `last_15m`. Can only be used for anomaly monitors.
   * `recovery_window` describes how long an anomalous metric must be normal before the alert recovers.
   * `trigger_window`  describes how long a metric must be anomalous before an alert triggers.
-* `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0.
+* `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0. **Deprecated** The `silenced` parameter is being deprecated in favor of the downtime resource. This will be removed in the next major version of the Terraform Provider.
+
     To mute the alert completely:
 
         silenced = {

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -118,7 +118,7 @@ The following arguments are supported:
 * `threshold_windows` (Optional) A mapping containing `recovery_window` and `trigger_window` values, e.g. `last_15m`. Can only be used for anomaly monitors.
   * `recovery_window` describes how long an anomalous metric must be normal before the alert recovers.
   * `trigger_window`  describes how long a metric must be anomalous before an alert triggers.
-* `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0. **Deprecated** The `silenced` parameter is being deprecated in favor of the downtime resource. This will be removed in the next major version of the Terraform Provider.
+* `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0. Use `-1` if you want to un-silence the scope. **Deprecated** The `silenced` parameter is being deprecated in favor of the downtime resource. This will be removed in the next major version of the Terraform Provider.
 
     To mute the alert completely:
 


### PR DESCRIPTION
This PR looks to accomplish a few things surrounding the `silence` attribute of monitor resources. 

* Add a deprecation notice that we'll stop supporting the `silenced` param soon. (In a couple Major versions of the Provider as outlined by the best practices doc - https://www.terraform.io/docs/extend/best-practices/deprecations.html)
* Add the ability to specify a `-1` on any scope of the silenced attribute to unmute that scope. This will make a separate API call to unmute those scopes (Only on updates, newly created monitors shouldn't be muted :) ) 
* Fix an issue where running terraform apply would detect a diff on the silence scope if the timestamp were in the past. This is due to the Datadog Monitor API not returning scopes with timestamps in the past in the API response. So the monitor resource will detect this and leave the state unchanged. 
* Add some tests 🎉 