### PR TITLE
Fail fast if index isn't imported

### DIFF
--- a/datadog/resource_datadog_logs_index.go
+++ b/datadog/resource_datadog_logs_index.go
@@ -2,9 +2,10 @@ package datadog
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/zorkian/go-datadog-api"
-	"strings"
 )
 
 var indexSchema = map[string]*schema.Schema{
@@ -57,6 +58,12 @@ func resourceDatadogLogsIndex() *schema.Resource {
 }
 
 func resourceDatadogLogsIndexCreate(d *schema.ResourceData, meta interface{}) error {
+	// This is a bit of a hack to ensure we fail fast if an index is about to be created, and
+	// to ensure we provide a useful error message (and don't panic)
+	// Indexes can only be updated, and the id is only set in the state if it was already imported
+	if _, ok := d.GetOk("id"); !ok {
+		return fmt.Errorf("logs index creation is not allowed, please import the index first. index_name: %s", d.Get("name").(string))
+	}
 	return resourceDatadogLogsIndexUpdate(d, meta)
 }
 


### PR DESCRIPTION
Fixes #432 

There is an explicit catch to try and inform users that indexes can't be created and only updated after imported. However, this catch happens after we try to build an index with data that doesn't yet exist in the state. 

This change includes a quick check for the `id` field (only available if the object is in the state) before continuing. This lets us fail fast and provide a helpful error message. 