### PR TITLE
Correction to the threshold_windows

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -223,10 +223,12 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 
 	o := datadog.Options{
 		Thresholds:        &thresholds,
-		ThresholdWindows:  &threshold_windows,
 		NotifyNoData:      datadog.Bool(d.Get("notify_no_data").(bool)),
 		RequireFullWindow: datadog.Bool(d.Get("require_full_window").(bool)),
 		IncludeTags:       datadog.Bool(d.Get("include_tags").(bool)),
+	}
+	if threshold_windows.HasRecoveryWindow() || threshold_windows.HasTriggerWindow() {
+		o.SetThresholdWindows(threshold_windows)
 	}
 	if attr, ok := d.GetOk("silenced"); ok {
 		s := make(map[string]int)

--- a/datadog/resource_datadog_monitor_test.go
+++ b/datadog/resource_datadog_monitor_test.go
@@ -521,6 +521,25 @@ func TestAccDatadogMonitor_Log(t *testing.T) {
 	})
 }
 
+func TestAccDatadogMonitor_NoThresholdWindows(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatadogMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogMonitorConfigNoThresholdWindows,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogMonitorExists("datadog_monitor.foo"),
+					resource.TestCheckResourceAttr("datadog_monitor.foo", "name", "test bug 259"),
+					resource.TestCheckResourceAttr("datadog_monitor.foo", "message", "test"),
+					resource.TestCheckResourceAttr("datadog_monitor.foo", "type", "query alert"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatadogMonitor_ThresholdWindows(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1064,6 +1083,29 @@ resource "datadog_monitor" "foo" {
   locked = false
   tags = ["foo:bar", "baz"]
 	enable_logs_sample = true
+}
+`
+
+const testAccCheckDatadogMonitorConfigNoThresholdWindows = `
+resource "datadog_monitor" "foo" {
+	name = "test bug 259"
+	type = "query alert"
+	message = "test"
+	query = "avg(last_1h):anomalies(avg:system.cpu.system{name:cassandra}, 'basic', 2, direction='above') >= 1"
+	thresholds = {
+	  ok = "0.0"
+	  warning = "0.5"
+	  warning_recovery = "0.25"
+	  critical = "1.0"
+	  critical_recovery = "0.5"
+	}
+
+	notify_no_data = false
+	renotify_interval = 60
+
+	notify_audit = false
+	timeout_h = 60
+	include_tags = true
 }
 `
 


### PR DESCRIPTION
This fixes issue #259
The `threshold_windows` should be added only if a window has been set

The Options structure already has the flag to omit it when it is empty:
```
type Options struct {
        ...
	EscalationMessage *string           `json:"escalation_message,omitempty"`
	Thresholds        *ThresholdCount   `json:"thresholds,omitempty"`
	ThresholdWindows  *ThresholdWindows `json:"threshold_windows,omitempty"`
	IncludeTags       *bool             `json:"include_tags,omitempty"`
        ...
}
```