### PR TITLE
Make is_admin computed

### DIFF
--- a/datadog/resource_datadog_user.go
+++ b/datadog/resource_datadog_user.go
@@ -36,8 +36,8 @@ func resourceDatadogUser() *schema.Resource {
 			},
 			"is_admin": {
 				Type:       schema.TypeBool,
+				Computed:   true,
 				Optional:   true,
-				Default:    false,
 				Deprecated: "This parameter will be replaced by `access_role` and will be removed from the next Major version",
 			},
 			"access_role": {
@@ -118,10 +118,10 @@ func resourceDatadogUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("disabled", u.GetDisabled())
 	d.Set("email", u.GetEmail())
 	d.Set("handle", u.GetHandle())
-	d.Set("is_admin", u.GetIsAdmin())
 	d.Set("name", u.GetName())
 	d.Set("verified", u.GetVerified())
 	d.Set("access_role", u.GetAccessRole())
+	d.Set("is_admin", u.GetIsAdmin())
 	return nil
 }
 


### PR DESCRIPTION
The `is_admin` flag that is going through its deprecation process has a lower precedence than the `access_role` flag. 

The is_admin doesn't really get used in the request, but is still returned with a different value depending on what the access_role for that user is set to. For this reason we should make it a Computed value to avoid spurious diffs while users make the transition. 

Before this change, if you were using the is_admin config option and had it set to True, you'd get a user that was an admin. If you transition to the access_role flag, and remove the `is_admin`, the default was False, and Terraform would attempt to mark this flag as false. Since the `access_role` takes precedence this led to an untrue diff being shown to the user on each new plan/apply. This removes that diff unless there is an explicit user config change. 