### PR TITLE
add example to the Downtime resource documentation

### DIFF
--- a/website/docs/r/downtime.html.markdown
+++ b/website/docs/r/downtime.html.markdown
@@ -10,10 +10,27 @@ description: |-
 
 Provides a Datadog downtime resource. This can be used to create and manage Datadog downtimes.
 
-## Example Usage
+## Example: downtime for a specific monitor
 
 ```hcl
-# Create a new daily 1700-0900 Datadog downtime
+# Create a new daily 1700-0900 Datadog downtime for a specific monitor id
+resource "datadog_downtime" "foo" {
+  scope = ["*"]
+  start = 1483308000
+  end   = 1483365600
+  monitor_id = 12345
+
+  recurrence {
+    type   = "days"
+    period = 1
+  }
+}
+```
+
+## Example: downtime for all monitors
+
+```hcl
+# Create a new daily 1700-0900 Datadog downtime for all monitors
 resource "datadog_downtime" "foo" {
   scope = ["*"]
   start = 1483308000


### PR DESCRIPTION
Motiviation:
- the existing documentation provides only one example for the Downtime resource
- the existing documentation provides an example that mutes **all** monitors
- Muting all monitors is not necessarily the best thing to do for large enterprises
- this PR is an attempt to show developers how to configure a Downtime for a single monitor
