### PR TITLE
Add template_variable_presets to datadog_dashboard

### DIFF
--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -356,6 +356,26 @@ resource "datadog_dashboard" "ordered_dashboard" {
 		prefix = "service_name"
 		default = "autoscaling"
 	}
+	template_variable_preset {
+		name = "preset_1"
+
+		template_variable {
+			name = "var_1"
+			value = "var_1_value"
+		}
+		template_variable {
+			name = "var_2"
+			value = "var_2_value"
+		}
+	}
+	template_variable_preset {
+		name = "preset_2"
+
+		template_variable {
+			name = "var_1"
+			value = "var_1_value"
+		}
+	}
 }
 
 resource "datadog_dashboard" "free_dashboard" {
@@ -507,6 +527,26 @@ resource "datadog_dashboard" "free_dashboard" {
 		name   = "var_2"
 		prefix = "service_name"
 		default = "autoscaling"
+	}
+	template_variable_preset {
+		name = "preset_1"
+
+		template_variable {
+			name = "var_1"
+			value = "var_1_value"
+		}
+		template_variable {
+			name = "var_2"
+			value = "var_2_value"
+		}
+	}
+	template_variable_preset {
+		name = "preset_2"
+
+		template_variable {
+			name = "var_1"
+			value = "var_1_value"
+		}
 	}
 }
 `
@@ -733,6 +773,17 @@ func TestAccDatadogDashboard_update(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.1.default", "autoscaling"),
 					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "description", "Created using the Datadog provider in Terraform"),
 
+					// Template Variable Presets
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.#", "2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.0.name", "preset_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.0.template_variable.0.name", "var_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.0.template_variable.0.value", "var_1_value"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.0.template_variable.1.name", "var_2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.0.template_variable.1.value", "var_2_value"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.1.name", "preset_2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.1.template_variable.0.name", "var_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable_preset.1.template_variable.0.value", "var_1_value"),
+
 					// Free layout dashboard
 
 					// Dashboard metadata
@@ -834,6 +885,17 @@ func TestAccDatadogDashboard_update(t *testing.T) {
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable.1.default", "autoscaling"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable.1.name", "var_2"),
 					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable.1.prefix", "service_name"),
+
+					// Template Variable Presets
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.#", "2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.0.name", "preset_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.0.template_variable.0.name", "var_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.0.template_variable.0.value", "var_1_value"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.0.template_variable.1.name", "var_2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.0.template_variable.1.value", "var_2_value"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.1.name", "preset_2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.1.template_variable.0.name", "var_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.free_dashboard", "template_variable_preset.1.template_variable.0.value", "var_1_value"),
 				),
 			},
 		},

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -387,6 +387,18 @@ resource "datadog_dashboard" "ordered_dashboard" {
     prefix = "service_name"
     default = "autoscaling"
   }
+
+  template_variable_preset {
+    name = "preset_1"
+    template_variable {
+      name = "var_1"
+      value = "host.dc"
+    }
+    template_variable {
+      name = "var_2"
+      value = "my_service"
+    }
+  }
 }
 ```
 ## Example Usage: Create a new Datadog dashboard - Free layout
@@ -549,6 +561,18 @@ resource "datadog_dashboard" "free_dashboard" {
     prefix = "service_name"
     default = "autoscaling"
   }
