### PR TITLE
Add make command to update go api client dep

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=datadog
 DIR=~/.terraform.d/plugins
+GO_CLIENT_VERSION=master
 
 default: build
 
@@ -65,5 +66,9 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+update-go-client:
+	go get github.com/zorkian/go-datadog-api@$(GO_CLIENT_VERSION)
+	go mod vendor
+	go mod tidy
 
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test


### PR DESCRIPTION
Adds a new make command `update-go-client`. 

By default this will update the go client to the latest master. 
It also accepts an argument `GO_CLIENT_VERSION` so you can pick the revision you want to update to, ex:

```
make update-go-client GO_CLIENT_VERSION=v2.22.0
```