### PR TITLE
[dashboards] Update compute and sort fields types to TypeList

### DIFF
--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -210,7 +210,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 			request {
 				log_query {
 					index = "mcnulty"
-					compute = {
+					compute {
 						aggregation = "count"
 						facet = "@duration"
 						interval = 5000
@@ -221,7 +221,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 					group_by {
 						facet = "host"
 						limit = 10
-						sort = {
+						sort {
 							aggregation = "avg"
 							order = "desc"
 							facet = "@duration"
@@ -233,7 +233,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 			request {
 				apm_query {
 					index = "apm-search"
-					compute = {
+					compute {
 						aggregation = "count"
 						facet = "@duration"
 						interval = 5000
@@ -244,7 +244,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 					group_by {
 						facet = "resource_name"
 						limit = 50
-						sort = {
+						sort {
 							aggregation = "avg"
 							order = "desc"
 							facet = "@string_query.interval"
@@ -619,28 +619,28 @@ func TestAccDatadogDashboard_update(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.0.metadata.0.expression", "avg:system.cpu.user{app:general} by {env}"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.0.metadata.0.alias_name", "Alpha"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.index", "mcnulty"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.compute.aggregation", "count"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.compute.facet", "@duration"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.compute.interval", "5000"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.compute.0.aggregation", "count"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.compute.0.facet", "@duration"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.compute.0.interval", "5000"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.search.query", "status:info"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.#", "1"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.facet", "host"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.limit", "10"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.sort.aggregation", "avg"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.sort.facet", "@duration"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.sort.order", "desc"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.sort.0.aggregation", "avg"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.sort.0.facet", "@duration"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.log_query.0.group_by.0.sort.0.order", "desc"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.1.display_type", "area"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.index", "apm-search"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.compute.aggregation", "count"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.compute.facet", "@duration"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.compute.interval", "5000"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.compute.0.aggregation", "count"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.compute.0.facet", "@duration"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.compute.0.interval", "5000"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.search.query", "type:web"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.#", "1"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.facet", "resource_name"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.limit", "50"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.sort.aggregation", "avg"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.sort.facet", "@string_query.interval"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.sort.order", "desc"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.sort.0.aggregation", "avg"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.sort.0.facet", "@string_query.interval"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.apm_query.0.group_by.0.sort.0.order", "desc"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.2.display_type", "bars"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.3.process_query.0.metric", "process.stat.cpu.total_pct"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.request.3.process_query.0.search_by", "error"),

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -236,7 +236,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
       request {
         log_query {
           index = "mcnulty"
-          compute = {
+          compute {
             aggregation = "count"
             facet = "@duration"
             interval = 5000
@@ -247,7 +247,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
           group_by {
             facet = "host"
             limit = 10
-            sort = {
+            sort {
               aggregation = "avg"
               order = "desc"
               facet = "@duration"
@@ -259,7 +259,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
       request {
         apm_query {
           index = "apm-search"
-          compute = {
+          compute {
             aggregation = "count"
             facet = "@duration"
             interval = 5000
@@ -270,7 +270,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
           group_by {
             facet = "resource_name"
             limit = 50
-            sort = {
+            sort {
               aggregation = "avg"
               order = "desc"
               facet = "@string_query.interval"


### PR DESCRIPTION
Since `TypeMap`  doesn't appear to let us use standard schema functions for its sub elements (e.g. `Required`, `Validate`, `DiffSuppressFunc`), we decided to use `TypeList` instead, in `compute` and `group_by`->`sort` fields.

- This PR fixes the panic crashes that occur when we don't set some required fields.
- Updates the tests and docs examples.

 **Warning**: This PR might lead to breaking changes (when using terraform 0.12).

Example:

```
resource "datadog_dashboard" "dashboard_test" {
	title = "Dashboard Test"
	description   = "Created using the Datadog provider in Terraform"
	widget {
		timeseries_definition {
			request {
				log_query {
					index = "mcnulty"
					compute {
						aggregation = "avg"
						facet = "@duration"
						interval = 5000
					}
					search = {
						query = "status:info"
					}
					group_by {
						facet = "host"
						limit = 10
						sort {
							aggregation = "avg"
							order = "desc"
							facet = "@duration"
						}
					}
				}
				display_type = "area"
			}
		}
	}
}
```