### PR TITLE
Fix synth resource docs to reference `id` as exported attribute

### DIFF
--- a/website/docs/r/synthetics.html.markdown
+++ b/website/docs/r/synthetics.html.markdown
@@ -148,7 +148,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-- `public_id` - ID of the Datadog synthetics test
+- `id` - ID of the Datadog synthetics test
 
 ## Import
 

--- a/website/docs/r/synthetics.html.markdown
+++ b/website/docs/r/synthetics.html.markdown
@@ -148,7 +148,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-- `id` - ID of the Datadog synthetics test
+- `id` - ID (public_id) of the Datadog synthetics test
 
 ## Import
 


### PR DESCRIPTION
Fixes #321 