### PR TITLE
Add terraform sdk + cli versions to user agent header

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -9,13 +9,16 @@ import (
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/meta"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-datadog/version"
 	"github.com/zorkian/go-datadog-api"
 )
 
+var datadogProvider *schema.Provider
+
 func Provider() terraform.ResourceProvider {
-	return &schema.Provider{
+	datadogProvider = &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {
 				Type:        schema.TypeString,
@@ -62,6 +65,8 @@ func Provider() terraform.ResourceProvider {
 
 		ConfigureFunc: providerConfigure,
 	}
+
+	return datadogProvider
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
@@ -73,7 +78,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	c := cleanhttp.DefaultClient()
 	c.Transport = logging.NewTransport("Datadog", c.Transport)
 	client.HttpClient = c
-	client.ExtraHeader["User-Agent"] = fmt.Sprintf("Datadog/%s/terraform (%s)", version.ProviderVersion, runtime.Version())
+	client.ExtraHeader["User-Agent"] = fmt.Sprintf("Datadog/%s/terraform (%s)/terraform (%s)/terraform-cli (%s)", version.ProviderVersion, runtime.Version(), meta.SDKVersionString(), datadogProvider.TerraformVersion)
 
 	log.Println("[INFO] Datadog client successfully initialized, now validating...")
 	ok, err := client.Validate()

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -84,7 +84,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	c := cleanhttp.DefaultClient()
 	c.Transport = logging.NewTransport("Datadog", c.Transport)
-	communityClient.ExtraHeader["User-Agent"] = fmt.Sprintf("Datadog/%s/terraform (%s)/terraform (%s)/terraform-cli (%s)", version.ProviderVersion, runtime.Version(), meta.SDKVersionString(), datadogProvider.TerraformVersion)
+	communityClient.ExtraHeader["User-Agent"] = fmt.Sprintf("terraform-provider-datadog/%s (go %s; terraform %s; terraform-cli %s)", version.ProviderVersion, runtime.Version(), meta.SDKVersionString(), datadogProvider.TerraformVersion)
 	communityClient.HttpClient = c
 
 	log.Println("[INFO] Datadog client successfully initialized, now validating...")


### PR DESCRIPTION
This PR includes a couple extra pieces of info about the running terraform version in the user agent header:
* The Terraform SDK version (This is vendored into the provider, so this could be extracted indirectly by knowing the provider version, but this explicitly includes it)
* The terraform CLI version used to invoke the provider. 

Inspiration from - https://github.com/terraform-providers/terraform-provider-oci/blob/8ed6736016dfc4ee36cb77c80ea7f519ae2c84f4/oci/provider.go#L958
SDK Meta version from the `meta` package - https://github.com/hashicorp/terraform-plugin-sdk/blob/dbee9ba9e9bca050f5fa5d56d3232eefc64e44be/meta/meta.go