### PR TITLE
Gracefully handle downtimes that were canceled manually

### DIFF
--- a/datadog/resource_datadog_downtime.go
+++ b/datadog/resource_datadog_downtime.go
@@ -297,11 +297,18 @@ func resourceDatadogDowntimeExists(d *schema.ResourceData, meta interface{}) (b 
 		return false, err
 	}
 
-	if _, err = client.GetDowntime(id); err != nil {
+	downtime, err := client.GetDowntime(id)
+	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
 			return false, nil
 		}
 		return false, err
+	}
+
+	if _, ok := downtime.GetCanceledOk(); ok {
+		// when the Downtime is deleted via UI, it is in fact still returned through API, it's just "canceled"
+		// in this case, we need to consider it deleted, as canceled downtimes can't be used again
+		return false, nil
 	}
 
 	return true, nil


### PR DESCRIPTION
Fixes #315 - if the downtime gets deleted (==canceled) manually in UI, we have to consider it canceled and recreate it.