### PR TITLE
doc: AWS integration & EU Datadog clarifications

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -40,4 +40,4 @@ The following arguments are supported:
 
 * `api_key` - (Required) Datadog API key. This can also be set via the `DATADOG_API_KEY` environment variable.
 * `app_key` - (Required) Datadog APP key. This can also be set via the `DATADOG_APP_KEY` environment variable.
-* `api_url` - (Optional) The API Url. This can be also be set via the `DATADOG_HOST` environment variable. Note that this URL must not end with the `/api/` path. For example, `https://api.datadoghq.com/` is a correct value, while `https://api.datadoghq.com/api/` is not.
+* `api_url` - (Optional) The API Url. This can be also be set via the `DATADOG_HOST` environment variable. Note that this URL must not end with the `/api/` path. For example, `https://api.datadoghq.com/` is a correct value, while `https://api.datadoghq.com/api/` is not. And if you're working with  "EU" version of Datadog, use `https://api.datadoghq.eu/`.

--- a/website/docs/r/integration_aws.html.markdown
+++ b/website/docs/r/integration_aws.html.markdown
@@ -41,8 +41,7 @@ The following arguments are supported:
   e.x. `env:production,instance-type:c1.*,!region:us-east-1`
 
 * `host_tags` - (Optional) Array of tags (in the form key:value) to add to all hosts and metrics reporting through this integration.
-* `account_specific_namespace_rules` - (Optional) Enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the [available namespace rules API endpoint](https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules). 
-In order to use this API you'll have to manually set the `api_key` and `application_key` parameters in the URL (ex: `.../aws/available_namespace_rules?api_key=<your_api_key>&application_key=<your_application_key>`) and not forget to use `.eu` instead of `.com` extension if you're working with "EU" Datadog. 
+* `account_specific_namespace_rules` - (Optional) Enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the [available namespace rules API endpoint](https://docs.datadoghq.com/api/?lang=bash#list-namespace-rules).
 
 ### See also
 * [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/?lang=bash#aws)

--- a/website/docs/r/integration_aws.html.markdown
+++ b/website/docs/r/integration_aws.html.markdown
@@ -41,7 +41,8 @@ The following arguments are supported:
   e.x. `env:production,instance-type:c1.*,!region:us-east-1`
 
 * `host_tags` - (Optional) Array of tags (in the form key:value) to add to all hosts and metrics reporting through this integration.
-* `account_specific_namespace_rules` - (Optional) Enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the [available namespace rules API endpoint](https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules).
+* `account_specific_namespace_rules` - (Optional) Enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the [available namespace rules API endpoint](https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules). 
+In order to use this API you'll have to manually set the `api_key` and `application_key` parameters in the URL (ex: `.../aws/available_namespace_rules?api_key=<your_api_key>&application_key=<your_application_key>`) and not forget to use `.eu` instead of `.com` extension if you're working with "EU" Datadog. 
 
 ### See also
 * [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/?lang=bash#aws)


### PR DESCRIPTION
Missing information on AWS integration documentation while using the API Endpoint and EU version of Datadog