+
+  template_variable_preset {
+    name = "preset_1"
+    template_variable {
+      name = "var_1"
+      value = "host.dc"
+    }
+    template_variable {
+      name = "var_2"
+      value = "my_service"
+    }
+  }
 }
 ```
 
@@ -557,13 +581,14 @@ resource "datadog_dashboard" "free_dashboard" {
 The following arguments are supported:
 
 - `title` - (Required) Title of the dashboard.
-- `widget` - (Required) Nested block describing a widget. The structure of this block is described [below](dashboard.html#nested-widget-blocks). Multiple `widget` blocks are allowed within a `datadog_dashboard` resource
+- `widget` - (Required) Nested block describing a widget. The structure of this block is described [below](dashboard.html#nested-widget-blocks). Multiple `widget` blocks are allowed within a `datadog_dashboard` resource.
 - `layout_type` - (Required) Layout type of the dashboard. Available values are: `ordered` (previous timeboard) or `free` (previous screenboard layout).
 <br>**Note: This value cannot be changed. Converting a dashboard from `free` <-> `ordered` requires destroying and re-creating the dashboard.** Instead of using `ForceNew`, this is a manual action as many underlying widget configs need to be updated to work for the updated layout, otherwise the new dashboard won't be created properly.
 - `description` - (Optional) Description of the dashboard.
 - `is_read_only` - (Optional) Whether this dashboard is read-only. If `true`, only the author and admins can make changes to it.
 - `notify_list` - (Optional) List of handles of users to notify when changes are made to this dashboard.
 - `template_variables` - (Optional) Nested block describing a template variable. The structure of this block is described [below](dashboard.html#nested-template_variable-blocks). Multiple template_variable blocks are allowed within a `datadog_dashboard` resource.
+- `template_variable_presets` - (Optional) Nested block describing saved configurations of existing template variables. The structure of this block is described [below](dashboard.html#nested-template_variable_preset-blocks). Multiple template_variable_preset blocks are allowed within a `datadog_dashboard` resource, and multiple template_variables can be described by each template_variable_preset.
 
 ### Nested `widget` blocks
 
@@ -692,7 +717,7 @@ Nested `widget` blocks have the following structure:
       - `title_size`: (Optional) The size of the widget's title. Default is 16.
       - `title_align`: (Optional) The alignment of the widget's title. One of "left", "center", or "right".
   - `note_definition`: The definition for a Note widget. Exactly one nested block is allowed with the following structure:
-      - `content` - (Required) Content of the note
+      - `content` - (Required) Content of the note.
       - `background_color` - (Optional) Background color of the note.
       - `font_size` - (Optional) Size of the text.
       - `text_align` - (Optional) How to align the text on the widget. Available values are: `center`, `left`, or `right`.
@@ -701,14 +726,14 @@ Nested `widget` blocks have the following structure:
       - `tick_edge` - (Optional") When tick = true, string indicating on which side of the widget the tick should be displayed. One of "bottom", "top", "left", "right".
   - `query_value_definition`: The definition for a Query Value widget. Exactly one nested block is allowed with the following structure:
         - `request`: (Required) Nested block describing the request to use when displaying the widget. Multiple request blocks are allowed with the following structure (exactly only one of `q`, `apm_query`, `log_query` or `process_query` is required within the request block):
-            - `q`: (Optional) The metric query to use in the widget
+            - `q`: (Optional) The metric query to use in the widget.
             - `apm_query`: (Optional) The APM query to use in the widget. The structure of this block is described [below](dashboard.html#nested-apm_query-and-log_query-blocks).
             - `log_query`: (Optional) The log query to use in the widget. The structure of this block is described [below](dashboard.html#nested-apm_query-and-log_query-blocks).
             - `process_query`: (Optional) The process query to use in the widget. The structure of this block is described [below](dashboard.html#nested-process_query-blocks).
             - `conditional_formats` - (Optional) Conditional formats allow you to set the color of your widget content or background, depending on a rule applied to your data. Multiple request blocks are allowed. The structure of this block is described [below](dashboard.html#nested-widget-conditional_formats-blocks).
             - `aggregator` - (Optional) The aggregator to use for time aggregation. One of `avg`, `min`, `max`, `sum`, `last`.
         - `autoscale` - (Optional) Boolean indicating whether to automatically scale the tile.
-        - `custom_unit` - (Optional) The unit for the value displayed in the widget
+        - `custom_unit` - (Optional) The unit for the value displayed in the widget.
         - `precision` - (Optional) The precision to use when displaying the tile.
         - `text_align` - (Optional, "alert_value", "note") The alignment of the text in the widget.
         - `title`: (Optional) The title of the widget.
@@ -741,7 +766,7 @@ Nested `widget` blocks have the following structure:
         - `title_align`: (Optional) The alignment of the widget's title. One of "left", "center", or "right".
   - `timeseries_definition`: The definition for a Timeseries  widget. Exactly one nested block is allowed with the following structure:
         - `request`: (Required) Nested block describing the request to use when displaying the widget. Multiple request blocks are allowed with the following structure (exactly only one of `q`, `apm_query`, `log_query` or `process_query` is required within the request block):
-            - `q`: (Optional) The metric query to use in the widget
+            - `q`: (Optional) The metric query to use in the widget.
             - `apm_query`: (Optional) The APM query to use in the widget. The structure of this block is described [below](dashboard.html#nested-apm_query-and-log_query-blocks).
             - `log_query`: (Optional) The log query to use in the widget. The structure of this block is described [below](dashboard.html#nested-apm_query-and-log_query-blocks).
             - `process_query`: (Optional) The process query to use in the widget. The structure of this block is described [below](dashboard.html#nested-process_query-blocks).
@@ -760,11 +785,11 @@ Nested `widget` blocks have the following structure:
         - `time`: (Optional) Nested block describing the timeframe to use when displaying the widget. The structure of this block is described [below](dashboard.html#nested-widget-time-blocks).
         - `show_legend`: (Optional) Whether or not to show the legend on this widget.
         - `event`: (Optional) The definition of the event to overlay on the graph. Includes the following structure:
-          - `q`: (Required) The event query to use in the widget
+          - `q`: (Required) The event query to use in the widget.
         - `yaxis`: (Optional) Nested block describing the Y-Axis Controls. The structure of this block is described [below](dashboard.html#nested-widget-axis-blocks)
   - `toplist_definition`: The definition for a Toplist  widget. Exactly one nested block is allowed with the following structure:
         - `request`: (Required) Nested block describing the request to use when displaying the widget. Multiple request blocks are allowed with the following structure (exactly only one of `q`, `apm_query`, `log_query` or `process_query` is required within the request block):
-            - `q`: (Optional) The metric query to use in the widget
+            - `q`: (Optional) The metric query to use in the widget.
             - `apm_query`: (Optional) The APM query to use in the widget. The structure of this block is described [below](dashboard.html#nested-apm_query-and-log_query-blocks).
             - `log_query`: (Optional) The log query to use in the widget. The structure of this block is described [below](dashboard.html#nested-apm_query-and-log_query-blocks).
             - `process_query`: (Optional) The process query to use in the widget. The structure of this block is described [below](dashboard.html#nested-process_query-blocks).
@@ -871,6 +896,15 @@ Nested `template_variable` blocks have the following structure:
 - `name` - (Required) The variable name. Can be referenced as $name in `graph` `request` `q` query strings.
 - `prefix` - (Optional) The tag group. Default: no tag group.
 - `default` - (Optional) The default tag. Default: "\*" (match all).
+
+### Nested `template_variable_preset` blocks
+
+Nested `template_variable_preset` blocks have the following structure:
+
+- `name` - (Required) The displayed name of the preset.
+- `template_variable`: (Required) Block describing the values that a template_variable within this preset should assume. Each referenced template_variable name must be defined on the dashboard, but not all template_variables must be included in a preset. One or more blocks can be defined per preset.
+    - `name`: (Required) The name of the template_variable being referenced.
+    - `value`: (Required) The value that the template_variable should assume.
 
 ## Import
 


### PR DESCRIPTION
~This is a bit premature as https://github.com/zorkian/go-datadog-api/pull/296 is still awaiting review, but I've confirmed it works when everything is hooked together properly:~

 ## What

<img width="625" alt="image"
src="https://user-images.githubusercontent.com/6370918/71746068-9073ba00-2e31-11ea-83c5-8498d3a14cb8.png">

"Template Variable Presets" aka "Saved Views" are a quick shortcut that
can be added by hand or via json to dashboards in datadog, and appear in
the top left corner.

They allow you to string together common combinations of template
variable values, so if for example you want a "production us-east-2"
view of your dashboard, you could have a "production us-east-2" preset
that sets your template variables to `environment = production` and
`region = us-east-2`.

This PR adds support for template variable presets to dashboards, using the
new SDK functionality linked to above. 

Cheers!