### PR TITLE
Mention units explicitly

### DIFF
--- a/website/docs/r/synthetics.html.markdown
+++ b/website/docs/r/synthetics.html.markdown
@@ -93,9 +93,9 @@ The following arguments are supported:
   - `target` - (Required) Expected value, please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#validation) as target depend on assertion type
   - `property` - (Optional) if assertion type is "header", this is a the header name
 - `options` - (Required)
-  - `tick_every` - (Required) 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
+  - `tick_every` - (Required)  How often the test should run (in seconds). Current possible values are 900, 1800, 3600, 21600, 43200, 86400, 604800 plus 60 if type=api or 300 if type=browser
   - `follow_redirects` - (Optional) true or false
-  - `min_failure_duration` - (Optional) Grace period during which a synthetics test is allowed to fail before sending notifications
+  - `min_failure_duration` - (Optional) How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.
   - `min_location_failed` - (Optional) Threshold below which a synthetics test is allowed to fail before sending notifications
 - `locations` - (Required) Please refer to [Datadog documentation](https://docs.datadoghq.com/synthetics/api_test/#request) for available locations (e.g. "aws:eu-central-1")
 - `device_ids` - (Optional) "laptop_large", "tablet" or "mobile_small" (only available if type=browser)


### PR DESCRIPTION
 All of the parameters are in seconds: https://docs.datadoghq.com/api/?lang=python#create-a-test.

There can be some confusion because some datadog docs say its in
minutes e.g. in https://docs.datadoghq.com/synthetics/api_tests/?tab=httptest#alert-conditions
it is mentioned:
```
At least one location was in failure (at least one assertion failed) during the last X minutes,
```

Also, one of the parameters is called `min_failure_duration`,
which caused some confusion whether the `min` referred to
minimum or minutes : ).

Specify the units explicilty, and save others from being confused
like we were.