### PR TITLE
Suppress diff on default precision

### DIFF
--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -197,6 +197,14 @@ func resourceDatadogTimeboard() *schema.Resource {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: "How many digits to show",
+					// Suppress the diff shown if the graph is going to be set to a default of 2 iff its not set by the config
+					// Since this precision attribute is only valid for certain graph types, we aren't setting a global default
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if old == "2" && new == "" {
+							return true
+						}
+						return false
+					},
 				},
 				"custom_unit": {
 					Type:        schema.TypeString,
@@ -826,7 +834,6 @@ func resourceDatadogTimeboardRead(d *schema.ResourceData, meta interface{}) erro
 	// Ensure the ID saved in the state is always the legacy ID returned from the API
 	// and not the ID passed to the import statement which could be in the new ID format
 	d.SetId(strconv.Itoa(timeboard.GetId()))
-
 	return nil
 }
 


### PR DESCRIPTION
Suppress the diff on the precision attribute of timeboard graphs when it makes sense. 

Some widget types allow the `precision` field to be set. The default value for this is `2`. If the value isn't set in the config, the Datadog API applies a value of `2` on certain widget types (mainly query value widgets)

Since the state has a `2` returned by the API, it doesn't match the config value of `""`, causing a diff. We could provide this as a default to the schema, but its not a valid attribute to all graph widgets, so its cleaner to suppress the diff in this case. 

