### PR TITLE
Stabilize TestDatadogDashListImport test by always creating resources in the same order

### DIFF
--- a/datadog/resource_datadog_dashboard_list_test.go
+++ b/datadog/resource_datadog_dashboard_list_test.go
@@ -32,6 +32,9 @@ resource "datadog_dashboard_list" "new_list" {
 
 resource "datadog_dashboard" "time" {
 	title         = "TF Test Layout Dashboard"
+	# NOTE: this dependency is present to make sure the dashboards are created in
+	# a predictable order and thus the recorder test cassettes always work
+	depends_on    = ["datadog_dashboard.screen"]
 	description   = "Created using the Datadog provider in Terraform"
 	layout_type   = "ordered"
 	is_read_only  = true


### PR DESCRIPTION
Previously, the test would fail in ~50 % of runs, as the `screen` and `time` dashboards were created in random order.