### PR TITLE
Update AWS resource to use Datadog Go client

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -129,19 +129,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
-		// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
-		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
-		if parsedApiUrl.Host == "datadoghq.eu" {
-			authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
-				"site": "datadoghq.eu",
-			})
-		} else if parsedApiUrl.Host != "datadoghq.com" {
-			authV1 = context.WithValue(authV1, datadogV1.ContextServerIndex, len(configV1.Servers)-1)
-			authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
-				"name":     parsedApiUrl.Host,
-				"protocol": parsedApiUrl.Scheme,
-			})
-		}
+		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+		authV1 = context.WithValue(authV1, datadogV1.ContextServerIndex, 1)
+		authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
+			"name":     parsedApiUrl.Host,
+			"protocol": parsedApiUrl.Scheme,
+		})
 	}
 	datadogClientV1 := datadogV1.NewAPIClient(configV1)
 
@@ -167,19 +160,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
-		// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
-		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
-		if parsedApiUrl.Host == "api.datadoghq.eu" {
-			authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
-				"site": "datadoghq.eu",
-			})
-		} else if parsedApiUrl.Host != "api.datadoghq.com" {
-			authV2 = context.WithValue(authV2, datadogV2.ContextServerIndex, len(configV2.Servers)-1)
-			authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
-				"name":     parsedApiUrl.Host,
-				"protocol": parsedApiUrl.Scheme,
-			})
-		}
+		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+		authV2 = context.WithValue(authV2, datadogV2.ContextServerIndex, 1)
+		authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
+			"name":     parsedApiUrl.Host,
+			"protocol": parsedApiUrl.Scheme,
+		})
 	}
 	datadogClientV2 := datadogV2.NewAPIClient(configV2)
 

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -129,7 +129,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
-		// Set site on datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
+		// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
 		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the custom name and protocol on ServerIndex{-1}
 		if parsedApiUrl.Host == "datadoghq.eu" {
 			authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
@@ -167,7 +167,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
-		// Set site on datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
+		// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
 		// If custom server api url (not https://api.datadoghq.eu or https://api.datadoghq.com) is passed,
 		// set the custom name and protocol on ServerIndex{-1}
 		if parsedApiUrl.Host == "api.datadoghq.eu" {

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -129,7 +129,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
-		// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
+		// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
 		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
 		if parsedApiUrl.Host == "datadoghq.eu" {
 			authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
@@ -167,9 +167,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
-		// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
-		// If custom server api url (not https://api.datadoghq.eu or https://api.datadoghq.com) is passed,
-		// set the api name and protocol on ServerIndex{-1}
+		// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
+		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
 		if parsedApiUrl.Host == "api.datadoghq.eu" {
 			authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
 				"site": "datadoghq.eu",

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -130,7 +130,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
 		// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
-		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the custom name and protocol on ServerIndex{-1}
+		// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
 		if parsedApiUrl.Host == "datadoghq.eu" {
 			authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
 				"site": "datadoghq.eu",
@@ -169,7 +169,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 		// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
 		// If custom server api url (not https://api.datadoghq.eu or https://api.datadoghq.com) is passed,
-		// set the custom name and protocol on ServerIndex{-1}
+		// set the api name and protocol on ServerIndex{-1}
 		if parsedApiUrl.Host == "api.datadoghq.eu" {
 			authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
 				"site": "datadoghq.eu",

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -121,6 +121,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			},
 		},
 	)
+	config := datadog.NewConfiguration()
+	if apiURL := d.Get("api_url").(string); apiURL != "" {
+		if strings.Contains(apiURL, "datadoghq.eu") {
+			auth = context.WithValue(auth, datadog.ContextServerVariables, map[string]string{
+				"site": "datadoghq.eu",
+			})
+		}
+	}
+	datadogClient := datadog.NewAPIClient(config)
 
 	// Initialize the official Datadog V2 API client
 	authV2 := context.WithValue(
@@ -135,19 +144,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			},
 		},
 	)
-
-	//Initialize Datadog V1 API Config
-	config := datadog.NewConfiguration()
-	if apiURL := d.Get("api_url").(string); apiURL != "" {
-		if strings.Contains(apiURL, "datadoghq.eu") {
-			auth = context.WithValue(auth, datadog.ContextServerVariables, map[string]string{
-				"site": "datadoghq.eu",
-			})
-		}
-	}
-	datadogClient := datadog.NewAPIClient(config)
-
-	//Initialize Datadog V2 API Config
 	configV2 := datadogV2.NewConfiguration()
 	if apiURL := d.Get("api_url").(string); apiURL != "" {
 		if strings.Contains(apiURL, "datadoghq.eu") {

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -140,21 +140,6 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 				},
 			},
 		)
-
-		// Initialize the official datadog v2 API client
-		authV2 := context.WithValue(
-			context.Background(),
-			datadogV2.ContextAPIKeys,
-			map[string]datadogV2.APIKey{
-				"apiKeyAuth": datadogV2.APIKey{
-					Key: d.Get("api_key").(string),
-				},
-				"appKeyAuth": datadogV2.APIKey{
-					Key: d.Get("app_key").(string),
-				},
-			},
-		)
-
 		//Datadog V1 API config.HTTPClient
 		configV1 := datadogV1.NewConfiguration()
 		configV1.Debug = true
@@ -183,6 +168,19 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 		}
 		datadogClientV1 := datadogV1.NewAPIClient(configV1)
 
