### PR TITLE
Hide deprecated monitor summary widget params

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2357,13 +2357,15 @@ func getManageStatusDefinitionSchema() map[string]*schema.Schema {
 		},
 		// The count param is deprecated
 		"count": {
-			Type:     schema.TypeInt,
-			Optional: true,
+			Type:       schema.TypeInt,
+			Deprecated: "This parameter may be removed from the dashboard API in the future",
+			Optional:   true,
 		},
 		// The start param is deprecated
 		"start": {
-			Type:     schema.TypeInt,
-			Optional: true,
+			Type:       schema.TypeInt,
+			Deprecated: "This parameter may be removed from the dashboard API in the future",
+			Optional:   true,
 		},
 		"display_format": {
 			Type:     schema.TypeString,

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2355,10 +2355,12 @@ func getManageStatusDefinitionSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		// The count param is deprecated
 		"count": {
 			Type:     schema.TypeInt,
 			Optional: true,
 		},
+		// The start param is deprecated
 		"start": {
 			Type:     schema.TypeInt,
 			Optional: true,

--- a/datadog/resource_datadog_screenboard.go
+++ b/datadog/resource_datadog_screenboard.go
@@ -1208,6 +1208,7 @@ func buildWidgets(tfWidgets *[]interface{}) []datadog.Widget {
 				matches: []match{
 					{"sort", &d.Params.Sort},
 					{"text", &d.Params.Text},
+					// The count and start params are deprecated for the monitor summary widget
 					{"count", &d.Params.Count},
 					{"start", &d.Params.Start},
 				}})

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -685,9 +685,7 @@ Nested `widget` blocks have the following structure:
   - `manage_status_definition`: The definition for a Manage Status, aka Monitor Summary, widget. Exactly one nested block is allowed with the following structure:
       - `query`: (Required) The query to use in the widget.
       - `summary_type` - (Optional) The monitor summary type to use. One of "monitors", "groups", or "combined". Defaults to "monitors".
-      - `sort` - (Optional) The method to use to sort monitors. One of : "desc" or "asc".
-      `count` - (Optional) The number of monitors to display.
-      `start` - (Optional) The start of the list. Typically 0.
+      - `sort` - (Optional) The method to use to sort monitors. Example: "status,asc".
       - `display_format` - (Optional") The display setting to use. One of "counts", "list", or "countsAndList".
       - `color_preference` - (Optional") Whether to colorize text or background. One of "text", "background".
       - `hide_zero_counts` - (Optional") Boolean indicating whether to hide empty categories.

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -493,13 +493,11 @@ resource "datadog_dashboard" "free_dashboard" {
   widget {
     manage_status_definition {
       color_preference = "text"
-      count = 50
       display_format = "countsAndList"
       hide_zero_counts = true
       query = "type:metric"
       show_last_triggered = false
       sort = "status,asc"
-      start = 0
       summary_type = "monitors"
       title = "Widget Title"
       title_size = 16

--- a/website/docs/r/screenboard.html.markdown
+++ b/website/docs/r/screenboard.html.markdown
@@ -409,8 +409,6 @@ resource "datadog_screenboard" "acceptance_test" {
     params = {
       sort  = "status,asc"
       text  = "status:alert"
-      count = 50
-      start = 0
     }
   }
 
@@ -544,8 +542,6 @@ Nested `widget` `params` blocks have the following structure:
 
 - `sort` - (Optional) The method to use to sort monitors. Example: "status,asc".
 - `text` - (Optional) The query to use to get monitors. Example: "status:alert".
-- `count` - (Optional) The number of monitors to display.
-- `start` - (Optional) The start of the list. Typically 0.
 
 ### Nested `widget` `tile_def` blocks
 


### PR DESCRIPTION
Remove the count and start monitor summary widget params from the docs and deprecate them.

While these params are still supported (and will continue to be), they don't appear to be used by anyone and we don't know of any use cases for them, so we should remove them from the docs to avoid confusion.

Related: https://github.com/terraform-providers/terraform-provider-datadog/pull/300 (the `sort` param does have use cases so we're adding it to the docs here: https://github.com/DataDog/documentation/pull/6568).
