### PR TITLE
Make sure PD services don't get removed by updating PD resource

### DIFF
--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -167,15 +167,17 @@ func resourceDatadogIntegrationPagerdutyUpdate(d *schema.ResourceData, meta inte
 	// if there are none currently configured services, we actually
 	// have to remove them explicitly, otherwise the underlying API client
 	// would not send the "services" key at all and they wouldn't get deleted
-	currentServices := d.Get("services").([]interface{})
-	if len(currentServices) == 0 {
-		pd, err := client.GetIntegrationPD()
-		if err != nil {
-			return fmt.Errorf("Error while deleting Pagerduty integration service object: %v", err)
-		}
-		for _, service := range pd.Services {
-			if err := client.DeleteIntegrationPDService(*service.ServiceName); err != nil {
+	if value, ok := d.GetOk("individual_services"); !ok || !value.(bool) {
+		currentServices := d.Get("services").([]interface{})
+		if len(currentServices) == 0 {
+			pd, err := client.GetIntegrationPD()
+			if err != nil {
 				return fmt.Errorf("Error while deleting Pagerduty integration service object: %v", err)
+			}
+			for _, service := range pd.Services {
+				if err := client.DeleteIntegrationPDService(*service.ServiceName); err != nil {
+					return fmt.Errorf("Error while deleting Pagerduty integration service object: %v", err)
+				}
 			}
 		}
 	}

--- a/datadog/resource_datadog_integration_pagerduty_service_object_test.go
+++ b/datadog/resource_datadog_integration_pagerduty_service_object_test.go
@@ -1,6 +1,7 @@
 package datadog
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -46,6 +47,10 @@ func TestAccDatadogIntegrationPagerdutyServiceObject_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_integration_pagerduty_service_object.testing_bar", "service_key", "54321098765432109876_2"),
 				),
+			},
+			{
+				// make sure that updating the PD resource itself doesn't delete the individual service objects
+				Config: strings.Replace(testAccCheckDatadogIntegrationPagerdutyServiceObjectUpdatedConfig, "testdomain", "testdomain2", -1),
 			},
 		},
 	})

--- a/datadog/resource_datadog_integration_pagerduty_test.go
+++ b/datadog/resource_datadog_integration_pagerduty_test.go
@@ -89,6 +89,11 @@ func TestAccDatadogIntegrationPagerduty_Migrate2ServiceObjects(t *testing.T) {
 				),
 			},
 			{
+				// this represents the intermediary step which will ensure the old
+				// inline-defined service objects get removed
+				Config: testAccCheckDatadogIntegrationPagerdutyConfigDuringMigration,
+			},
+			{
 				Config: testAccCheckDatadogIntegrationPagerdutyConfigAfterMigration,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatadogIntegrationPagerdutyExists("datadog_integration_pagerduty.pd"),
@@ -192,6 +197,16 @@ resource "datadog_integration_pagerduty" "pd" {
 		  service_key = services.value
 	  }
   }
+  schedules = [
+	  "https://ddog.pagerduty.com/schedules/X123VF",
+	  "https://ddog.pagerduty.com/schedules/X321XX"
+	]
+  subdomain = "ddog"
+  api_token = "*****"
+}`
+
+const testAccCheckDatadogIntegrationPagerdutyConfigDuringMigration = `
+resource "datadog_integration_pagerduty" "pd" {
   schedules = [
 	  "https://ddog.pagerduty.com/schedules/X123VF",
 	  "https://ddog.pagerduty.com/schedules/X321XX"

--- a/website/docs/r/integration_pagerduty.html.markdown
+++ b/website/docs/r/integration_pagerduty.html.markdown
@@ -97,10 +97,10 @@ resource "datadog_integration_pagerduty" "pd" {
 
 ### Migrating from Inline Services to Individual Resources
 
-Migrating from usage of inline services to individual resources is very simple. The following example shows how to convert an existing inline services configuration to configuration using individual resources. Doing analogous change and running `terraform apply` is all that's necessary to migrate.
+Migrating from usage of inline services to individual resources is very simple. The following example shows how to convert an existing inline services configuration to configuration using individual resources. Doing analogous change and running `terraform apply` after every step is all that's necessary to migrate.
 
 ```
-# Before
+# First step - this is what the configuration looked like initially
 
 locals {
   pd_services = {
@@ -127,11 +127,24 @@ resource "datadog_integration_pagerduty" "pd" {
 ```
 
 ```
-# After
+# Second step - this will remove the inline-defined service objects
+# Note that during this step, `individual_services` must not be defined
+resource "datadog_integration_pagerduty" "pd" {
+  # `services` was removed
+  schedules = [
+    "https://ddog.pagerduty.com/schedules/X123VF",
+    "https://ddog.pagerduty.com/schedules/X321XX"
+    ]
+  subdomain = "ddog"
+  api_token = "38457822378273432587234242874"
+}
+```
+
+```
+# Third step - this will reintroduce the service objects as individual resources
 
 resource "datadog_integration_pagerduty" "pd" {
-  # `individual_services` was added
-  # `services` was removed
+  # `individual_services = true` was added
   individual_services = true
   schedules = [
     "https://ddog.pagerduty.com/schedules/X123VF",


### PR DESCRIPTION
Previously, doing any update on the PD resource would delete the individual service objects. This PR fixes that (at the cost of doing the migration from inline services to individual service objects somewhat harder, but that's a one-time migration process, so shouldn't hurt a lot - I don't see a better way to solve this).

Fixes #299.