### PR TITLE
Update error wording for credential validation

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -65,7 +65,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		log.Printf("[ERROR] Datadog Client validation error: %v", err)
 		return client, err
 	} else if !ok {
-		err := errors.New(`No valid credential sources found for Datadog Provider. Please see https://terraform.io/docs/providers/datadog/index.html for more information on providing credentials for the Datadog Provider`)
+		err := errors.New(`Invalid or missing credentials provided to the Datadog Provider. Please confirm your API and APP keys are valid and see https://terraform.io/docs/providers/datadog/index.html for more information on providing credentials for the Datadog Provider`)
 		log.Printf("[ERROR] Datadog Client validation error: %v", err)
 		return client, err
 	}


### PR DESCRIPTION
A `false` response from the Validation command could mean either that the credentials are missing or expired. This updates the error wording a bit to make that clearer. 