### PR TITLE
Enable ForceNew=true for dashboard.layout_type

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -39,6 +39,7 @@ func resourceDatadogDashboard() *schema.Resource {
 				Required:     true,
 				Description:  "The layout type of the dashboard, either 'free' or 'ordered'.",
 				ValidateFunc: validateDashboardLayoutType,
+				ForceNew:     true,
 			},
 			"description": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Datadog dashboard's `layout_type` parameter cannot be updated/modified through the API:

```
Error: Failed to update dashboard using Datadog API: API error 400 Bad Request: {"errors": ["'layout_type' is not editable for existing dashboards. This dashboard uses 'ordered' layout."]}
```

As the error helpfully points out, dashboards must be destroyed and recreated to modify the `layout_type`. Turning on `ForceNew` forces Terraform to follow this protocol when changes are made to `layout_type`.