### PR TITLE
[dashboards] Safely type assert optional fields from log and apm query

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -3789,8 +3789,10 @@ func buildDatadogApmOrLogQuery(terraformQuery map[string]interface{}) *datadog.W
 	if v, ok := terraformCompute["facet"].(string); ok && len(v) != 0 {
 		datadogCompute.Facet = datadog.String(v)
 	}
-	if v, err := strconv.ParseInt(terraformCompute["interval"].(string), 10, 64); err == nil {
-		datadogCompute.Interval = datadog.Int(int(v))
+	if interval, ok := terraformCompute["interval"].(string); ok && len(interval) != 0 {
+		if v, err := strconv.ParseInt(interval, 10, 64); err == nil {
+			datadogCompute.Interval = datadog.Int(int(v))
+		}
 	}
 	datadogQuery.Compute = &datadogCompute
 	// Search
@@ -3818,7 +3820,7 @@ func buildDatadogApmOrLogQuery(terraformQuery map[string]interface{}) *datadog.W
 					Aggregation: datadog.String(sort["aggregation"].(string)),
 					Order:       datadog.String(sort["order"].(string)),
 				}
-				if len(sort["facet"].(string)) > 0 {
+				if facet, ok := sort["facet"].(string); ok && len(facet) > 0 {
 					datadogGroupBy.Sort.Facet = datadog.String(sort["facet"].(string))
 				}
 			}

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -802,8 +802,8 @@ Nested `apm_query` and `log_query` blocks have the following structure (Visit th
     - `facet` - (Optional)
     - `limit` - (Optional)
     - `sort` - (Optional). One nested block is allowed with the following structure:
-      - `aggregation` - (Optional)
-      - `order` - (Optional)
+      - `aggregation` - (Required)
+      - `order` - (Required)
       - `facet` - (Optional)
 
 


### PR DESCRIPTION
- Add a safe type assert for all optional fields in the dashboard resource (includes `sort->facet` and `compute->interval`). 
- Update documentation