### PR TITLE
remove deprecated parameters from MANAGE_STATUS_WIDGET

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2363,15 +2363,6 @@ func buildDatadogManageStatusDefinition(terraformDefinition map[string]interface
 	datadogDefinition.Type = datadog.String(datadog.MANAGE_STATUS_WIDGET)
 	datadogDefinition.Query = datadog.String(terraformDefinition["query"].(string))
 	// Optional params
-	if v, ok := terraformDefinition["sort"].(string); ok && len(v) != 0 {
-		datadogDefinition.SetSort(v)
-	}
-	if v, ok := terraformDefinition["count"].(int); ok {
-		datadogDefinition.SetCount(v)
-	}
-	if v, ok := terraformDefinition["start"].(int); ok {
-		datadogDefinition.SetStart(v)
-	}
 	if v, ok := terraformDefinition["display_format"].(string); ok && len(v) != 0 {
 		datadogDefinition.SetDisplayFormat(v)
 	}
@@ -2398,15 +2389,6 @@ func buildTerraformManageStatusDefinition(datadogDefinition datadog.ManageStatus
 	// Required params
 	terraformDefinition["query"] = *datadogDefinition.Query
 	// Optional params
-	if datadogDefinition.Sort != nil {
-		terraformDefinition["sort"] = *datadogDefinition.Sort
-	}
-	if datadogDefinition.Count != nil {
-		terraformDefinition["count"] = *datadogDefinition.Count
-	}
-	if datadogDefinition.Start != nil {
-		terraformDefinition["start"] = *datadogDefinition.Start
-	}
 	if datadogDefinition.DisplayFormat != nil {
 		terraformDefinition["display_format"] = *datadogDefinition.DisplayFormat
 	}

--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -430,12 +430,9 @@ resource "datadog_dashboard" "free_dashboard" {
 	widget {
 		manage_status_definition {
 			color_preference = "text"
-			count = 50
 			display_format = "countsAndList"
 			hide_zero_counts = true
 			query = "type:metric"
-			sort = "status,asc"
-			start = 0
 			title = "Widget Title"
 			title_size = 16
 			title_align = "left"
@@ -756,12 +753,9 @@ func TestAccDatadogDashboard_update(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.5.layout.y", "51"),
 					// Manage Status widget
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.color_preference", "text"),
-					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.count", "50"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.display_format", "countsAndList"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.hide_zero_counts", "true"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.query", "type:metric"),
-					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.sort", "status,asc"),
-					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.start", "0"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.title", "Widget Title"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.title_align", "left"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "widget.6.manage_status_definition.0.title_size", "16"),


### PR DESCRIPTION
According to https://docs.datadoghq.com/graphing/widgets/monitor_summary/ the set of parameters accepted by the manage status (Monitor Summary) widget have changed. This PR removes the deprecated parameters.