### PR TITLE
[Synthetics] Fix follow redirects

### DIFF
--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -394,10 +394,7 @@ func updateSyntheticsTestLocalState(d *schema.ResourceData, syntheticsTest *data
 func convertToString(i interface{}) string {
 	switch v := i.(type) {
 	case bool:
-		if v {
-			return "true"
-		}
-		return "false"
+		return strconv.FormatBool(v)
 	case int:
 		return strconv.Itoa(v)
 	case float64:

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -272,7 +272,7 @@ func newSyntheticsTestFromLocalState(d *schema.ResourceData) *datadog.Synthetics
 		options.SetTickEvery(tickEvery)
 	}
 	if attr, ok := d.GetOk("options.follow_redirects"); ok {
-		followRedirects := attr.(string) == "1"
+		followRedirects := attr.(string) == "true"
 		options.SetFollowRedirects(followRedirects)
 	}
 	if attr, ok := d.GetOk("options.min_failure_duration"); ok {
@@ -391,9 +391,9 @@ func convertToString(i interface{}) string {
 	switch v := i.(type) {
 	case bool:
 		if v {
-			return "1"
+			return "true"
 		}
-		return "0"
+		return "false"
 	case int:
 		return strconv.Itoa(v)
 	case float64:

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -273,6 +273,10 @@ func newSyntheticsTestFromLocalState(d *schema.ResourceData) *datadog.Synthetics
 		options.SetTickEvery(tickEvery)
 	}
 	if attr, ok := d.GetOk("options.follow_redirects"); ok {
+		// TF nested schemas is limited to string values only
+		// follow_redirects being a boolean in Datadog json api
+		// we need a sane way to convert from boolean to string
+		// and from string to boolean
 		followRedirects := attr.(string) == "true"
 		options.SetFollowRedirects(followRedirects)
 	}

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -130,7 +130,7 @@ func syntheticsTestOptions() *schema.Schema {
 		ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 			followRedirectsRaw, ok := val.(map[string]interface{})["follow_redirects"]
 			if ok {
-				followRedirectsStr := followRedirectsRaw.(string)
+				followRedirectsStr := convertToString(followRedirectsRaw)
 				switch followRedirectsStr {
 				case "0", "1":
 					warns = append(warns, fmt.Sprintf("%q must be either true or false, got: %s (please change 1 => true, 0 => false)", key, followRedirectsStr))

--- a/datadog/resource_datadog_synthetics_test_.go
+++ b/datadog/resource_datadog_synthetics_test_.go
@@ -116,7 +116,11 @@ func syntheticsTestOptions() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"follow_redirects": {
-					Type:     schema.TypeBool,
+					Type: schema.TypeBool,
+					DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+						m := map[string]bool{"1": true, "0": false, "true": true, "false": false}
+						return m[oldVal] == m[newVal]
+					},
 					Optional: true,
 				},
 				"min_failure_duration": {

--- a/datadog/resource_datadog_synthetics_test_test.go
+++ b/datadog/resource_datadog_synthetics_test_test.go
@@ -137,6 +137,8 @@ var createSyntheticsAPITestStep = resource.TestStep{
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "options.tick_every", "60"),
 		resource.TestCheckResourceAttr(
+			"datadog_synthetics_test.foo", "options.follow_redirects", "true"),
+		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "options.min_failure_duration", "0"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "options.min_location_failed", "1"),
@@ -199,6 +201,7 @@ resource "datadog_synthetics_test" "foo" {
 	locations = [ "aws:eu-central-1" ]
 	options = {
 		tick_every = 60
+		follow_redirects = true
 		min_failure_duration = 0
 		min_location_failed = 1
 	}
@@ -237,6 +240,8 @@ var updateSyntheticsAPITestStep = resource.TestStep{
 			"datadog_synthetics_test.foo", "locations.0", "aws:eu-central-1"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "options.tick_every", "900"),
+		resource.TestCheckResourceAttr(
+			"datadog_synthetics_test.foo", "options.follow_redirects", "false"),
 		resource.TestCheckResourceAttr(
 			"datadog_synthetics_test.foo", "options.min_failure_duration", "10"),
 		resource.TestCheckResourceAttr(
@@ -282,6 +287,7 @@ resource "datadog_synthetics_test" "foo" {
 
 	options = {
 		tick_every = 900
+		follow_redirects = false
 		min_failure_duration = 10
 		min_location_failed = 1
 	}


### PR DESCRIPTION
Considering:
 - TF nested schemas is limited to string values
 - `follow_redirects` is a boolean in Datadog json api

we need to convert boolean like this:
 - true => "true"
 - false => "false"

☝️better because `follow_redirects` is advertised as a boolean in the documentation