### PR TITLE
Update scope docs with explicit example

### DIFF
--- a/website/docs/r/downtime.html.markdown
+++ b/website/docs/r/downtime.html.markdown
@@ -47,7 +47,7 @@ resource "datadog_downtime" "foo" {
 
 The following arguments are supported:
 
-* `scope` - (Required) A list of items to apply the downtime to, e.g. host:X
+* `scope` - (Required)  The scope(s) to which the downtime applies, e.g. host:app2. Provide multiple scopes as a comma-separated list, e.g. env:dev,env:prod. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.
 * `active` - (Optional) A flag indicating if the downtime is active now.
 * `disabled` - (Optional) A flag indicating if the downtime was disabled.
 * `start` - (Optional) POSIX timestamp to start the downtime.


### PR DESCRIPTION
Update the documentation for the downtime scope field to more closely reflect the Datadog Documentation page - https://docs.datadoghq.com/api/?lang=bash#schedule-monitor-downtime
From issue - #430 