### PR TITLE
synthetics: add support for retry (count, interval)

### DIFF
--- a/datadog/resource_datadog_synthetics_test_test.go
+++ b/datadog/resource_datadog_synthetics_test_test.go
@@ -589,6 +589,8 @@ func createSyntheticsBrowserTestStep(accProvider *schema.Provider) resource.Test
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "options.min_location_failed", "1"),
 			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.bar", "options.retry_count", "2"),
+			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "name", "name for synthetics browser test bar"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "message", "Notify @datadog.user"),
@@ -625,6 +627,7 @@ resource "datadog_synthetics_test" "bar" {
 		tick_every = 900
 		min_failure_duration = 0
 		min_location_failed = 1
+		retry_count = 2
 	}
 
 	name = "name for synthetics browser test bar"
@@ -675,6 +678,8 @@ func updateSyntheticsBrowserTestStep(accProvider *schema.Provider) resource.Test
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "options.min_location_failed", "1"),
 			resource.TestCheckResourceAttr(
+				"datadog_synthetics_test.bar", "options.retry_count", "3"),
+			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "name", "updated name for synthetics browser test bar"),
 			resource.TestCheckResourceAttr(
 				"datadog_synthetics_test.bar", "message", "Notify @pagerduty"),
@@ -709,6 +714,7 @@ resource "datadog_synthetics_test" "bar" {
 		tick_every = 1800
 		min_failure_duration = 10
 		min_location_failed = 1
+		retry_count = 3
 	}
 	name = "updated name for synthetics browser test bar"
 	message = "Notify @pagerduty"


### PR DESCRIPTION
This adds `options.retry_count` and `options.retry_interval` for configuring retry options for a synthetics test. I'm not sure if/how I should be updating the cassettes as introduced in #423, but the tests should pass once those are re-generated.

This has significant overlap with #424, which also adds support for `renotify_interval`. This PR makes fewer changes to the existing patterns in the library. It uses a flat naming scheme for retry options instead of placing them in their own map.

I'm supportive of moving to `schema.TypeList` for `options` as [recommended by the Terraform docs](https://www.terraform.io/docs/extend/writing-custom-providers.html#implementing-a-more-complex-read). However, I think that should wait until a major release and a provider-wide change rather than maintaining both for backwards compatibility.