+		// Initialize the official datadog v2 API client
+		authV2 := context.WithValue(
+			context.Background(),
+			datadogV2.ContextAPIKeys,
+			map[string]datadogV2.APIKey{
+				"apiKeyAuth": datadogV2.APIKey{
+					Key: d.Get("api_key").(string),
+				},
+				"appKeyAuth": datadogV2.APIKey{
+					Key: d.Get("app_key").(string),
+				},
+			},
+		)
 		//Datadog V2 API config.HTTPClient
 		configV2 := datadogV2.NewConfiguration()
 		configV2.Debug = true

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -152,19 +152,12 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
-			// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
-			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
-			if parsedApiUrl.Host == "datadoghq.eu" {
-				authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
-					"site": "datadoghq.eu",
-				})
-			} else if parsedApiUrl.Host != "datadoghq.com" {
-				authV1 = context.WithValue(authV1, datadogV1.ContextServerIndex, len(configV1.Servers)-1)
-				authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
-					"name":     parsedApiUrl.Host,
-					"protocol": parsedApiUrl.Scheme,
-				})
-			}
+			// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+			authV1 = context.WithValue(authV1, datadogV1.ContextServerIndex, 1)
+			authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
+				"name":     parsedApiUrl.Host,
+				"protocol": parsedApiUrl.Scheme,
+			})
 		}
 		datadogClientV1 := datadogV1.NewAPIClient(configV1)
 
@@ -193,19 +186,12 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
-			// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
-			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
-			if parsedApiUrl.Host == "api.datadoghq.eu" {
-				authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
-					"site": "datadoghq.eu",
-				})
-			} else if parsedApiUrl.Host != "api.datadoghq.com" {
-				authV2 = context.WithValue(authV2, datadogV2.ContextServerIndex, len(configV2.Servers)-1)
-				authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
-					"name":     parsedApiUrl.Host,
-					"protocol": parsedApiUrl.Scheme,
-				})
-			}
+			// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+			authV2 = context.WithValue(authV2, datadogV2.ContextServerIndex, 1)
+			authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
+				"name":     parsedApiUrl.Host,
+				"protocol": parsedApiUrl.Scheme,
+			})
 		}
 		datadogClientV2 := datadogV2.NewAPIClient(configV2)
 

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -168,7 +168,7 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
 			// Set site to "datadoghq.eu" for ServerIndex{0} if Datadog EU API URL is passed.
-			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the custom name and protocol on ServerIndex{-1}
+			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
 			if parsedApiUrl.Host == "datadoghq.eu" {
 				authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
 					"site": "datadoghq.eu",
@@ -197,7 +197,7 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			}
 			// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
 			// If custom server api url (not https://api.datadoghq.eu or https://api.datadoghq.com) is passed,
-			// set the custom name and protocol on ServerIndex{-1}
+			// set the api name and protocol on ServerIndex{-1}
 			if parsedApiUrl.Host == "api.datadoghq.eu" {
 				authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
 					"site": "datadoghq.eu",

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -167,7 +167,7 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
-			// Set site to "datadoghq.eu" for ServerIndex{0} if Datadog EU API URL is passed.
+			// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
 			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
 			if parsedApiUrl.Host == "datadoghq.eu" {
 				authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
@@ -195,9 +195,8 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
-			// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
-			// If custom server api url (not https://api.datadoghq.eu or https://api.datadoghq.com) is passed,
-			// set the api name and protocol on ServerIndex{-1}
+			// Set site to "datadoghq.eu" on ServerIndex{0} if Datadog EU API URL is passed.
+			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the api name and protocol on ServerIndex{-1}
 			if parsedApiUrl.Host == "api.datadoghq.eu" {
 				authV2 = context.WithValue(authV2, datadogV2.ContextServerVariables, map[string]string{
 					"site": "datadoghq.eu",

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -167,7 +167,7 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
-			// Set site on datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
+			// Set site to "datadoghq.eu" for ServerIndex{0} if Datadog EU API URL is passed.
 			// If custom api url (not datadoghq.eu or datadoghq.com) is passed, set the custom name and protocol on ServerIndex{-1}
 			if parsedApiUrl.Host == "datadoghq.eu" {
 				authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
@@ -195,7 +195,7 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
 				return nil, fmt.Errorf(`missing protocol or host : %v`, apiURL)
 			}
-			// Set site on datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
+			// Set site to datadoghq.eu ServerIndex{0} if Datadog EU API URL is passed.
 			// If custom server api url (not https://api.datadoghq.eu or https://api.datadoghq.com) is passed,
 			// set the custom name and protocol on ServerIndex{-1}
 			if parsedApiUrl.Host == "api.datadoghq.eu" {

--- a/datadog/provider_test.go
+++ b/datadog/provider_test.go
@@ -168,7 +168,7 @@ func testProviderConfigure(r *recorder.Recorder) schema.ConfigureFunc {
 			}
 		}
 		datadogClient := datadog.NewAPIClient(config)
-		//Datadog V1 API config.HTTPClient
+		//Datadog V2 API config.HTTPClient
 		configV2 := datadogV2.NewConfiguration()
 		configV2.Debug = true
 		configV2.HTTPClient = c


### PR DESCRIPTION
This PR is based on sherz/client - (#477)

Updates AWS resource to use Datadog GO client.

- The update method utilizes the same approach as the Community go client (deleting and recreating the resource) to retain same behavior during client migration