### PR TITLE
Fix integration tests (again)

### DIFF
--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -282,7 +282,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 			event {
 				q = "sources:test tags:2"
 			}
-			yaxis = {
+			yaxis {
 				scale = "log"
 				include_zero = false
 				max = 100
@@ -670,9 +670,9 @@ func TestAccDatadogDashboard_update(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.time.live_span", "1h"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.event.0.q", "sources:test tags:1"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.event.1.q", "sources:test tags:2"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.yaxis.scale", "log"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.yaxis.include_zero", "false"),
-					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.yaxis.max", "100"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.yaxis.0.scale", "log"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.yaxis.0.include_zero", "false"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.yaxis.0.max", "100"),
 					// Toplist widget
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.11.toplist_definition.0.request.0.q", "avg:system.cpu.user{app:general} by {env}"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.11.toplist_definition.0.request.0.conditional_formats.#", "2"),

--- a/datadog/resource_datadog_screenboard_test.go
+++ b/datadog/resource_datadog_screenboard_test.go
@@ -586,7 +586,7 @@ func TestAccDatadogScreenboard_update(t *testing.T) {
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.no_metric_hosts", "false"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.node_type", ""),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.precision", ""),
-			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.request.#", "1"),
+			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.request.#", "4"),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.request.0.aggregator", ""),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.request.0.change_type", ""),
 			resource.TestCheckResourceAttr("datadog_screenboard.acceptance_test", "widget.1.tile_def.0.request.0.compare_to", ""),

--- a/datadog/resource_datadog_service_level_objective_test.go
+++ b/datadog/resource_datadog_service_level_objective_test.go
@@ -29,7 +29,7 @@ resource "datadog_service_level_objective" "foo" {
 
   thresholds {
 	timeframe = "30d"
-	target = 99 
+	target = 99
   }
 
   tags = ["foo:bar", "baz"]
@@ -54,7 +54,8 @@ resource "datadog_service_level_objective" "foo" {
 
   thresholds {
 	timeframe = "30d"
-	target = 98 
+	target = 98
+	warning = 99.0
   }
 
   tags = ["foo:bar", "baz"]
@@ -189,7 +190,7 @@ func testAccCheckDatadogServiceLevelObjectiveDestroy(s *terraform.State) error {
 func testAccCheckDatadogServiceLevelObjectiveExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*datadog.Client)
-		if err := existsHelper(s, client); err != nil {
+		if err := existsServiceLevelObjectiveHelper(s, client); err != nil {
 			return err
 		}
 		return nil

--- a/datadog/resource_datadog_timeboard_test.go
+++ b/datadog/resource_datadog_timeboard_test.go
@@ -145,6 +145,11 @@ resource "datadog_timeboard" "acceptance_test" {
     viz = "timeseries"
     request {
       q = "avg:system.cpu.user{*}"
+      metadata_json = jsonencode({
+        "avg:system.cpu.user{*}": {
+          "alias": "Avg CPU user"
+        }
+      })
       type = "line"
       style = {
         palette = "purple"
@@ -168,6 +173,7 @@ resource "datadog_timeboard" "acceptance_test" {
           limit = 10
           sort {
             aggregation = "avg"
+            facet = "@duration"
             order = "desc"
           }
         }


### PR DESCRIPTION
Looks like nobody ran these for a while and some failures accumulated due to several changes, so here's the fix to make all tests pass again (also on TF 0.12)