### PR TITLE
Mark datadog_monitor.type as ForceNew, since changing type is not actually possible

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -55,6 +55,7 @@ func resourceDatadogMonitor() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			// Options


### PR DESCRIPTION
To change a monitor type, one needs to actually delete the old one and create new, which is precisely what `ForceNew` does.