### PR TITLE
Ignore the change of no_data_timeframe if notify_no_data is false

### DIFF
--- a/datadog/resource_datadog_monitor.go
+++ b/datadog/resource_datadog_monitor.go
@@ -136,6 +136,15 @@ func resourceDatadogMonitor() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  10,
+				DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+					if !d.Get("notify_no_data").(bool) {
+						if newVal != oldVal {
+							log.Printf("[DEBUG] Ignore the no_data_timeframe change of monitor '%s' because notify_no_data is false.", d.Get("name"))
+						}
+						return true
+					}
+					return newVal == oldVal
+				},
 			},
 			"renotify_interval": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
This PR will resolve https://github.com/terraform-providers/terraform-provider-datadog/issues/383.

Datadog seems to have changed the response of monitors recently modified and the response no longer includes "no_data_timeframe" if "notify_no_data" is false.
For example, if I execute the following script:

```sh
for monitor_id in $OLD_MONITOR_ID $RECENTLY_MODIFIED_MONITOR_ID; do
  curl -s -X GET \
  -H "DD-API-KEY: ${DATADOG_API_KEY}" \
  -H "DD-APPLICATION-KEY: ${DATADOG_APP_KEY}" \
  -d "group_states=all" \
  "https://api.datadoghq.com/api/v1/monitor/${monitor_id}" | \
  jq '{modified, options: .options | {notify_no_data, no_data_timeframe}}'
done
```

The output is like below:

```
{
  "modified": "2019-09-17T08:08:32.094503+00:00",
  "options": {
    "notify_no_data": false,
    "no_data_timeframe": 10
  }
}
{
  "modified": "2020-01-07T14:06:55.889061+00:00",
  "options": {
    "notify_no_data": false,
    "no_data_timeframe": null
  }
}
```