### PR TITLE
Add resources for API and application keys

### DIFF
--- a/datadog/cassettes/TestAccDatadogAPIKey_Basic.yaml
+++ b/datadog/cassettes/TestAccDatadogAPIKey_Basic.yaml
@@ -1,0 +1,354 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"foo"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key
+    method: POST
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:05 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:05 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:05 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:05 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:05 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:05 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:06 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:06 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:06 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:06 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:06 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:06 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:06 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:06 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: DELETE
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:05","disabled_by":"frog@datadoghq.com","is_active":false,"created_by":"frog@datadoghq.com","disabled":"2020-04-16
+      04:02:06","key":"84e9a927e6cc2a3b4145b531316311d0"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "221"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:06 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:06 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/84e9a927e6cc2a3b4145b531316311d0
+    method: GET
+  response:
+    body: '{"errors": ["API key not found"]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "33"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:07 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/datadog/cassettes/TestAccDatadogAPIKey_Updated.yaml
+++ b/datadog/cassettes/TestAccDatadogAPIKey_Updated.yaml
@@ -1,0 +1,629 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"foo"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key
+    method: POST
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:07 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:07 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:07 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:07 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:07 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:07 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:07 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:07 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:07 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:07 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"foo","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"bar"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: PUT
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:08 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:08 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:09 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:09 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"","is_active":true,"created_by":"frog@datadoghq.com","disabled":"","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "182"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:09 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:09 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: DELETE
+  response:
+    body: '{"api_key":{"name":"bar","created":"2020-04-16 04:02:07","disabled_by":"frog@datadoghq.com","is_active":false,"created_by":"frog@datadoghq.com","disabled":"2020-04-16
+      04:02:09","key":"aec5892033f656759fcf471b7c3b769b"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "221"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:09 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:09 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/api_key/aec5892033f656759fcf471b7c3b769b
+    method: GET
+  response:
+    body: '{"errors": ["API key not found"]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "33"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:09 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/datadog/cassettes/TestAccDatadogAppKey_Basic.yaml
+++ b/datadog/cassettes/TestAccDatadogAppKey_Basic.yaml
@@ -1,0 +1,353 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"foo"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key
+    method: POST
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:17 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:18 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:18 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:18 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:18 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:18 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:18 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:18 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: DELETE
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"cb6db208e9fb8a68e5b1c24df98853cee95df0a7","name":"foo","revoked":true}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "145"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:19 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:19 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/cb6db208e9fb8a68e5b1c24df98853cee95df0a7
+    method: GET
+  response:
+    body: '{"errors": ["Application key not found"]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "41"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:19 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/datadog/cassettes/TestAccDatadogAppKey_Updated.yaml
+++ b/datadog/cassettes/TestAccDatadogAppKey_Updated.yaml
@@ -1,0 +1,628 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"foo"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key
+    method: POST
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:19 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:19 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:19 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:19 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:19 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:19 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:19 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:19 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:20 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:20 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"foo","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:20 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"bar"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: PUT
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:20 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:20 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:20 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:21 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:20 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:21 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:21 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:21 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:21 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":false}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "146"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:21 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:21 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: DELETE
+  response:
+    body: '{"application_key":{"owner":"frog@datadoghq.com","org_id":403816,"hash":"11b8d6f152e47d7b952d3119ed5d07f8458d559b","name":"bar","revoked":true}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "145"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:21 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - DD-PSHARD=141; Max-Age=604800; Path=/; expires=Thu, 23-Apr-2020 04:02:21 GMT;
+        secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Datadog/dev/terraform (go1.14)
+    url: https://api.datadoghq.com/api/v1/application_key/11b8d6f152e47d7b952d3119ed5d07f8458d559b
+    method: GET
+  response:
+    body: '{"errors": ["Application key not found"]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "41"
+      Content-Security-Policy:
+      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Apr 2020 04:02:21 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15724800;
+      X-Content-Type-Options:
+      - nosniff
+      X-Dd-Version:
+      - "35.2396352"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -38,6 +38,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"datadog_api_key":                              resourceDatadogAPIKey(),
+			"datadog_app_key":                              resourceDatadogAppKey(),
 			"datadog_dashboard":                            resourceDatadogDashboard(),
 			"datadog_dashboard_list":                       resourceDatadogDashboardList(),
 			"datadog_downtime":                             resourceDatadogDowntime(),

