### PR TITLE
Support Synthetics tests in composite monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
 ## 1.10.0 (Unreleased)
-
-IMPROVEMENTS:
-
-* Support Synthetics tests in composite monitors
-
 ## 1.9.0 (May 09, 2019)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.10.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* Support Synthetics tests in composite monitors
+
 ## 1.9.0 (May 09, 2019)
 
 IMPROVEMENTS:

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -73,6 +73,10 @@ func resourceDatadogSyntheticsTest() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"monitor_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -380,6 +384,7 @@ func updateSyntheticsTestLocalState(d *schema.ResourceData, syntheticsTest *data
 	d.Set("message", syntheticsTest.GetMessage())
 	d.Set("status", syntheticsTest.GetStatus())
 	d.Set("tags", syntheticsTest.Tags)
+	d.Set("monitor_id", syntheticsTest.MonitorId)
 }
 
 func convertToString(i interface{}) string {

--- a/datadog/resource_datadog_synthetics_test_test.go
+++ b/datadog/resource_datadog_synthetics_test_test.go
@@ -152,6 +152,8 @@ var createSyntheticsAPITestStep = resource.TestStep{
 			"datadog_synthetics_test.foo", "tags.1", "baz"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "status", "paused"),
+		resource.TestCheckResourceAttrSet(
+			"datadog_synthetics_test.foo", "monitor_id"),
 	),
 }
 
@@ -253,6 +255,8 @@ var updateSyntheticsAPITestStep = resource.TestStep{
 			"datadog_synthetics_test.foo", "tags.2", "env:test"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "status", "live"),
+		resource.TestCheckResourceAttrSet(
+			"datadog_synthetics_test.foo", "monitor_id"),
 	),
 }
 
@@ -338,6 +342,8 @@ var createSyntheticsBrowserTestStep = resource.TestStep{
 			"datadog_synthetics_test.bar", "tags.0", "foo:bar"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.bar", "tags.1", "baz"),
+		resource.TestCheckResourceAttrSet(
+			"datadog_synthetics_test.bar", "monitor_id"),
 	),
 }
 
@@ -420,6 +426,8 @@ var updateSyntheticsBrowserTestStep = resource.TestStep{
 			"datadog_synthetics_test.bar", "tags.0", "foo:bar"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.bar", "tags.1", "buz"),
+		resource.TestCheckResourceAttrSet(
+			"datadog_synthetics_test.bar", "monitor_id"),
 	),
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/kr/pretty v0.1.0
 	github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible
 )
+
+replace github.com/zorkian/go-datadog-api => github.com/DataDog/go-datadog-api v0.0.0-20190529090230-16add2864293

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,5 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/terraform v0.12.0
 	github.com/kr/pretty v0.1.0
-	github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible
+	github.com/zorkian/go-datadog-api v2.20.1-0.20190603153832-e55ea7fe7831+incompatible
 )
-
-replace github.com/zorkian/go-datadog-api => github.com/DataDog/go-datadog-api v0.0.0-20190529090230-16add2864293

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec h1:MSeYjmyjucsFbecM
 github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible h1:jNXocK/Zh6e6QRF+4Eqt4d+01M1i4E7OlOMmz5uU0VU=
 github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.20.1-0.20190603153832-e55ea7fe7831+incompatible h1:fd28pEQilBq2gBNrZM4rs7cXWLWS+QWurCo5V9GCTxo=
+github.com/zorkian/go-datadog-api v2.20.1-0.20190603153832-e55ea7fe7831+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,9 @@ github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNfDF5AZvjr+5UyGQvQEBL7pwo+v+wX6q9JI8=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
+github.com/DHowett/go-plist v0.0.0-20180609054337-500bd5b9081b/go.mod h1:5paT5ZDrOm8eAJPem2Bd+q3FTi3Gxm/U4tb2tH8YIUQ=
+github.com/DataDog/go-datadog-api v0.0.0-20190529090230-16add2864293 h1:Xm0TM43qs4zN4vDmfXXoHDHBnJd6XblABVe7fsZoPoc=
+github.com/DataDog/go-datadog-api v0.0.0-20190529090230-16add2864293/go.mod h1:M39kErhCx5HcdIQ1FA2NHJSWPA6qvUGkJ/Bhz6MAOa4=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=

