### PR TITLE
Fix optional threshold fields handling in update function

### DIFF
--- a/datadog/resource_datadog_service_level_objective_test.go
+++ b/datadog/resource_datadog_service_level_objective_test.go
@@ -151,7 +151,7 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.1.target", "98"),
 					resource.TestCheckResourceAttr(
-						"datadog_service_level_objective.foo", "thresholds.1.warning", "99.0"),
+						"datadog_service_level_objective.foo", "thresholds.1.warning", "99"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.2.timeframe", "90d"),
 					resource.TestCheckResourceAttr(

--- a/datadog/resource_datadog_service_level_objective_test.go
+++ b/datadog/resource_datadog_service_level_objective_test.go
@@ -107,14 +107,10 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 						"datadog_service_level_objective.foo", "thresholds.1.timeframe", "30d"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.1.target", "99"),
-					resource.TestCheckNoResourceAttr(
-						"datadog_service_level_objective.foo", "thresholds.1.warning"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.2.timeframe", "90d"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.2.target", "99"),
-					resource.TestCheckNoResourceAttr(
-						"datadog_service_level_objective.foo", "thresholds.2.warning"),
 					// Tags are a TypeSet => use a weird way to access members by their hash
 					// TF TypeSet is internally represented as a map that maps computed hashes
 					// to actual values. Since the hashes are always the same for one value,
@@ -160,8 +156,6 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 						"datadog_service_level_objective.foo", "thresholds.2.timeframe", "90d"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.2.target", "99.9"),
-					resource.TestCheckNoResourceAttr(
-						"datadog_service_level_objective.foo", "thresholds.2.warning"),
 					// Tags are a TypeSet => use a weird way to access members by their hash
 					// TF TypeSet is internally represented as a map that maps computed hashes
 					// to actual values. Since the hashes are always the same for one value,

--- a/datadog/resource_datadog_service_level_objective_test.go
+++ b/datadog/resource_datadog_service_level_objective_test.go
@@ -32,6 +32,11 @@ resource "datadog_service_level_objective" "foo" {
 	target = 99
   }
 
+  thresholds {
+	timeframe = "90d"
+	target = 99
+  }
+
   tags = ["foo:bar", "baz"]
 }
 `
@@ -56,6 +61,11 @@ resource "datadog_service_level_objective" "foo" {
 	timeframe = "30d"
 	target = 98
 	warning = 99.0
+  }
+
+  thresholds {
+	timeframe = "90d"
+	target = 99.9
   }
 
   tags = ["foo:bar", "baz"]
@@ -86,7 +96,7 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 						"datadog_service_level_objective.foo", "query.0.denominator", "sum:my.metric{*}.as_count()"),
 					// Thresholds are a TypeList, that are sorted by timeframe alphabetically.
 					resource.TestCheckResourceAttr(
-						"datadog_service_level_objective.foo", "thresholds.#", "2"),
+						"datadog_service_level_objective.foo", "thresholds.#", "3"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.0.timeframe", "7d"),
 					resource.TestCheckResourceAttr(
@@ -97,6 +107,14 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 						"datadog_service_level_objective.foo", "thresholds.1.timeframe", "30d"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.1.target", "99"),
+					resource.TestCheckNoResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.1.warning"),
+					resource.TestCheckResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.2.timeframe", "90d"),
+					resource.TestCheckResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.2.target", "99"),
+					resource.TestCheckNoResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.2.warning"),
 					// Tags are a TypeSet => use a weird way to access members by their hash
 					// TF TypeSet is internally represented as a map that maps computed hashes
 					// to actual values. Since the hashes are always the same for one value,
@@ -125,7 +143,7 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 						"datadog_service_level_objective.foo", "query.0.denominator", "sum:my.metric{type:good}.as_count() + sum:my.metric{type:bad}.as_count()"),
 					// Thresholds are a TypeList, that are sorted by timeframe alphabetically.
 					resource.TestCheckResourceAttr(
-						"datadog_service_level_objective.foo", "thresholds.#", "2"),
+						"datadog_service_level_objective.foo", "thresholds.#", "3"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.0.timeframe", "7d"),
 					resource.TestCheckResourceAttr(
@@ -136,6 +154,14 @@ func TestAccDatadogServiceLevelObjective_Basic(t *testing.T) {
 						"datadog_service_level_objective.foo", "thresholds.1.timeframe", "30d"),
 					resource.TestCheckResourceAttr(
 						"datadog_service_level_objective.foo", "thresholds.1.target", "98"),
+					resource.TestCheckResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.1.warning", "99.0"),
+					resource.TestCheckResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.2.timeframe", "90d"),
+					resource.TestCheckResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.2.target", "99.9"),
+					resource.TestCheckNoResourceAttr(
+						"datadog_service_level_objective.foo", "thresholds.2.warning"),
 					// Tags are a TypeSet => use a weird way to access members by their hash
 					// TF TypeSet is internally represented as a map that maps computed hashes
 					// to actual values. Since the hashes are always the same for one value,


### PR DESCRIPTION
Optional fields in the threshold object were always added to the update payload, even when they were not actually set in the state or the configuration.
This broke the update function as the `warning` field cannot be set to a lower value that the slo value (`target`), which triggers a `warning must be greater than slo value` error.

If the warning field was not set, the `ResourceData.Get()` function would return the default value for the field, which is `0.0` for a float, hence the error being triggered.

This PR fixes this problem by using the `ResourceData.GetOk()` to check if the field was actually set or not.

The code was compiled and tested for two scenarios, both working as expected:

- The update of an slo created with the previous terraform provider
- The creation and then the update of an slo created with the new code