--- a/datadog/resource_datadog_api_key.go
+++ b/datadog/resource_datadog_api_key.go
@@ -1,0 +1,103 @@
+package datadog
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/zorkian/go-datadog-api"
+)
+
+func resourceDatadogAPIKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDatadogAPIKeyCreate,
+		Read:   resourceDatadogAPIKeyRead,
+		Update: resourceDatadogAPIKeyUpdate,
+		Delete: resourceDatadogAPIKeyDelete,
+		Exists: resourceDatadogAPIKeyExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceDatadogAPIKeyExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+	// Exists - This is called to verify a resource still exists. It is called prior to Read,
+	// and lowers the burden of Read to be able to assume the resource exists.
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	if _, err := client.GetAPIKey(d.Id()); err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, translateClientError(err, "error checking API key exists")
+	}
+
+	return true, nil
+}
+
+func resourceDatadogAPIKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	key, err := client.CreateAPIKey(d.Get("name").(string))
+	if err != nil {
+		return translateClientError(err, "error creating API key")
+	}
+
+	d.SetId(key.GetKey())
+
+	return resourceDatadogAPIKeyRead(d, meta)
+}
+
+func resourceDatadogAPIKeyRead(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	k, err := client.GetAPIKey(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", k.GetName())
+	d.Set("key", k.GetKey())
+	return nil
+}
+
+func resourceDatadogAPIKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	k := &datadog.APIKey{}
+	k.SetKey(d.Id())
+	k.SetName(d.Get("name").(string))
+
+	if err := client.UpdateAPIKey(k); err != nil {
+		return translateClientError(err, "error updating API key")
+	}
+
+	return resourceDatadogAPIKeyRead(d, meta)
+}
+
+func resourceDatadogAPIKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	if err := client.DeleteAPIKey(d.Id()); err != nil {
+		return translateClientError(err, "error deleting API key")
+	}
+
+	return nil
+}

