### PR TITLE
Downtime fixes

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -3,6 +3,7 @@ package datadog
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -133,9 +134,17 @@ func resourceDatadogDowntime() *schema.Resource {
 				Description:   "When specified, this downtime will only apply to this monitor",
 			},
 			"monitor_tags": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Description:   "A list of monitor tags (up to 25), i.e. tags that are applied directly to monitors to which the downtime applies",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "A list of monitor tags (up to 25), i.e. tags that are applied directly to monitors to which the downtime applies",
+				// MonitorTags conflicts with MonitorId and it also has a default of `["*"]`, which brings some problems:
+				// * We can't use DefaultFunc to default to ["*"], since that's incompatible with
+				//   ConflictsWith
+				// * Since this is a TypeList, DiffSuppressFunc can't really be written well for it
+				//   (it is called and expected to give result for each element, not for the whole
+				//    list, so there's no way to tell in each iteration whether the new config value
+				//    is an empty list).
+				// Therefore we handle the "default" manually in resourceDatadogDowntimeRead function
 				ConflictsWith: []string{"monitor_id"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
@@ -316,7 +325,10 @@ func resourceDatadogDowntimeRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("recurrence", recurrenceList)
 	}
 	d.Set("scope", dt.Scope)
-	d.Set("monitor_tags", dt.MonitorTags)
+	// See the comment for monitor_tags in the schema definition above
+	if !reflect.DeepEqual(dt.MonitorTags, []string{"*"}) {
+		d.Set("monitor_tags", dt.MonitorTags)
+	}
 	d.Set("start", dt.GetStart())
 
 	return nil

--- a/datadog/resource_datadog_downtime_test.go
+++ b/datadog/resource_datadog_downtime_test.go
@@ -465,8 +465,7 @@ resource "datadog_downtime" "foo" {
   end   = %d
 
   message = "Example Datadog downtime message."
-	monitor_id = "${datadog_monitor.downtime_monitor.id}"
-  monitor_tags = ["*"]
+  monitor_id = "${datadog_monitor.downtime_monitor.id}"
 }
 `, end, start, end)
 }

--- a/website/docs/r/downtime.html.markdown
+++ b/website/docs/r/downtime.html.markdown
@@ -23,14 +23,6 @@ resource "datadog_downtime" "foo" {
     type   = "days"
     period = 1
   }
-
-  # Datadog API will reject dates in the past so let's ignore `start` and `end`
-  # arguments during lifecycle. To update or extend an existing downtime, temporarily
-  # remove the `ignore` section, apply timestamp changes, and re-apply the `ignore`
-  # section.
-  lifecycle {
-    ignore_changes = ["start", "end"]
-  }
 }
 ```
 


### PR DESCRIPTION
This PR includes 2 fixes:

* On updates to downtime attributes, `start` and `end` are no longer sent when unchanged. This makes it possible to update various downtime attributes without having to touch the timestamps.
* Fixes non-empty plan for monitors that have empty `monitor_tags`.
  * Note that this issue wasn't previously discovered because of a faulty test (that I fixed in the same commit). The test is faulty because it seems `ConflictsWith` doesn't work right when one of the attributes has its content from a variable - this seems to be a bug in Terraform and I'm currently discussing that with Hashicorp folks.