### PR TITLE
Fix up the GCP and User tests

### DIFF
--- a/datadog/resource_datadog_integration_gcp_test.go
+++ b/datadog/resource_datadog_integration_gcp_test.go
@@ -2,7 +2,6 @@ package datadog
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -89,10 +88,8 @@ func TestAccDatadogIntegrationGCP(t *testing.T) {
 }
 
 func checkIntegrationGCPExists(s *terraform.State) error {
-	log.Println("Checking GCP Int exists")
 	client := testAccProvider.Meta().(*datadog.Client)
 	integrations, err := client.ListIntegrationGCP()
-	log.Printf("These integrations exist %v", integrations)
 	if err != nil {
 		return err
 	}

--- a/datadog/resource_datadog_integration_gcp_test.go
+++ b/datadog/resource_datadog_integration_gcp_test.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -11,7 +12,7 @@ import (
 
 const testAccCheckDatadogIntegrationGCPConfig = `
 resource "datadog_integration_gcp" "awesome_gcp_project_integration" {
-  project_id     = "awesome-project-id"
+  project_id     = "super-awesome-project-id"
   private_key_id = "1234567890123456789012345678901234567890"
   private_key    = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
   client_email   = "awesome-service-account@awesome-project-id.iam.gserviceaccount.com"
@@ -21,7 +22,7 @@ resource "datadog_integration_gcp" "awesome_gcp_project_integration" {
 `
 const testAccCheckDatadogIntegrationGCPEmptyHostFiltersConfig = `
 resource "datadog_integration_gcp" "awesome_gcp_project_integration" {
-  project_id     = "awesome-project-id"
+  project_id     = "super-awesome-project-id"
   private_key_id = "1234567890123456789012345678901234567890"
   private_key    = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
   client_email   = "awesome-service-account@awesome-project-id.iam.gserviceaccount.com"
@@ -41,7 +42,7 @@ func TestAccDatadogIntegrationGCP(t *testing.T) {
 					checkIntegrationGCPExists,
 					resource.TestCheckResourceAttr(
 						"datadog_integration_gcp.awesome_gcp_project_integration",
-						"project_id", "awesome-project-id"),
+						"project_id", "super-awesome-project-id"),
 					resource.TestCheckResourceAttr(
 						"datadog_integration_gcp.awesome_gcp_project_integration",
 						"private_key_id", "1234567890123456789012345678901234567890"),
@@ -65,7 +66,7 @@ func TestAccDatadogIntegrationGCP(t *testing.T) {
 					checkIntegrationGCPExists,
 					resource.TestCheckResourceAttr(
 						"datadog_integration_gcp.awesome_gcp_project_integration",
-						"project_id", "awesome-project-id"),
+						"project_id", "super-awesome-project-id"),
 					resource.TestCheckResourceAttr(
 						"datadog_integration_gcp.awesome_gcp_project_integration",
 						"private_key_id", "1234567890123456789012345678901234567890"),
@@ -88,8 +89,10 @@ func TestAccDatadogIntegrationGCP(t *testing.T) {
 }
 
 func checkIntegrationGCPExists(s *terraform.State) error {
+	log.Println("Checking GCP Int exists")
 	client := testAccProvider.Meta().(*datadog.Client)
 	integrations, err := client.ListIntegrationGCP()
+	log.Printf("These integrations exist %v", integrations)
 	if err != nil {
 		return err
 	}

--- a/datadog/resource_datadog_user_test.go
+++ b/datadog/resource_datadog_user_test.go
@@ -21,9 +21,9 @@ func TestAccDatadogUser_Updated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogUserExists("datadog_user.foo"),
 					resource.TestCheckResourceAttr(
-						"datadog_user.foo", "email", "test@example.com"),
+						"datadog_user.foo", "email", "tftestuser@example.com"),
 					resource.TestCheckResourceAttr(
-						"datadog_user.foo", "handle", "test@example.com"),
+						"datadog_user.foo", "handle", "tftestuser@example.com"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "name", "Test User"),
 					resource.TestCheckResourceAttr(
@@ -38,9 +38,9 @@ func TestAccDatadogUser_Updated(t *testing.T) {
 						"datadog_user.foo", "disabled", "true"),
 					// NOTE: it's not possible ATM to update email of another user
 					resource.TestCheckResourceAttr(
-						"datadog_user.foo", "email", "test@example.com"),
+						"datadog_user.foo", "email", "tftestuser@example.com"),
 					resource.TestCheckResourceAttr(
-						"datadog_user.foo", "handle", "test@example.com"),
+						"datadog_user.foo", "handle", "tftestuser@example.com"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "is_admin", "true"),
 					resource.TestCheckResourceAttr(
@@ -76,8 +76,8 @@ func testAccCheckDatadogUserExists(n string) resource.TestCheckFunc {
 
 const testAccCheckDatadogUserConfigRequired = `
 resource "datadog_user" "foo" {
-  email     = "test@example.com"
-  handle    = "test@example.com"
+  email     = "tftestuser@example.com"
+  handle    = "tftestuser@example.com"
   name      = "Test User"
 }
 `
@@ -86,8 +86,8 @@ const testAccCheckDatadogUserConfigUpdated = `
 resource "datadog_user" "foo" {
   disabled    = true
   // NOTE: it's not possible ATM to update email of another user
-  email       = "test@example.com"
-  handle      = "test@example.com"
+  email       = "tftestuser@example.com"
+  handle      = "tftestuser@example.com"
   is_admin    = true
   access_role = "adm"
   name        = "Updated User"


### PR DESCRIPTION
Fixes up the last two integration tests as of this writing:

TestAccDatadogIntegrationGCP and TestAccDatadogUser_Updated
Neither of these tests were inherently broken, just needed some coercion to play nicely with the CI

GCP: 
The project drifted a bit from the CI but is difficult to fix with limited access. This should address that for now while working on a longer term solution

User:
A user may only edit their own email via the API, not someone elses. The CI DD account likely has a `test@` user in the org. However this doesn't play nicely with running the integration tests locally. This uses a random user email so we get the same test behavior both on the CI and locally. 