--- a/datadog/resource_datadog_api_key_test.go
+++ b/datadog/resource_datadog_api_key_test.go
@@ -1,0 +1,114 @@
+package datadog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDatadogAPIKey_Basic(t *testing.T) {
+	accProviders, cleanup := testAccProviders(t)
+	defer cleanup(t)
+	accProvider := testAccProvider(t, accProviders)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    accProviders,
+		CheckDestroy: testAccCheckDatadogAPIKeyDestroy(accProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogAPIKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogAPIKeyExists(accProvider, "datadog_api_key.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_api_key.foo", "name", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_api_key.foo", "key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatadogAPIKey_Updated(t *testing.T) {
+	accProviders, cleanup := testAccProviders(t)
+	defer cleanup(t)
+	accProvider := testAccProvider(t, accProviders)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    accProviders,
+		CheckDestroy: testAccCheckDatadogAPIKeyDestroy(accProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogAPIKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogAPIKeyExists(accProvider, "datadog_api_key.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_api_key.foo", "name", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_api_key.foo", "key"),
+				),
+			},
+			{
+				Config: testAccCheckDatadogAPIKeyConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogAPIKeyExists(accProvider, "datadog_api_key.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_api_key.foo", "name", "bar"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_api_key.foo", "key"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatadogAPIKeyDestroy(accProvider *schema.Provider) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		providerConf := accProvider.Meta().(*ProviderConfiguration)
+		client := providerConf.CommunityClient
+		for _, r := range s.RootModule().Resources {
+			if _, err := client.GetAPIKey(r.Primary.ID); err != nil {
+				if strings.Contains(err.Error(), "404 Not Found") {
+					continue
+				}
+				return fmt.Errorf("received an error retrieving api key %s", err)
+			}
+			return fmt.Errorf("api key still exists")
+		}
+		return nil
+	}
+}
+
+func testAccCheckDatadogAPIKeyExists(accProvider *schema.Provider, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		providerConf := accProvider.Meta().(*ProviderConfiguration)
+		client := providerConf.CommunityClient
+
+		for _, r := range s.RootModule().Resources {
+			id := r.Primary.ID
+			if _, err := client.GetAPIKey(id); err != nil {
+				return fmt.Errorf("received an error retrieving api key %s", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckDatadogAPIKeyConfig = `
+resource "datadog_api_key" "foo" {
+  name = "foo"
+}
+`
+
+const testAccCheckDatadogAPIKeyConfigUpdated = `
+resource "datadog_api_key" "foo" {
+  name = "bar"
+}
+`

--- a/datadog/resource_datadog_app_key.go
+++ b/datadog/resource_datadog_app_key.go
@@ -1,0 +1,103 @@
+package datadog
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/zorkian/go-datadog-api"
+)
+
+func resourceDatadogAppKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDatadogAppKeyCreate,
+		Read:   resourceDatadogAppKeyRead,
+		Update: resourceDatadogAppKeyUpdate,
+		Delete: resourceDatadogAppKeyDelete,
+		Exists: resourceDatadogAppKeyExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"hash": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceDatadogAppKeyExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+	// Exists - This is called to verify a resource still exists. It is called prior to Read,
+	// and lowers the burden of Read to be able to assume the resource exists.
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	if _, err := client.GetAPPKey(d.Id()); err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, translateClientError(err, "error checking app key exists")
+	}
+
+	return true, nil
+}
+
+func resourceDatadogAppKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	key, err := client.CreateAPPKey(d.Get("name").(string))
+	if err != nil {
+		return translateClientError(err, "error creating app key")
+	}
+
+	d.SetId(key.GetHash())
+
+	return resourceDatadogAppKeyRead(d, meta)
+}
+
+func resourceDatadogAppKeyRead(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	k, err := client.GetAPPKey(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", k.GetName())
+	d.Set("hash", k.GetHash())
+	return nil
+}
+
+func resourceDatadogAppKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	k := &datadog.APPKey{}
+	k.SetHash(d.Id())
+	k.SetName(d.Get("name").(string))
+
+	if err := client.UpdateAPPKey(k); err != nil {
+		return translateClientError(err, "error updating app key")
+	}
+
+	return resourceDatadogAppKeyRead(d, meta)
+}
+
+func resourceDatadogAppKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	client := providerConf.CommunityClient
+
+	if err := client.DeleteAPPKey(d.Id()); err != nil {
+		return translateClientError(err, "error deleting app key")
+	}
+
+	return nil
+}

--- a/datadog/resource_datadog_app_key_test.go
+++ b/datadog/resource_datadog_app_key_test.go
@@ -1,0 +1,114 @@
+package datadog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDatadogAppKey_Basic(t *testing.T) {
+	accProviders, cleanup := testAccProviders(t)
+	defer cleanup(t)
+	accProvider := testAccProvider(t, accProviders)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    accProviders,
+		CheckDestroy: testAccCheckDatadogAppKeyDestroy(accProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogAppKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogAppKeyExists(accProvider, "datadog_app_key.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_app_key.foo", "name", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_app_key.foo", "hash"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatadogAppKey_Updated(t *testing.T) {
+	accProviders, cleanup := testAccProviders(t)
+	defer cleanup(t)
+	accProvider := testAccProvider(t, accProviders)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    accProviders,
+		CheckDestroy: testAccCheckDatadogAppKeyDestroy(accProvider),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatadogAppKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogAppKeyExists(accProvider, "datadog_app_key.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_app_key.foo", "name", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_app_key.foo", "hash"),
+				),
+			},
+			{
+				Config: testAccCheckDatadogAppKeyConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogAppKeyExists(accProvider, "datadog_app_key.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_app_key.foo", "name", "bar"),
+					resource.TestCheckResourceAttrSet(
+						"datadog_app_key.foo", "hash"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatadogAppKeyDestroy(accProvider *schema.Provider) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		providerConf := accProvider.Meta().(*ProviderConfiguration)
+		client := providerConf.CommunityClient
+		for _, r := range s.RootModule().Resources {
+			if _, err := client.GetAPPKey(r.Primary.ID); err != nil {
+				if strings.Contains(err.Error(), "404 Not Found") {
+					continue
+				}
+				return fmt.Errorf("received an error retrieving app key %s", err)
+			}
+			return fmt.Errorf("app key still exists")
+		}
+		return nil
+	}
+}
+
+func testAccCheckDatadogAppKeyExists(accProvider *schema.Provider, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		providerConf := accProvider.Meta().(*ProviderConfiguration)
+		client := providerConf.CommunityClient
+
+		for _, r := range s.RootModule().Resources {
+			id := r.Primary.ID
+			if _, err := client.GetAPPKey(id); err != nil {
+				return fmt.Errorf("received an error retrieving app key %s", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckDatadogAppKeyConfig = `
+resource "datadog_app_key" "foo" {
+  name = "foo"
+}
+`
+
+const testAccCheckDatadogAppKeyConfigUpdated = `
+resource "datadog_app_key" "foo" {
+  name = "bar"
+}
+`

--- a/website/docs/r/api_key.html.markdown
+++ b/website/docs/r/api_key.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "datadog"
+page_title: "Datadog: api_key"
+sidebar_current: "docs-datadog-resource-api-key"
+description: |-
+  Provides a Datadog API key resource. This can be used to create and manage API keys.
+---
+
+# datadog_api_key
+
+Provides a Datadog API key resource. This can be used to create and manage Datadog API keys.
+
+## Example Usage
+
+```hcl
+# Create a new Datadog API key
+resource "datadog_api_key" "foo" {
+  name = "My App"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name for the API key
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `key` - The API key
+
+## Import
+
+Keys can be imported using their key, e.g.
+
+```
+$ terraform import datadog_api_key.foo 289d32a8097785306e8c990cd66f416a
+```

--- a/website/docs/r/app_key.html.markdown
+++ b/website/docs/r/app_key.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "datadog"
+page_title: "Datadog: app_key"
+sidebar_current: "docs-datadog-resource-app-key"
+description: |-
+  Provides a Datadog app key resource. This can be used to create and manage application keys.
+---
+
+# datadog_app_key
+
+Provides a Datadog app key resource. This can be used to create and manage Datadog application keys.
+
+## Example Usage
+
+```hcl
+# Create a new Datadog app key
+resource "datadog_app_key" "foo" {
+  name = "My App"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name for the application key
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `hash` - The application key
+
+## Import
+
+Application keys can be imported using their hash, e.g.
+
+```
+$ terraform import datadog_app_key.foo 10d7ea9c5803590730411eea434758ffcf24d280
+```


### PR DESCRIPTION
The team at @takescoop is looking to move from a small number of Datadog API keys to provisioning a unique key for each infrastructure service we run, in each environment. I reached out to support and they graciously raised our account limit from 5 keys (the default) to 200, though we currently need maybe 10% of that. All of the places we distribute Datadog credentials to are already managed via Terraform so we're hoping to distribute new credentials by adding something like this:

```tf
resource "datadog_api_key" "agent" {
  name = "Kubernetes (${var.environment})"
}
```

Or to allow Terraform Cloud workspaces to use the Datadog provider:

```tf
resource "datadog_api_key" "terraform" {
  name = "Terraform Cloud"
}

resource "datadog_app_key" "terraform" {
  name = "Terraform Cloud"
}

resource "tfe_variable" "datadog_api_key" {
  key          = "DATADOG_API_KEY"
  value        = datadog_api_key.terraform.key
  sensitive    = true
  category     = "env"
  description  = "API key required by Datadog provider"
  workspace_id = "..."
}

resource "tfe_variable" "datadog_app_key" {
  for_each = tfe_workspace.project

  key          = "DATADOG_APP_KEY"
  value        = datadog_app_key.terraform.hash
  sensitive    = true
  category     = "env"
  description  = "Application key required by Datadog provider"
  workspace_id = each.value.id
}
```

* Acceptance tests are passing and cover creating keys and updating their names
* Cassettes are updated, and I replaced my email with `frog@datadoghq.com`, which was present in some other cassettes
* Docs are included

Notes:

* Application keys return a `hash` attribute but the UI calls the column "key." I chose to maintain parity with the API but if you're interested in using `key` uniformly in Terraform I'm happy to do that too.
* The fact that keys don't have a unique non-secret identifier means that the key/hash value is used as the Terraform resource ID. Setting `Sensitive: true` for key/hash is relatively meaningless because the resource ID is printed during a refresh. 

My wishlist for these APIs:

* Return a unique but non-secret random ID with each API/application key (`id`)
* Accept it in requests to `GET /{api,application}_key/*`, in addition to the secret key/hash for backwards compatibility
* Return key/hash on `POST`, but never again (i.e. GET/PUT)
  * Breaking and requires UI changes, but would leave the keys a lot less exposed

Thanks and let me know if there are any other changes/revisions you'd like! 🔑🐶 