### PR TITLE
remove ignore_changes quotes in monitor example

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -154,7 +154,7 @@ Both of these actions add a new value to the `silenced` map. This can be problem
 
 ```
 lifecycle {
-  ignore_changes = ["silenced"]
+  ignore_changes = [silenced]
 }
 ```
 


### PR DESCRIPTION
this avoids a warning message since the 0.12.14 release (see [this](https://discuss.hashicorp.com/t/terraform-0-12-14-released/3898))