--- a/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
+++ b/vendor/github.com/zorkian/go-datadog-api/datadog-accessors.go
@@ -14739,6 +14739,37 @@ func (s *SyntheticsTest) SetModifiedBy(v SyntheticsUser) {
 	s.ModifiedBy = &v
 }
 
+// GetMonitorId returns the MonitorId field if non-nil, zero value otherwise.
+func (s *SyntheticsTest) GetMonitorId() int {
+	if s == nil || s.MonitorId == nil {
+		return 0
+	}
+	return *s.MonitorId
+}
+
+// GetMonitorIdOk returns a tuple with the MonitorId field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *SyntheticsTest) GetMonitorIdOk() (int, bool) {
+	if s == nil || s.MonitorId == nil {
+		return 0, false
+	}
+	return *s.MonitorId, true
+}
+
+// HasMonitorId returns a boolean if a field has been set.
+func (s *SyntheticsTest) HasMonitorId() bool {
+	if s != nil && s.MonitorId != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMonitorId allocates a new s.MonitorId and returns the pointer to it.
+func (s *SyntheticsTest) SetMonitorId(v int) {
+	s.MonitorId = &v
+}
+
 // GetMonitorStatus returns the MonitorStatus field if non-nil, zero value otherwise.
 func (s *SyntheticsTest) GetMonitorStatus() string {
 	if s == nil || s.MonitorStatus == nil {

--- a/vendor/github.com/zorkian/go-datadog-api/synthetics.go
+++ b/vendor/github.com/zorkian/go-datadog-api/synthetics.go
@@ -8,6 +8,7 @@ import (
 // SyntheticsTest represents a synthetics test, either api or browser
 type SyntheticsTest struct {
 	PublicId      *string            `json:"public_id,omitempty"`
+	MonitorId     *int               `json:"monitor_id,omitempty"`
 	Name          *string            `json:"name,omitempty"`
 	Type          *string            `json:"type,omitempty"`
 	Tags          []string           `json:"tags"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -230,7 +230,7 @@ github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/set
 github.com/zclconf/go-cty/cty/function
 github.com/zclconf/go-cty/cty/function/stdlib
-# github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible => github.com/DataDog/go-datadog-api v0.0.0-20190529090230-16add2864293
+# github.com/zorkian/go-datadog-api v2.20.1-0.20190603153832-e55ea7fe7831+incompatible
 github.com/zorkian/go-datadog-api
 # go.opencensus.io v0.18.0
 go.opencensus.io/trace

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -230,7 +230,7 @@ github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/set
 github.com/zclconf/go-cty/cty/function
 github.com/zclconf/go-cty/cty/function/stdlib
-# github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible
+# github.com/zorkian/go-datadog-api v2.20.1-0.20190521074352-d479e1923790+incompatible => github.com/DataDog/go-datadog-api v0.0.0-20190529090230-16add2864293
 github.com/zorkian/go-datadog-api
 # go.opencensus.io v0.18.0
 go.opencensus.io/trace

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -174,3 +174,19 @@ Monitors can be imported using their numeric ID, e.g.
 ```
 $ terraform import datadog_monitor.bytes_received_localhost 2081
 ```
+
+## Composite Monitors
+
+You can compose monitors of all types in order to define more specific alert conditions (see the [doc](https://docs.datadoghq.com/monitors/monitor_types/composite/)).
+You just need to reuse the ID of your `datadog_monitor` resources.
+You can also compose any monitor with a `datadog_synthetics_test` by passing the computed `monitor_id` attribute in the query.
+
+```tf
+resource "datadog_monitor" "bar" {
+  name = "Composite Monitor"
+  type = "composite"
+  message = "This is a message"
+
+	query = "${datadog_monitor.foo.id} || ${datadog_synthetics_test.foo.monitor_id}"
+}
+```


### PR DESCRIPTION
- [x] Update the doc
- [x] Add test for synthetics test composition
- [x] Fetch monitor_id in terraform state

**Please do not merge this PR until the [PR on go-datadog-api](https://github.com/zorkian/go-datadog-api/pull/243) is merged**.