### PR TITLE
Correct typo on dashboard options

### DIFF
--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -630,8 +630,8 @@ Nested `widget` blocks have the following structure:
           - `size`: (Optional) The query used to size the map. Exactly one nested block is allowed with the following structure:
               - `q`: (Required) The metric query to use in the widget.
       - `node_type` - (Optional) The type of node used. Either "host" or "container".
-      - `no_metric_host` - (Optional) Boolean indicating whether to show nodes with no metrics.
-      - `no_group_host` - (Optional) Boolean indicating whether to show ungrouped nodes.
+      - `no_metric_hosts` - (Optional) Boolean indicating whether to show nodes with no metrics.
+      - `no_group_hosts` - (Optional) Boolean indicating whether to show ungrouped nodes.
       - `group` - (Optional) The list of tags to group nodes by.
       - `scope` - (Optional) The list of tags to filter nodes by.
       - `style` - (Optional) Style of the widget graph. One nested block is allowed with the following structure:

--- a/website/docs/r/screenboard.html.markdown
+++ b/website/docs/r/screenboard.html.markdown
@@ -502,8 +502,8 @@ Nested `widget` `tile_def` blocks have the following structure:
 - `node_type` - (Optional, only for widgets of type "hostmap") The type of node used. Either "host" or "container".
 - `scope` - (Optional, only for widgets of type "hostmap") The list of tags to filter nodes by.
 - `group` - (Optional, only for widgets of type "hostmap") The list of tags to group nodes by.
-- `no_group_host` - (Optional, only for widgets of type "hostmap") Boolean indicating whether to show ungrouped nodes.
-- `no_metric_host` - (Optional, only for widgets of type "hostmap") Boolean indicating whether to show nodes with no metrics.
+- `no_group_hosts` - (Optional, only for widgets of type "hostmap") Boolean indicating whether to show ungrouped nodes.
+- `no_metric_hosts` - (Optional, only for widgets of type "hostmap") Boolean indicating whether to show nodes with no metrics.
 - `style` - (Optional, only for widgets of type "hostmap") Nested block describing how to display the widget. The structure of this block is described below. At most one such block should be present in a given tile_def block.
 
 ### Nested `widget` `tile_def` `style` blocks


### PR DESCRIPTION
Correct typo on the `no_metric_groups` and `no_host_groups` options in the dashboard documentation. 

The schema (and the example config) has these as plurals, but the description had them as singular. The proper version is the plural - https://github.com/terraform-providers/terraform-provider-datadog/blob/ee1f7cfb0dae3e59cc2d685ed2b1f3a830f43d59/datadog/resource_datadog_dashboard.go#L1918

Fixes #284 