### PR TITLE
Fix several integration tests and related code

### DIFF
--- a/datadog/import_datadog_downtime_test.go
+++ b/datadog/import_datadog_downtime_test.go
@@ -31,6 +31,7 @@ resource "datadog_downtime" "foo" {
   scope = ["host:X", "host:Y"]
   start = 1735707600
   end   = 1735765200
+  timezone = "UTC"
 
   message = "Example Datadog downtime message."
   monitor_tags = ["*"]

--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -280,6 +280,10 @@ func resourceDatadogDowntimeRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	if err := d.Set("timezone", dt.GetTimezone()); err != nil {
+		return err
+	}
+
 	if r, ok := dt.GetRecurrenceOk(); ok {
 		recurrence := make(map[string]interface{})
 		recurrenceList := make([]map[string]interface{}, 0, 1)

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -49,11 +49,16 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
-					// Tags are sorted
+					// Tags are a TypeSet => use a weird way to access members by their hash
+					// TF TypeSet is internally represented as a map that maps computed hashes
+					// to actual values. Since the hashes are always the same for one value,
+					// this is the way to get them.
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "baz"),
+						"datadog_monitor.foo", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "foo:bar"),
+						"datadog_monitor.foo", "tags.2644851163", "baz"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.1750285118", "foo:bar"),
 				),
 			},
 		},
@@ -98,11 +103,13 @@ func TestAccDatadogMonitorServiceCheck_Basic(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
-					// Tags are sorted
+					// Tags are a TypeSet => use a weird way to access members by their hash
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "baz"),
+						"datadog_monitor.foo", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "foo:bar"),
+						"datadog_monitor.foo", "tags.2644851163", "baz"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.1750285118", "foo:bar"),
 				),
 			},
 		},
@@ -135,11 +142,13 @@ func TestAccDatadogMonitor_BasicNoTreshold(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
-					// Tags are sorted
+					// Tags are a TypeSet => use a weird way to access members by their hash
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "bar:baz"),
+						"datadog_monitor.foo", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "foo:bar"),
+						"datadog_monitor.foo", "tags.3417822676", "bar:baz"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.1750285118", "foo:bar"),
 				),
 			},
 		},
@@ -192,11 +201,13 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
-					// Tags are sorted
+					// Tags are a TypeSet => use a weird way to access members by their hash
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "baz"),
+						"datadog_monitor.foo", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "foo:bar"),
+						"datadog_monitor.foo", "tags.2644851163", "baz"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.1750285118", "foo:bar"),
 				),
 			},
 			{
@@ -245,11 +256,13 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "false"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "true"),
-					// Tags are sorted
+					// Tags are a TypeSet => use a weird way to access members by their hash
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "baz:qux"),
+						"datadog_monitor.foo", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "quux"),
+						"datadog_monitor.foo", "tags.1280427750", "baz:qux"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.1520885421", "quux"),
 				),
 			},
 			{
@@ -318,11 +331,13 @@ func TestAccDatadogMonitor_UpdatedToRemoveTags(t *testing.T) {
 						"datadog_monitor.foo", "require_full_window", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
-					// Tags are sorted
+					// Tags are a TypeSet => use a weird way to access members by their hash
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.0", "baz"),
+						"datadog_monitor.foo", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.1", "foo:bar"),
+						"datadog_monitor.foo", "tags.2644851163", "baz"),
+					resource.TestCheckResourceAttr(
+						"datadog_monitor.foo", "tags.1750285118", "foo:bar"),
 				),
 			},
 			{
@@ -372,9 +387,7 @@ func TestAccDatadogMonitor_UpdatedToRemoveTags(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "true"),
 					resource.TestCheckNoResourceAttr(
-						"datadog_monitor.foo", "tags.0"),
-					resource.TestCheckNoResourceAttr(
-						"datadog_monitor.foo", "tags.1"),
+						"datadog_monitor.foo", "tags.#"),
 				),
 			},
 			{
@@ -446,13 +459,13 @@ func TestAccDatadogMonitor_Basic_float_int(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogMonitorExists("datadog_monitor.foo"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "thresholds.warning", "1"),
+						"datadog_monitor.foo", "thresholds.warning", "1.0"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "thresholds.warning_recovery", "0"),
+						"datadog_monitor.foo", "thresholds.warning_recovery", "0.0"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "thresholds.critical", "2"),
+						"datadog_monitor.foo", "thresholds.critical", "2.0"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "thresholds.critical_recovery", "1"),
+						"datadog_monitor.foo", "thresholds.critical_recovery", "1.0"),
 				),
 			},
 


### PR DESCRIPTION
* Set datadog_downtime.timezone attribute in resourceDatadogDowntimeRead,
  handle it in import test
* Make datadog_downtime.tags a TypeSet to be able to properly ignore
  differences in ordering of its contents
* Fix two regressions caused by calling resourceDatadogMonitorRead from
  resourceDatadogMonitorUpdate and resourceDatadogMonitorCreate:
  * Make sure that API sometimes changing "metric alert" to "query alert"
    continues to be ignored
  * Fix tests for threshold values to always expect floats

The last change should be mentioned in the changelog, because that will actually create a non-empty plan for people who have used integers as values for thresholds previously - with next apply, these are all going to change to floats (one-time only). It's not really a regression, since the values will just change their type, but still noteworthy IMO.