### PR TITLE
Properly add show_legend

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -3035,6 +3035,9 @@ func buildDatadogTimeseriesDefinition(terraformDefinition map[string]interface{}
 	if v, ok := terraformDefinition["time"].(map[string]interface{}); ok && len(v) > 0 {
 		datadogDefinition.Time = buildDatadogWidgetTime(v)
 	}
+	if v, ok := terraformDefinition["show_legend"].(bool); ok {
+		datadogDefinition.ShowLegend = datadog.Bool(v)
+	}
 	return datadogDefinition
 }
 
@@ -3064,6 +3067,9 @@ func buildTerraformTimeseriesDefinition(datadogDefinition datadog.TimeseriesDefi
 	}
 	if datadogDefinition.Time != nil {
 		terraformDefinition["time"] = buildTerraformWidgetTime(*datadogDefinition.Time)
+	}
+	if datadogDefinition.ShowLegend != nil {
+		terraformDefinition["show_legend"] = *datadogDefinition.ShowLegend
 	}
 	return terraformDefinition
 }

--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -273,6 +273,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
 				label = " x=8 "
 			}
 			title = "Widget Title"
+			show_legend = true
 			time = {
 				live_span = "1h"
 			}
@@ -667,6 +668,7 @@ func TestAccDatadogDashboard_update(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.marker.1.label", " x=8 "),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.marker.1.value", "10 < y < 999"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.title", "Widget Title"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.show_legend", "true"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.time.live_span", "1h"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.event.0.q", "sources:test tags:1"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.10.timeseries_definition.0.event.1.q", "sources:test tags:2"),

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -299,6 +299,7 @@ resource "datadog_dashboard" "ordered_dashboard" {
         label = " x=8 "
       }
       title = "Widget Title"
+      show_legend = true
       time = {
         live_span = "1h"
       }
@@ -737,6 +738,7 @@ Nested `widget` blocks have the following structure:
         - `title_size`: (Optional) The size of the widget's title. Default is 16.
         - `title_align`: (Optional) The alignment of the widget's title. One of "left", "center", or "right".
         - `time`: (Optional) Nested block describing the timeframe to use when displaying the widget. The structure of this block is described [below](dashboard.html#nested-widget-time-blocks).
+        - `show_legend`: (Optional) Whether or not to show the legend on this widget.
         - `event`: (Optional) The definition of the event to overlay on the graph. Includes the following structure:
           - `q`: (Required) The event query to use in the widget
         - `yaxis`: (Optional) Nested block describing the Y-Axis Controls. The structure of this block is described [below](dashboard.html#nested-widget-axis-blocks)


### PR DESCRIPTION
`show_legend` was in the timeseries schema but not being added to the state/api request. This addresses that. 

Fixes: #323 