### PR TITLE
`datadog_monitor` ignore `query alert` vs `metric alert` diff

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -383,11 +383,13 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 		if d.Get("type").(string) == "metric alert" && typ == "query alert" ||
 			d.Get("type").(string) == "query alert" && typ == "metric alert" {
 			/* Datadog API quirk, see https://github.com/hashicorp/terraform/issues/13784
-			*
+			*                     and https://github.com/terraform-providers/terraform-provider-datadog/issues/241
 			* If current type of monitor is "metric alert" and the API is returning "query alert",
 			* we want to keep "metric alert". We previously had this as DiffSuppressFunc on "type".
 			* After adding a call to "resourceDatadogMonitorRead" in create/update methods, this
-			* started creating the monitor as "query alert". To make sure that the behaviour stays
+			* started creating the monitor as "query alert". The same applies for the reverse, when the
+			* current type of monitor is "query alert" and the API is returning "metric alert"
+			* To make sure that the behaviour stays
 			* the same, we added this code (which made DiffSuppressFunc useless, so we removed it).
 			 */
 		} else {

--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -380,7 +380,8 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("message", m.GetMessage())
 	d.Set("query", m.GetQuery())
 	if typ, ok := m.GetTypeOk(); ok {
-		if d.Get("type").(string) == "metric alert" && typ == "query alert" {
+		if d.Get("type").(string) == "metric alert" && typ == "query alert" ||
+			d.Get("type").(string) == "query alert" && typ == "metric alert" {
 			/* Datadog API quirk, see https://github.com/hashicorp/terraform/issues/13784
 			*
 			* If current type of monitor is "metric alert" and the API is returning "query alert",


### PR DESCRIPTION
Fixes #241 

The API will return `query alert` or `metric alert` depending on the query. We currently ignore the fact that the user may have a `metric alert` but the API returns a `query alert` but we don't ignore the opposite. 

This config seems to replicate the behavior:

```
  name = "Anomolous CPU usage"
  type = "query alert"
  message = "CPU utilization is outside normal bounds"
  query = "avg(last_4h):anomalies(ewma_20(avg:system.cpu.system{env:prod,service:website}.as_rate()), 'robust', 3, direction='below', alert_window='last_30m', interval=60, count_default_zero='true', seasonality='weekly') >= 1"
  thresholds {
    critical          = 1.0
    critical_recovery = 0.0
  }
  threshold_windows {
    trigger_window    = "last_30m"
    recovery_window   = "last_30m"
  }

  notify_no_data    = false
  renotify_interval = 60
}
```

This monitor is seen by Datadog as a `metric alert`. So when the read function occurs the provider sees this as a change in type and does a `forceNew`. This PR aims to suppress that diff. 
