### PR TITLE
[dashboards] Add safe type asserts to required fields

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -3783,11 +3783,12 @@ func buildDatadogApmOrLogQuery(terraformQuery map[string]interface{}) *datadog.W
 	}
 	// Compute
 	terraformCompute := terraformQuery["compute"].(map[string]interface{})
-	datadogCompute := datadog.ApmOrLogQueryCompute{
-		Aggregation: datadog.String(terraformCompute["aggregation"].(string)),
+	datadogCompute := datadog.ApmOrLogQueryCompute{}
+	if aggr, ok := terraformCompute["aggregation"].(string); ok && len(aggr) != 0 {
+		datadogCompute.Aggregation = datadog.String(aggr)
 	}
-	if v, ok := terraformCompute["facet"].(string); ok && len(v) != 0 {
-		datadogCompute.Facet = datadog.String(v)
+	if facet, ok := terraformCompute["facet"].(string); ok && len(facet) != 0 {
+		datadogCompute.Facet = datadog.String(facet)
 	}
 	if interval, ok := terraformCompute["interval"].(string); ok && len(interval) != 0 {
 		if v, err := strconv.ParseInt(interval, 10, 64); err == nil {
@@ -3816,9 +3817,13 @@ func buildDatadogApmOrLogQuery(terraformQuery map[string]interface{}) *datadog.W
 			}
 			// Sort
 			if sort, ok := groupBy["sort"].(map[string]interface{}); ok && len(sort) > 0 {
-				datadogGroupBy.Sort = &datadog.ApmOrLogQueryGroupBySort{
-					Aggregation: datadog.String(sort["aggregation"].(string)),
-					Order:       datadog.String(sort["order"].(string)),
+
+				datadogGroupBy.Sort = &datadog.ApmOrLogQueryGroupBySort{}
+				if aggr, ok := sort["aggregation"].(string); ok && len(aggr) > 0 {
+					datadogGroupBy.Sort.Aggregation = datadog.String(aggr)
+				}
+				if order, ok := sort["order"].(string); ok && len(order) > 0 {
+					datadogGroupBy.Sort.Order = datadog.String(order)
 				}
 				if facet, ok := sort["facet"].(string); ok && len(facet) > 0 {
 					datadogGroupBy.Sort.Facet = datadog.String(sort["facet"].(string))


### PR DESCRIPTION
### Description

- This PR fixes panic crashes that occur when we don't set some required fields

Since `TypeMap` doesn't seem to let us use standard schema functions for its sub elements (e.g. `Required`, `Validate`, `DiffSuppressFunc`), we decided to type assert required fields also (i.e. `compute->aggregation`, `sort`->`aggregation` and `sort`->`order` fields). So, if they aren't present, they aren't sent to the API and this will result in a response error.

