### PR TITLE
Add missing 'exists' methods to PD integration and PD service objects

### DIFF
--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -16,6 +17,7 @@ func resourceDatadogIntegrationPagerduty() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDatadogIntegrationPagerdutyCreate,
 		Read:   resourceDatadogIntegrationPagerdutyRead,
+		Exists: resourceDatadogIntegrationPagerdutyExists,
 		Update: resourceDatadogIntegrationPagerdutyUpdate,
 		Delete: resourceDatadogIntegrationPagerdutyDelete,
 		Importer: &schema.ResourceImporter{
@@ -148,6 +150,20 @@ func resourceDatadogIntegrationPagerdutyRead(d *schema.ResourceData, meta interf
 	d.Set("api_token", pd.GetAPIToken())
 
 	return nil
+}
+
+func resourceDatadogIntegrationPagerdutyExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+	client := meta.(*datadog.Client)
+
+	_, err := client.GetIntegrationPD()
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 func resourceDatadogIntegrationPagerdutyUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/datadog/resource_datadog_integration_pagerduty_service_object.go
+++ b/datadog/resource_datadog_integration_pagerduty_service_object.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/zorkian/go-datadog-api"
@@ -13,6 +14,7 @@ func resourceDatadogIntegrationPagerdutySO() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDatadogIntegrationPagerdutySOCreate,
 		Read:   resourceDatadogIntegrationPagerdutySORead,
+		Exists: resourceDatadogIntegrationPagerdutySOExists,
 		Update: resourceDatadogIntegrationPagerdutySOUpdate,
 		Delete: resourceDatadogIntegrationPagerdutySODelete,
 		// since the API never returns service_key, it's impossible to meaningfully import resources
@@ -77,6 +79,20 @@ func resourceDatadogIntegrationPagerdutySORead(d *schema.ResourceData, meta inte
 	}
 
 	return nil
+}
+
+func resourceDatadogIntegrationPagerdutySOExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+	client := meta.(*datadog.Client)
+
+	_, err := client.GetIntegrationPDService(d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 func resourceDatadogIntegrationPagerdutySOUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Without this, people would experience TF error out if the integration was manually deactivated outside TF (the Read functions would fail with 404 and TF wouldn't recover from that).