### PR TITLE
Update Logs custom pipeline resource to utilize Datadog Go client

### DIFF
--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -142,6 +142,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			"protocol": parsedApiUrl.Scheme,
 		})
 	}
+	configV1.Debug = true
 	datadogClientV1 := datadogV1.NewAPIClient(configV1)
 
 	// Initialize the official Datadog V2 API client
@@ -173,6 +174,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			"protocol": parsedApiUrl.Scheme,
 		})
 	}
+	configV2.Debug = true
 	datadogClientV2 := datadogV2.NewAPIClient(configV2)
 
 	return &ProviderConfiguration{

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -142,7 +142,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			"protocol": parsedApiUrl.Scheme,
 		})
 	}
-	configV1.Debug = true
 	datadogClientV1 := datadogV1.NewAPIClient(configV1)
 
 	// Initialize the official Datadog V2 API client
@@ -174,7 +173,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			"protocol": parsedApiUrl.Scheme,
 		})
 	}
-	configV2.Debug = true
 	datadogClientV2 := datadogV2.NewAPIClient(configV2)
 
 	return &ProviderConfiguration{

--- a/datadog/resource_datadog_logs_custom_pipeline.go
+++ b/datadog/resource_datadog_logs_custom_pipeline.go
@@ -419,7 +419,6 @@ func buildTerraformProcessors(ddProcessors []datadogV1.LogsProcessor) ([]map[str
 func buildTerraformProcessor(ddProcessor datadogV1.LogsProcessor) (map[string]interface{}, error) {
 	tfProcessor := make(map[string]interface{})
 	var err error
-	log.Println("YERRRR", ddProcessor.LogsProcessorInterface.GetType())
 	switch ddProcessor.LogsProcessorInterface.GetType() {
 	case datadogV1.NewLogsArithmeticProcessorWithDefaults().GetType():
 		logsArithmeticProcessor := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsArithmeticProcessor)
@@ -455,7 +454,6 @@ func buildTerraformProcessor(ddProcessor datadogV1.LogsProcessor) (map[string]in
 		logsLookupProcessor := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsLookupProcessor)
 		tfProcessor = buildTerraformLookupProcessor(logsLookupProcessor)
 	case "pipeline":
-		log.Println("YERRRR 2")
 		logsPipeline := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsPipeline)
 		tfProcessor, err = buildTerraformNestedPipeline(logsPipeline)
 	case datadogV1.NewLogsStringBuilderProcessorWithDefaults().GetType():
@@ -733,8 +731,6 @@ func buildDatadogURLParser(tfProcessor map[string]interface{}) *datadogV1.LogsUR
 	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
 		ddURLParser.Sources = ddSources
 	}
-	tfTarget, exists := tfProcessor["target"].(string)
-	log.Println("Hello my friends", tfTarget, exists)
 	if tfTarget, exists := tfProcessor["target"].(string); exists {
 		ddURLParser.SetTarget(tfTarget)
 	}

--- a/datadog/resource_datadog_logs_custom_pipeline.go
+++ b/datadog/resource_datadog_logs_custom_pipeline.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/zorkian/go-datadog-api"
 )
 
 const (
@@ -21,27 +21,27 @@ const (
 	tfServiceRemapperProcessor   = "service_remapper"
 	tfStatusRemapperProcessor    = "status_remapper"
 	tfStringBuilderProcessor     = "string_builder_processor"
-	tfTraceIdRemapperProcessor   = "trace_id_remapper"
-	tfUrlParserProcessor         = "url_parser"
+	tfTraceIDRemapperProcessor   = "trace_id_remapper"
+	tfURLParserProcessor         = "url_parser"
 	tfUserAgentParserProcessor   = "user_agent_parser"
 )
 
 var tfProcessorTypes = map[string]string{
-	tfArithmeticProcessor:        datadog.ArithmeticProcessorType,
-	tfAttributeRemapperProcessor: datadog.AttributeRemapperType,
-	tfCategoryProcessor:          datadog.CategoryProcessorType,
-	tfDateRemapperProcessor:      datadog.DateRemapperType,
-	tfGeoIPParserProcessor:       datadog.GeoIPParserType,
-	tfGrokParserProcessor:        datadog.GrokParserType,
-	tfLookupProcessor:            datadog.LookupProcessorType,
-	tfMessageRemapperProcessor:   datadog.MessageRemapperType,
-	tfNestedPipelineProcessor:    datadog.NestedPipelineType,
-	tfServiceRemapperProcessor:   datadog.ServiceRemapperType,
-	tfStatusRemapperProcessor:    datadog.StatusRemapperType,
-	tfStringBuilderProcessor:     datadog.StringBuilderProcessorType,
-	tfTraceIdRemapperProcessor:   datadog.TraceIdRemapperType,
-	tfUrlParserProcessor:         datadog.UrlParserType,
-	tfUserAgentParserProcessor:   datadog.UserAgentParserType,
+	tfArithmeticProcessor:        datadogV1.NewLogsArithmeticProcessorWithDefaults().GetType(),
+	tfAttributeRemapperProcessor: datadogV1.NewLogsAttributeRemapperWithDefaults().GetType(),
+	tfCategoryProcessor:          datadogV1.NewLogsCategoryProcessorWithDefaults().GetType(),
+	tfDateRemapperProcessor:      datadogV1.NewLogsDateRemapperWithDefaults().GetType(),
+	tfGeoIPParserProcessor:       datadogV1.NewLogsGeoIPParserWithDefaults().GetType(),
+	tfGrokParserProcessor:        datadogV1.NewLogsGrokParserWithDefaults().GetType(),
+	tfLookupProcessor:            datadogV1.NewLogsLookupProcessorWithDefaults().GetType(),
+	tfMessageRemapperProcessor:   datadogV1.NewLogsMessageRemapperWithDefaults().GetType(),
+	tfNestedPipelineProcessor:    "pipeline",
+	tfServiceRemapperProcessor:   datadogV1.NewLogsServiceRemapperWithDefaults().GetType(),
+	tfStatusRemapperProcessor:    datadogV1.NewLogsStatusRemapperWithDefaults().GetType(),
+	tfStringBuilderProcessor:     datadogV1.NewLogsStringBuilderProcessorWithDefaults().GetType(),
+	tfTraceIDRemapperProcessor:   datadogV1.NewLogsTraceRemapperWithDefaults().GetType(),
+	tfURLParserProcessor:         datadogV1.NewLogsURLParserWithDefaults().GetType(),
+	tfUserAgentParserProcessor:   datadogV1.NewLogsUserAgentParserWithDefaults().GetType(),
 }
 
 var tfProcessors = map[string]*schema.Schema{
@@ -56,27 +56,27 @@ var tfProcessors = map[string]*schema.Schema{
 	tfServiceRemapperProcessor:   serviceRemapper,
 	tfStatusRemapperProcessor:    statusRemmaper,
 	tfStringBuilderProcessor:     stringBuilderProcessor,
-	tfTraceIdRemapperProcessor:   traceIdRemapper,
-	tfUrlParserProcessor:         urlParser,
+	tfTraceIDRemapperProcessor:   traceIDRemapper,
+	tfURLParserProcessor:         urlParser,
 	tfUserAgentParserProcessor:   userAgentParser,
 }
 
 var ddProcessorTypes = map[string]string{
-	datadog.ArithmeticProcessorType:    tfArithmeticProcessor,
-	datadog.AttributeRemapperType:      tfAttributeRemapperProcessor,
-	datadog.CategoryProcessorType:      tfCategoryProcessor,
-	datadog.DateRemapperType:           tfDateRemapperProcessor,
-	datadog.GeoIPParserType:            tfGeoIPParserProcessor,
-	datadog.GrokParserType:             tfGrokParserProcessor,
-	datadog.LookupProcessorType:        tfLookupProcessor,
-	datadog.MessageRemapperType:        tfMessageRemapperProcessor,
-	datadog.NestedPipelineType:         tfNestedPipelineProcessor,
-	datadog.ServiceRemapperType:        tfServiceRemapperProcessor,
-	datadog.StatusRemapperType:         tfStatusRemapperProcessor,
-	datadog.StringBuilderProcessorType: tfStringBuilderProcessor,
-	datadog.TraceIdRemapperType:        tfTraceIdRemapperProcessor,
-	datadog.UrlParserType:              tfUrlParserProcessor,
-	datadog.UserAgentParserType:        tfUserAgentParserProcessor,
+	datadogV1.NewLogsArithmeticProcessorWithDefaults().GetType(): tfArithmeticProcessor,
+	datadogV1.NewLogsAttributeRemapperWithDefaults().GetType():   tfAttributeRemapperProcessor,
+	datadogV1.NewLogsCategoryProcessorWithDefaults().GetType():   tfCategoryProcessor,
+	datadogV1.NewLogsDateRemapperWithDefaults().GetType():        tfDateRemapperProcessor,
+	datadogV1.NewLogsGeoIPParserWithDefaults().GetType():         tfGeoIPParserProcessor,
+	datadogV1.NewLogsGrokParserWithDefaults().GetType():          tfGrokParserProcessor,
+	datadogV1.NewLogsLookupProcessorWithDefaults().GetType():     tfLookupProcessor,
+	datadogV1.NewLogsMessageRemapperWithDefaults().GetType():     tfMessageRemapperProcessor,
+	"pipeline": tfNestedPipelineProcessor,
+	datadogV1.NewLogsServiceRemapperWithDefaults().GetType():        tfServiceRemapperProcessor,
+	datadogV1.NewLogsStatusRemapperWithDefaults().GetType():         tfStatusRemapperProcessor,
+	datadogV1.NewLogsStringBuilderProcessorWithDefaults().GetType(): tfStringBuilderProcessor,
+	datadogV1.NewLogsTraceRemapperWithDefaults().GetType():          tfTraceIDRemapperProcessor,
+	datadogV1.NewLogsURLParserWithDefaults().GetType():              tfURLParserProcessor,
+	datadogV1.NewLogsUserAgentParserWithDefaults().GetType():        tfUserAgentParserProcessor,
 }
 
 var arithmeticProcessor = &schema.Schema{
@@ -253,7 +253,7 @@ var stringBuilderProcessor = &schema.Schema{
 	},
 }
 
-var traceIdRemapper = &schema.Schema{
+var traceIDRemapper = &schema.Schema{
 	Type:     schema.TypeList,
 	MaxItems: 1,
 	Optional: true,
@@ -313,16 +313,17 @@ func resourceDatadogLogsCustomPipeline() *schema.Resource {
 }
 
 func resourceDatadogLogsPipelineCreate(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	datadogClientV1 := providerConf.DatadogClientV1
+	authV1 := providerConf.AuthV1
+
 	ddPipeline, err := buildDatadogPipeline(d)
 	if err != nil {
-		return fmt.Errorf("failed to parse resource configuration: %s", err.Error())
+		return err
 	}
-	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
-
-	createdPipeline, err := client.CreateLogsPipeline(ddPipeline)
+	createdPipeline, _, err := datadogClientV1.LogsPipelinesApi.CreateLogsPipeline(authV1).Body(*ddPipeline).Execute()
 	if err != nil {
-		return translateClientError(err, "error creating logs pipeline")
+		return translateClientError(err, "failed to create logs pipeline using Datadog API")
 	}
 	d.SetId(*createdPipeline.Id)
 	return resourceDatadogLogsPipelineRead(d, meta)
@@ -330,11 +331,12 @@ func resourceDatadogLogsPipelineCreate(d *schema.ResourceData, meta interface{})
 
 func resourceDatadogLogsPipelineRead(d *schema.ResourceData, meta interface{}) error {
 	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
+	datadogClientV1 := providerConf.DatadogClientV1
+	authV1 := providerConf.AuthV1
 
-	ddPipeline, err := client.GetLogsPipeline(d.Id())
+	ddPipeline, _, err := datadogClientV1.LogsPipelinesApi.GetLogsPipeline(authV1, d.Id()).Execute()
 	if err != nil {
-		return translateClientError(err, "error getting logs pipeline")
+		return translateClientError(err, "failed to get logs pipeline using Datadog API")
 	}
 	if err = d.Set("name", ddPipeline.GetName()); err != nil {
 		return err
@@ -345,7 +347,7 @@ func resourceDatadogLogsPipelineRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("filter", buildTerraformFilter(ddPipeline.Filter)); err != nil {
 		return err
 	}
-	tfProcessors, err := buildTerraformProcessors(ddPipeline.Processors)
+	tfProcessors, err := buildTerraformProcessors(ddPipeline.GetProcessors())
 	if err != nil {
 		return err
 	}
@@ -356,14 +358,15 @@ func resourceDatadogLogsPipelineRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceDatadogLogsPipelineUpdate(d *schema.ResourceData, meta interface{}) error {
+	providerConf := meta.(*ProviderConfiguration)
+	datadogClientV1 := providerConf.DatadogClientV1
+	authV1 := providerConf.AuthV1
+
 	ddPipeline, err := buildDatadogPipeline(d)
 	if err != nil {
-		return fmt.Errorf("failed to parse resource configuration: %s", err.Error())
+		return err
 	}
-	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
-
-	if _, err := client.UpdateLogsPipeline(d.Id(), ddPipeline); err != nil {
+	if _, _, err := datadogClientV1.LogsPipelinesApi.UpdateLogsPipeline(authV1, d.Id()).Body(*ddPipeline).Execute(); err != nil {
 		return translateClientError(err, "error updating logs pipeline")
 	}
 	return resourceDatadogLogsPipelineRead(d, meta)
@@ -371,9 +374,10 @@ func resourceDatadogLogsPipelineUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceDatadogLogsPipelineDelete(d *schema.ResourceData, meta interface{}) error {
 	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
+	datadogClientV1 := providerConf.DatadogClientV1
+	authV1 := providerConf.AuthV1
 
-	if err := client.DeleteLogsPipeline(d.Id()); err != nil {
+	if _, err := datadogClientV1.LogsPipelinesApi.DeleteLogsPipeline(authV1, d.Id()).Execute(); err != nil {
 		// API returns 400 when the specific pipeline id doesn't exist through DELETE request.
 		if strings.Contains(err.Error(), "400 Bad Request") {
 			return nil
@@ -385,19 +389,20 @@ func resourceDatadogLogsPipelineDelete(d *schema.ResourceData, meta interface{})
 
 func resourceDatadogLogsPipelineExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
+	datadogClientV1 := providerConf.DatadogClientV1
+	authV1 := providerConf.AuthV1
 
-	if _, err := client.GetLogsPipeline(d.Id()); err != nil {
+	if _, _, err := datadogClientV1.LogsPipelinesApi.GetLogsPipeline(authV1, d.Id()).Execute(); err != nil {
 		// API returns 400 when the specific pipeline id doesn't exist through GET request.
 		if strings.Contains(err.Error(), "400 Bad Request") {
 			return false, nil
 		}
-		return false, translateClientError(err, "error checking logs pipeline exists")
+		return false, translateClientError(err, "error getting logs pipeline")
 	}
 	return true, nil
 }
 
-func buildTerraformProcessors(ddProcessors []datadog.LogsProcessor) ([]map[string]interface{}, error) {
+func buildTerraformProcessors(ddProcessors []datadogV1.LogsProcessor) ([]map[string]interface{}, error) {
 	tfProcessors := make([]map[string]interface{}, len(ddProcessors))
 	for i, ddProcessor := range ddProcessors {
 		tfProcessor, err := buildTerraformProcessor(ddProcessor)
@@ -410,66 +415,87 @@ func buildTerraformProcessors(ddProcessors []datadog.LogsProcessor) ([]map[strin
 	return tfProcessors, nil
 }
 
-func buildTerraformProcessor(ddProcessor datadog.LogsProcessor) (map[string]interface{}, error) {
+func buildTerraformProcessor(ddProcessor datadogV1.LogsProcessor) (map[string]interface{}, error) {
 	tfProcessor := make(map[string]interface{})
 	var err error
-	switch *ddProcessor.Type {
-	case datadog.ArithmeticProcessorType:
-		tfProcessor = buildTerraformArithmeticProcessor(ddProcessor.Definition.(datadog.ArithmeticProcessor))
-	case datadog.AttributeRemapperType:
-		tfProcessor = buildTerraformAttributeRemapper(ddProcessor.Definition.(datadog.AttributeRemapper))
-	case datadog.CategoryProcessorType:
-		tfProcessor = buildTerraformCategoryProcessor(ddProcessor.Definition.(datadog.CategoryProcessor))
-	case datadog.DateRemapperType,
-		datadog.MessageRemapperType,
-		datadog.ServiceRemapperType,
-		datadog.StatusRemapperType,
-		datadog.TraceIdRemapperType:
-		tfProcessor = buildTerraformSourceRemapper(ddProcessor.Definition.(datadog.SourceRemapper))
-	case datadog.GeoIPParserType:
-		tfProcessor = buildTerraformGeoIPParser(ddProcessor.Definition.(datadog.GeoIPParser))
-	case datadog.GrokParserType:
-		tfProcessor = buildTerraformGrokParser(ddProcessor.Definition.(datadog.GrokParser))
-	case datadog.LookupProcessorType:
-		tfProcessor = buildTerraformLookupProcessor(ddProcessor.Definition.(datadog.LookupProcessor))
-	case datadog.NestedPipelineType:
-		tfProcessor, err = buildTerraformNestedPipeline(ddProcessor.Definition.(datadog.NestedPipeline))
-	case datadog.StringBuilderProcessorType:
-		tfProcessor = buildTerraformStringBuilderProcessor(ddProcessor.Definition.(datadog.StringBuilderProcessor))
-	case datadog.UrlParserType:
-		tfProcessor = buildTerraformUrlParser(ddProcessor.Definition.(datadog.UrlParser))
-	case datadog.UserAgentParserType:
-		tfProcessor = buildTerraformUserAgentParser(ddProcessor.Definition.(datadog.UserAgentParser))
+	switch ddProcessor.LogsProcessorInterface.GetType() {
+	case datadogV1.NewLogsArithmeticProcessorWithDefaults().GetType():
+		logsArithmeticProcessor := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsArithmeticProcessor)
+		tfProcessor = buildTerraformArithmeticProcessor(logsArithmeticProcessor)
+	case datadogV1.NewLogsAttributeRemapperWithDefaults().GetType():
+		logsAttributeRemapper := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsAttributeRemapper)
+		tfProcessor = buildTerraformAttributeRemapper(logsAttributeRemapper)
+	case datadogV1.NewLogsCategoryProcessorWithDefaults().GetType():
+		logsCategoryProcessor := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsCategoryProcessor)
+		tfProcessor = buildTerraformCategoryProcessor(logsCategoryProcessor)
+	case datadogV1.NewLogsDateRemapperWithDefaults().GetType():
+		logsDateRemapper := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsDateRemapper)
+		tfProcessor = buildTerraformDateRemapper(logsDateRemapper)
+	case datadogV1.NewLogsMessageRemapperWithDefaults().GetType():
+		logsMessageRemapper := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsMessageRemapper)
+		tfProcessor = buildTerraformMessageRemapper(logsMessageRemapper)
+	case datadogV1.NewLogsServiceRemapperWithDefaults().GetType():
+		logsServiceRemapper := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsServiceRemapper)
+		tfProcessor = buildTerraformServiceRemapper(logsServiceRemapper)
+	case datadogV1.NewLogsStatusRemapperWithDefaults().GetType():
+		logsStatusRemapper := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsStatusRemapper)
+		tfProcessor = buildTerraformStatusRemapper(logsStatusRemapper)
+	case datadogV1.NewLogsTraceRemapperWithDefaults().GetType():
+		logsTraceRemapper := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsTraceRemapper)
+		tfProcessor = buildTerraformTraceRemapper(logsTraceRemapper)
+	case datadogV1.NewLogsGeoIPParserWithDefaults().GetType():
+		logsGeoIPParser := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsGeoIPParser)
+		tfProcessor = buildTerraformGeoIPParser(logsGeoIPParser)
+	case datadogV1.NewLogsGrokParserWithDefaults().GetType():
+		logsGrokParser := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsGrokParser)
+		tfProcessor = buildTerraformGrokParser(logsGrokParser)
+	case datadogV1.NewLogsLookupProcessorWithDefaults().GetType():
+		logsLookupProcessor := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsLookupProcessor)
+		tfProcessor = buildTerraformLookupProcessor(logsLookupProcessor)
+	case "pipeline":
+		logsPipeline := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsPipeline)
+		tfProcessor, err = buildTerraformNestedPipeline(logsPipeline)
+	case datadogV1.NewLogsStringBuilderProcessorWithDefaults().GetType():
+		logsStringBuilderProcessor := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsStringBuilderProcessor)
+		tfProcessor = buildTerraformStringBuilderProcessor(logsStringBuilderProcessor)
+	case datadogV1.NewLogsURLParserWithDefaults().GetType():
+		logsURLParser := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsURLParser)
+		tfProcessor = buildTerraformURLParser(logsURLParser)
+	case datadogV1.NewLogsUserAgentParserWithDefaults().GetType():
+		logsUserAgentParser := ddProcessor.LogsProcessorInterface.(*datadogV1.LogsUserAgentParser)
+		tfProcessor = buildTerraformUserAgentParser(logsUserAgentParser)
 	default:
-		err = fmt.Errorf("failed to support datadog processor type, %s", *ddProcessor.Type)
+		err = fmt.Errorf("failed to support datadogV1 processor type, %s", ddProcessor.LogsProcessorInterface.GetType())
 	}
 	if err != nil {
 		return nil, err
 	}
-	tfProcessor["name"] = ddProcessor.GetName()
-	tfProcessor["is_enabled"] = ddProcessor.GetIsEnabled()
 	return map[string]interface{}{
-		ddProcessorTypes[*ddProcessor.Type]: []map[string]interface{}{tfProcessor},
+		ddProcessorTypes[ddProcessor.LogsProcessorInterface.GetType()]: []map[string]interface{}{tfProcessor},
 	}, nil
 }
 
-func buildTerraformUserAgentParser(ddUserAgent datadog.UserAgentParser) map[string]interface{} {
+func buildTerraformUserAgentParser(ddUserAgent *datadogV1.LogsUserAgentParser) map[string]interface{} {
 	return map[string]interface{}{
 		"sources":    ddUserAgent.Sources,
 		"target":     ddUserAgent.GetTarget(),
 		"is_encoded": ddUserAgent.GetIsEncoded(),
+		"name":       ddUserAgent.GetName(),
+		"is_enabled": ddUserAgent.GetIsEnabled(),
 	}
 }
 
-func buildTerraformUrlParser(ddUrl datadog.UrlParser) map[string]interface{} {
+func buildTerraformURLParser(ddURL *datadogV1.LogsURLParser) map[string]interface{} {
 	return map[string]interface{}{
-		"sources":                  ddUrl.Sources,
-		"target":                   ddUrl.GetTarget(),
-		"normalize_ending_slashes": ddUrl.GetNormalizeEndingSlashes(),
+		"sources":                  ddURL.Sources,
+		"target":                   ddURL.GetTarget(),
+		"normalize_ending_slashes": ddURL.GetNormalizeEndingSlashes(),
+		"name":                     ddURL.GetName(),
+		"is_enabled":               ddURL.GetIsEnabled(),
 	}
 }
 
-func buildTerraformLookupProcessor(ddLookup datadog.LookupProcessor) map[string]interface{} {
+func buildTerraformLookupProcessor(ddLookup *datadogV1.LogsLookupProcessor) map[string]interface{} {
 	tfProcessor := map[string]interface{}{
 		"source":       ddLookup.GetSource(),
 		"target":       ddLookup.GetTarget(),
@@ -483,41 +509,49 @@ func buildTerraformLookupProcessor(ddLookup datadog.LookupProcessor) map[string]
 	return tfProcessor
 }
 
-func buildTerraformNestedPipeline(ddNested datadog.NestedPipeline) (map[string]interface{}, error) {
-	tfProcessors, err := buildTerraformProcessors(ddNested.Processors)
+func buildTerraformNestedPipeline(ddNested *datadogV1.LogsPipeline) (map[string]interface{}, error) {
+	tfProcessors, err := buildTerraformProcessors(ddNested.GetProcessors())
 	if err != nil {
 		return nil, err
 	}
 	return map[string]interface{}{
-		"filter":    buildTerraformFilter(ddNested.Filter),
-		"processor": tfProcessors,
+		"filter":     buildTerraformFilter(ddNested.Filter),
+		"processor":  tfProcessors,
+		"name":       ddNested.GetName(),
+		"is_enabled": ddNested.GetIsEnabled(),
 	}, nil
 }
 
-func buildTerraformStringBuilderProcessor(ddStringBuilder datadog.StringBuilderProcessor) map[string]interface{} {
+func buildTerraformStringBuilderProcessor(ddStringBuilder *datadogV1.LogsStringBuilderProcessor) map[string]interface{} {
 	return map[string]interface{}{
 		"template":           ddStringBuilder.GetTemplate(),
 		"target":             ddStringBuilder.GetTarget(),
 		"is_replace_missing": ddStringBuilder.GetIsReplaceMissing(),
+		"name":               ddStringBuilder.GetName(),
+		"is_enabled":         ddStringBuilder.GetIsEnabled(),
 	}
 }
 
-func buildTerraformGeoIPParser(ddGeoIPParser datadog.GeoIPParser) map[string]interface{} {
+func buildTerraformGeoIPParser(ddGeoIPParser *datadogV1.LogsGeoIPParser) map[string]interface{} {
 	return map[string]interface{}{
-		"sources": ddGeoIPParser.Sources,
-		"target":  ddGeoIPParser.GetTarget(),
+		"sources":    ddGeoIPParser.Sources,
+		"target":     ddGeoIPParser.GetTarget(),
+		"name":       ddGeoIPParser.GetName(),
+		"is_enabled": ddGeoIPParser.GetIsEnabled(),
 	}
 }
 
-func buildTerraformGrokParser(ddGrok datadog.GrokParser) map[string]interface{} {
+func buildTerraformGrokParser(ddGrok *datadogV1.LogsGrokParser) map[string]interface{} {
 	return map[string]interface{}{
-		"samples": ddGrok.Samples,
-		"source":  ddGrok.GetSource(),
-		"grok":    buildTerraformGrokRule(ddGrok.GrokRule),
+		"samples":    ddGrok.Samples,
+		"source":     ddGrok.GetSource(),
+		"grok":       buildTerraformGrokRule(&ddGrok.Grok),
+		"name":       ddGrok.GetName(),
+		"is_enabled": ddGrok.GetIsEnabled(),
 	}
 }
 
-func buildTerraformGrokRule(ddGrokRule *datadog.GrokRule) []map[string]interface{} {
+func buildTerraformGrokRule(ddGrokRule *datadogV1.LogsGrokParserRules) []map[string]interface{} {
 	tfGrokRule := map[string]interface{}{
 		"support_rules": ddGrokRule.GetSupportRules(),
 		"match_rules":   ddGrokRule.GetMatchRules(),
@@ -525,20 +559,56 @@ func buildTerraformGrokRule(ddGrokRule *datadog.GrokRule) []map[string]interface
 	return []map[string]interface{}{tfGrokRule}
 }
 
-func buildTerraformSourceRemapper(ddSource datadog.SourceRemapper) map[string]interface{} {
+func buildTerraformMessageRemapper(remapper *datadogV1.LogsMessageRemapper) map[string]interface{} {
 	return map[string]interface{}{
-		"sources": ddSource.Sources,
+		"sources":    remapper.Sources,
+		"name":       remapper.GetName(),
+		"is_enabled": remapper.GetIsEnabled(),
 	}
 }
 
-func buildTerraformCategoryProcessor(ddCategory datadog.CategoryProcessor) map[string]interface{} {
+func buildTerraformDateRemapper(remapper *datadogV1.LogsDateRemapper) map[string]interface{} {
 	return map[string]interface{}{
-		"target":   ddCategory.GetTarget(),
-		"category": buildTerraformCategories(ddCategory.Categories),
+		"sources":    remapper.Sources,
+		"name":       remapper.GetName(),
+		"is_enabled": remapper.GetIsEnabled(),
 	}
 }
 
-func buildTerraformCategories(ddCategories []datadog.Category) []map[string]interface{} {
+func buildTerraformServiceRemapper(remapper *datadogV1.LogsServiceRemapper) map[string]interface{} {
+	return map[string]interface{}{
+		"sources":    remapper.Sources,
+		"name":       remapper.GetName(),
+		"is_enabled": remapper.GetIsEnabled(),
+	}
+}
+
+func buildTerraformStatusRemapper(remapper *datadogV1.LogsStatusRemapper) map[string]interface{} {
+	return map[string]interface{}{
+		"sources":    remapper.Sources,
+		"name":       remapper.GetName(),
+		"is_enabled": remapper.GetIsEnabled(),
+	}
+}
+
+func buildTerraformTraceRemapper(remapper *datadogV1.LogsTraceRemapper) map[string]interface{} {
+	return map[string]interface{}{
+		"sources":    remapper.Sources,
+		"name":       remapper.GetName(),
+		"is_enabled": remapper.GetIsEnabled(),
+	}
+}
+
+func buildTerraformCategoryProcessor(ddCategory *datadogV1.LogsCategoryProcessor) map[string]interface{} {
+	return map[string]interface{}{
+		"target":     ddCategory.GetTarget(),
+		"category":   buildTerraformCategories(ddCategory.Categories),
+		"name":       ddCategory.GetName(),
+		"is_enabled": ddCategory.GetIsEnabled(),
+	}
+}
+
+func buildTerraformCategories(ddCategories []datadogV1.LogsCategoryProcessorCategories) []map[string]interface{} {
 	tfCategories := make([]map[string]interface{}, len(ddCategories))
 	for i, ddCategory := range ddCategories {
 		tfCategories[i] = map[string]interface{}{
@@ -549,7 +619,7 @@ func buildTerraformCategories(ddCategories []datadog.Category) []map[string]inte
 	return tfCategories
 }
 
-func buildTerraformAttributeRemapper(ddAttribute datadog.AttributeRemapper) map[string]interface{} {
+func buildTerraformAttributeRemapper(ddAttribute *datadogV1.LogsAttributeRemapper) map[string]interface{} {
 	return map[string]interface{}{
 		"sources":              ddAttribute.Sources,
 		"source_type":          ddAttribute.GetSourceType(),
@@ -557,26 +627,31 @@ func buildTerraformAttributeRemapper(ddAttribute datadog.AttributeRemapper) map[
 		"target_type":          ddAttribute.GetTargetType(),
 		"preserve_source":      ddAttribute.GetPreserveSource(),
 		"override_on_conflict": ddAttribute.GetOverrideOnConflict(),
+		"name":                 ddAttribute.GetName(),
+		"is_enabled":           ddAttribute.GetIsEnabled(),
 	}
 }
 
-func buildTerraformArithmeticProcessor(ddArithmetic datadog.ArithmeticProcessor) map[string]interface{} {
+func buildTerraformArithmeticProcessor(ddArithmetic *datadogV1.LogsArithmeticProcessor) map[string]interface{} {
+
 	return map[string]interface{}{
 		"target":             ddArithmetic.GetTarget(),
 		"is_replace_missing": ddArithmetic.GetIsReplaceMissing(),
 		"expression":         ddArithmetic.GetExpression(),
+		"name":               ddArithmetic.GetName(),
+		"is_enabled":         ddArithmetic.GetIsEnabled(),
 	}
 }
 
-func buildTerraformFilter(ddFilter *datadog.FilterConfiguration) []map[string]interface{} {
+func buildTerraformFilter(ddFilter *datadogV1.LogsFilter) []map[string]interface{} {
 	tfFilter := map[string]interface{}{
 		"query": ddFilter.GetQuery(),
 	}
 	return []map[string]interface{}{tfFilter}
 }
 
-func buildDatadogPipeline(d *schema.ResourceData) (*datadog.LogsPipeline, error) {
-	var ddPipeline datadog.LogsPipeline
+func buildDatadogPipeline(d *schema.ResourceData) (*datadogV1.LogsPipeline, error) {
+	var ddPipeline datadogV1.LogsPipeline
 	ddPipeline.SetName(d.Get("name").(string))
 	ddPipeline.SetIsEnabled(d.Get("is_enabled").(bool))
 	if tfFilter := d.Get("filter").([]interface{}); len(tfFilter) > 0 {
@@ -590,8 +665,8 @@ func buildDatadogPipeline(d *schema.ResourceData) (*datadog.LogsPipeline, error)
 	return &ddPipeline, nil
 }
 
-func buildDatadogProcessors(tfProcessors []interface{}) ([]datadog.LogsProcessor, error) {
-	ddProcessors := make([]datadog.LogsProcessor, len(tfProcessors))
+func buildDatadogProcessors(tfProcessors []interface{}) (*[]datadogV1.LogsProcessor, error) {
+	ddProcessors := make([]datadogV1.LogsProcessor, len(tfProcessors))
 	for i, tfProcessor := range tfProcessors {
 		for tfProcessorType, ddProcessorType := range tfProcessorTypes {
 			tfProcessorMap := tfProcessor.(map[string]interface{})
@@ -605,68 +680,72 @@ func buildDatadogProcessors(tfProcessors []interface{}) ([]datadog.LogsProcessor
 			}
 		}
 	}
-	return ddProcessors, nil
+	return &ddProcessors, nil
 }
 
-func buildDatadogProcessor(ddProcessorType string, tfProcessor map[string]interface{}) (datadog.LogsProcessor, error) {
-	var ddProcessor = datadog.LogsProcessor{}
+func buildDatadogProcessor(ddProcessorType string, tfProcessor map[string]interface{}) (datadogV1.LogsProcessor, error) {
+	var ddProcessor = datadogV1.LogsProcessor{}
 	var err error
 	switch ddProcessorType {
-	case datadog.ArithmeticProcessorType:
-		ddProcessor.Definition = buildDatadogArithmeticProcessor(tfProcessor)
-	case datadog.AttributeRemapperType:
-		ddProcessor.Definition = buildDatadogAttributeRemapper(tfProcessor)
-	case datadog.CategoryProcessorType:
-		ddProcessor.Definition = buildDatadogCategoryProcessor(tfProcessor)
-	case datadog.DateRemapperType,
-		datadog.MessageRemapperType,
-		datadog.ServiceRemapperType,
-		datadog.StatusRemapperType,
-		datadog.TraceIdRemapperType:
-		ddProcessor.Definition = buildDatadogSourceRemapper(tfProcessor)
-	case datadog.GeoIPParserType:
-		ddProcessor.Definition = buildDatadogGeoIPParser(tfProcessor)
-	case datadog.GrokParserType:
-		ddProcessor.Definition = buildDatadogGrokParser(tfProcessor)
-	case datadog.LookupProcessorType:
-		ddProcessor.Definition = buildDatadogLookupProcessor(tfProcessor)
-	case datadog.NestedPipelineType:
-		ddProcessor.Definition, err = buildDatadogNestedPipeline(tfProcessor)
-	case datadog.StringBuilderProcessorType:
-		ddProcessor.Definition = buildDatadogStringBuilderProcessor(tfProcessor)
-	case datadog.UrlParserType:
-		ddProcessor.Definition = buildDatadogUrlParser(tfProcessor)
-	case datadog.UserAgentParserType:
-		ddProcessor.Definition = buildDatadogUserAgentParser(tfProcessor)
+	case datadogV1.NewLogsArithmeticProcessorWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogArithmeticProcessor(tfProcessor)
+	case datadogV1.NewLogsAttributeRemapperWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogAttributeRemapper(tfProcessor)
+	case datadogV1.NewLogsCategoryProcessorWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogCategoryProcessor(tfProcessor)
+	case datadogV1.NewLogsDateRemapperWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogDateRemapperProcessor(tfProcessor)
+	case datadogV1.NewLogsMessageRemapperWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogMessageRemapper(tfProcessor)
+	case datadogV1.NewLogsServiceRemapperWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogServiceRemapper(tfProcessor)
+	case datadogV1.NewLogsStatusRemapperWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogStatusRemapper(tfProcessor)
+	case datadogV1.NewLogsTraceRemapperWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogTraceRemapper(tfProcessor)
+	case datadogV1.NewLogsGeoIPParserWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogGeoIPParser(tfProcessor)
+	case datadogV1.NewLogsGrokParserWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogGrokParser(tfProcessor)
+	case datadogV1.NewLogsLookupProcessorWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogLookupProcessor(tfProcessor)
+	case datadogV1.NewLogsPipelineWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface, err = buildDatadogNestedPipeline(tfProcessor)
+	case "pipeline":
+		ddProcessor.LogsProcessorInterface = buildDatadogStringBuilderProcessor(tfProcessor)
+	case datadogV1.NewLogsURLParserWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogURLParser(tfProcessor)
+	case datadogV1.NewLogsUserAgentParserWithDefaults().GetType():
+		ddProcessor.LogsProcessorInterface = buildDatadogUserAgentParser(tfProcessor)
 	default:
 		err = fmt.Errorf("failed to recoginize processor type: %s", ddProcessorType)
 	}
-	if tfName, exists := tfProcessor["name"].(string); exists {
-		ddProcessor.SetName(tfName)
-	}
-	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
-		ddProcessor.SetIsEnabled(tfIsEnabled)
-	}
-	ddProcessor.SetType(ddProcessorType)
+
 	return ddProcessor, err
 }
 
-func buildDatadogUrlParser(tfProcessor map[string]interface{}) datadog.UrlParser {
-	ddUrlParser := datadog.UrlParser{}
+func buildDatadogURLParser(tfProcessor map[string]interface{}) *datadogV1.LogsURLParser {
+	ddURLParser := datadogV1.NewLogsURLParserWithDefaults()
 	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
-		ddUrlParser.Sources = ddSources
+		ddURLParser.Sources = ddSources
 	}
 	if tfTarget, exists := tfProcessor["target"].(string); exists {
-		ddUrlParser.SetTarget(tfTarget)
+		ddURLParser.SetTarget(tfTarget)
+	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddURLParser.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddURLParser.SetIsEnabled(tfIsEnabled)
 	}
 	if tfNormalizeEndingSlashes, exists := tfProcessor["normalize_ending_slashes"].(bool); exists {
-		ddUrlParser.SetNormalizeEndingSlashes(tfNormalizeEndingSlashes)
+		ddURLParser.SetNormalizeEndingSlashes(tfNormalizeEndingSlashes)
 	}
-	return ddUrlParser
+	return ddURLParser
 }
 
-func buildDatadogUserAgentParser(tfProcessor map[string]interface{}) datadog.UserAgentParser {
-	ddUserAgentParser := datadog.UserAgentParser{}
+func buildDatadogUserAgentParser(tfProcessor map[string]interface{}) *datadogV1.LogsUserAgentParser {
+	ddUserAgentParser := datadogV1.NewLogsUserAgentParserWithDefaults()
 	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
 		ddUserAgentParser.Sources = ddSources
 	}
@@ -676,11 +755,17 @@ func buildDatadogUserAgentParser(tfProcessor map[string]interface{}) datadog.Use
 	if tfIsEncoded, exists := tfProcessor["is_encoded"].(bool); exists {
 		ddUserAgentParser.SetIsEncoded(tfIsEncoded)
 	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddUserAgentParser.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddUserAgentParser.SetIsEnabled(tfIsEnabled)
+	}
 	return ddUserAgentParser
 }
 
-func buildDatadogLookupProcessor(tfProcessor map[string]interface{}) datadog.LookupProcessor {
-	ddLookupProcessor := datadog.LookupProcessor{}
+func buildDatadogLookupProcessor(tfProcessor map[string]interface{}) *datadogV1.LogsLookupProcessor {
+	ddLookupProcessor := datadogV1.NewLogsLookupProcessorWithDefaults()
 	if tfSource, exists := tfProcessor["source"].(string); exists {
 		ddLookupProcessor.SetSource(tfSource)
 	}
@@ -700,23 +785,29 @@ func buildDatadogLookupProcessor(tfProcessor map[string]interface{}) datadog.Loo
 	return ddLookupProcessor
 }
 
-func buildDatadogNestedPipeline(tfProcessor map[string]interface{}) (datadog.NestedPipeline, error) {
-	ddNestedPipeline := datadog.NestedPipeline{}
+func buildDatadogNestedPipeline(tfProcessor map[string]interface{}) (*datadogV1.LogsPipeline, error) {
+	ddNestedPipeline := datadogV1.LogsPipeline{}
 	if tfFilter, exist := tfProcessor["filter"].([]interface{}); exist && len(tfFilter) > 0 {
 		ddNestedPipeline.SetFilter(buildDatadogFilter(tfFilter[0].(map[string]interface{})))
 	}
 	if tfProcessors, exists := tfProcessor["processor"].([]interface{}); exists && len(tfProcessors) > 0 {
 		ddProcessors, err := buildDatadogProcessors(tfProcessors)
 		if err != nil {
-			return ddNestedPipeline, err
+			return &ddNestedPipeline, err
 		}
 		ddNestedPipeline.Processors = ddProcessors
 	}
-	return ddNestedPipeline, nil
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddNestedPipeline.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddNestedPipeline.SetIsEnabled(tfIsEnabled)
+	}
+	return &ddNestedPipeline, nil
 }
 
-func buildDatadogStringBuilderProcessor(tfProcessor map[string]interface{}) datadog.StringBuilderProcessor {
-	ddStringBuilder := datadog.StringBuilderProcessor{}
+func buildDatadogStringBuilderProcessor(tfProcessor map[string]interface{}) *datadogV1.LogsStringBuilderProcessor {
+	ddStringBuilder := datadogV1.NewLogsStringBuilderProcessorWithDefaults()
 	if tfTemplate, exists := tfProcessor["template"].(string); exists {
 		ddStringBuilder.SetTemplate(tfTemplate)
 	}
@@ -726,22 +817,34 @@ func buildDatadogStringBuilderProcessor(tfProcessor map[string]interface{}) data
 	if tfReplaceMissing, exists := tfProcessor["is_replace_missing"].(bool); exists {
 		ddStringBuilder.SetIsReplaceMissing(tfReplaceMissing)
 	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddStringBuilder.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddStringBuilder.SetIsEnabled(tfIsEnabled)
+	}
 	return ddStringBuilder
 }
 
-func buildDatadogGeoIPParser(tfProcessor map[string]interface{}) datadog.GeoIPParser {
-	ddGeoIPParser := datadog.GeoIPParser{}
+func buildDatadogGeoIPParser(tfProcessor map[string]interface{}) *datadogV1.LogsGeoIPParser {
+	ddGeoIPParser := datadogV1.NewLogsGeoIPParserWithDefaults()
 	if tfTarget, exists := tfProcessor["target"].(string); exists {
 		ddGeoIPParser.SetTarget(tfTarget)
 	}
 	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
 		ddGeoIPParser.Sources = ddSources
 	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddGeoIPParser.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddGeoIPParser.SetIsEnabled(tfIsEnabled)
+	}
 	return ddGeoIPParser
 }
 
-func buildDatadogGrokParser(tfProcessor map[string]interface{}) datadog.GrokParser {
-	ddGrokParser := datadog.GrokParser{}
+func buildDatadogGrokParser(tfProcessor map[string]interface{}) *datadogV1.LogsGrokParser {
+	ddGrokParser := datadogV1.NewLogsGrokParserWithDefaults()
 	if tfSource, exists := tfProcessor["source"].(string); exists {
 		ddGrokParser.SetSource(tfSource)
 	}
@@ -750,10 +853,10 @@ func buildDatadogGrokParser(tfProcessor map[string]interface{}) datadog.GrokPars
 		for i, tfSample := range tfSamples {
 			ddSamples[i] = tfSample.(string)
 		}
-		ddGrokParser.Samples = ddSamples
+		ddGrokParser.Samples = &ddSamples
 	}
 	if tfGrok, exists := tfProcessor["grok"].([]interface{}); exists && len(tfGrok) > 0 {
-		ddGrok := datadog.GrokRule{}
+		ddGrok := datadogV1.LogsGrokParserRules{}
 		tfGrokRule := tfGrok[0].(map[string]interface{})
 		if tfSupportRule, exist := tfGrokRule["support_rules"].(string); exist {
 			ddGrok.SetSupportRules(tfSupportRule)
@@ -761,29 +864,83 @@ func buildDatadogGrokParser(tfProcessor map[string]interface{}) datadog.GrokPars
 		if tfMatchRule, exist := tfGrokRule["match_rules"].(string); exist {
 			ddGrok.SetMatchRules(tfMatchRule)
 		}
-		ddGrokParser.GrokRule = &ddGrok
+		ddGrokParser.SetGrok(ddGrok)
+	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddGrokParser.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddGrokParser.SetIsEnabled(tfIsEnabled)
 	}
 	return ddGrokParser
 }
 
-func buildDatadogSourceRemapper(tfProcessor map[string]interface{}) datadog.SourceRemapper {
-	ddSourceRemapper := datadog.SourceRemapper{}
+func buildDatadogMessageRemapper(tfProcessor map[string]interface{}) *datadogV1.LogsMessageRemapper {
+	ddRemapper := datadogV1.NewLogsMessageRemapperWithDefaults()
 	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
-		ddSourceRemapper.Sources = ddSources
+		ddRemapper.Sources = ddSources
 	}
-	return ddSourceRemapper
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddRemapper.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddRemapper.SetIsEnabled(tfIsEnabled)
+	}
+	return ddRemapper
 }
 
-func buildDatadogCategoryProcessor(tfProcessor map[string]interface{}) datadog.CategoryProcessor {
-	ddCategory := datadog.CategoryProcessor{}
+func buildDatadogServiceRemapper(tfProcessor map[string]interface{}) *datadogV1.LogsServiceRemapper {
+	ddRemapper := datadogV1.NewLogsServiceRemapperWithDefaults()
+	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
+		ddRemapper.Sources = ddSources
+	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddRemapper.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddRemapper.SetIsEnabled(tfIsEnabled)
+	}
+	return ddRemapper
+}
+
+func buildDatadogStatusRemapper(tfProcessor map[string]interface{}) *datadogV1.LogsStatusRemapper {
+	ddRemapper := datadogV1.NewLogsStatusRemapperWithDefaults()
+	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
+		ddRemapper.Sources = ddSources
+	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddRemapper.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddRemapper.SetIsEnabled(tfIsEnabled)
+	}
+	return ddRemapper
+}
+
+func buildDatadogTraceRemapper(tfProcessor map[string]interface{}) *datadogV1.LogsTraceRemapper {
+	ddRemapper := datadogV1.NewLogsTraceRemapperWithDefaults()
+	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
+		ddRemapper.Sources = &ddSources
+	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddRemapper.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddRemapper.SetIsEnabled(tfIsEnabled)
+	}
+	return ddRemapper
+}
+
+func buildDatadogCategoryProcessor(tfProcessor map[string]interface{}) *datadogV1.LogsCategoryProcessor {
+	ddCategory := datadogV1.NewLogsCategoryProcessorWithDefaults()
 	if tfTarget, exists := tfProcessor["target"].(string); exists {
 		ddCategory.SetTarget(tfTarget)
 	}
 	if tfCategories, exists := tfProcessor["category"].([]interface{}); exists {
-		ddCategories := make([]datadog.Category, len(tfCategories))
+		ddCategories := make([]datadogV1.LogsCategoryProcessorCategories, len(tfCategories))
 		for i, tfC := range tfCategories {
 			tfCategory := tfC.(map[string]interface{})
-			ddCategory := datadog.Category{}
+			ddCategory := datadogV1.LogsCategoryProcessorCategories{}
 			if tfName, exist := tfCategory["name"].(string); exist {
 				ddCategory.SetName(tfName)
 			}
@@ -795,11 +952,18 @@ func buildDatadogCategoryProcessor(tfProcessor map[string]interface{}) datadog.C
 		}
 		ddCategory.Categories = ddCategories
 	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddCategory.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddCategory.SetIsEnabled(tfIsEnabled)
+	}
 	return ddCategory
 }
 
-func buildDatadogAttributeRemapper(tfProcessor map[string]interface{}) datadog.AttributeRemapper {
-	ddAttribute := datadog.AttributeRemapper{}
+func buildDatadogAttributeRemapper(tfProcessor map[string]interface{}) *datadogV1.LogsAttributeRemapper {
+	ddAttribute := datadogV1.NewLogsAttributeRemapperWithDefaults()
+
 	if ddSources := buildDatadogSources(tfProcessor); ddSources != nil {
 		ddAttribute.Sources = ddSources
 	}
@@ -818,6 +982,12 @@ func buildDatadogAttributeRemapper(tfProcessor map[string]interface{}) datadog.A
 	if tfOverrideOnConflict, exists := tfProcessor["override_on_conflict"].(bool); exists {
 		ddAttribute.SetOverrideOnConflict(tfOverrideOnConflict)
 	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddAttribute.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddAttribute.SetIsEnabled(tfIsEnabled)
+	}
 	return ddAttribute
 }
 
@@ -832,8 +1002,8 @@ func buildDatadogSources(tfProcessor map[string]interface{}) []string {
 	return nil
 }
 
-func buildDatadogArithmeticProcessor(tfProcessor map[string]interface{}) datadog.ArithmeticProcessor {
-	ddArithmetic := datadog.ArithmeticProcessor{}
+func buildDatadogArithmeticProcessor(tfProcessor map[string]interface{}) *datadogV1.LogsArithmeticProcessor {
+	ddArithmetic := datadogV1.NewLogsArithmeticProcessorWithDefaults()
 	if tfTarget, exists := tfProcessor["target"].(string); exists {
 		ddArithmetic.SetTarget(tfTarget)
 	}
@@ -843,11 +1013,31 @@ func buildDatadogArithmeticProcessor(tfProcessor map[string]interface{}) datadog
 	if tfIsReplaceMissing, exists := tfProcessor["is_replace_missing"].(bool); exists {
 		ddArithmetic.SetIsReplaceMissing(tfIsReplaceMissing)
 	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddArithmetic.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddArithmetic.SetIsEnabled(tfIsEnabled)
+	}
 	return ddArithmetic
 }
 
-func buildDatadogFilter(tfFilter map[string]interface{}) datadog.FilterConfiguration {
-	ddFilter := datadog.FilterConfiguration{}
+func buildDatadogDateRemapperProcessor(tfProcessor map[string]interface{}) *datadogV1.LogsDateRemapper {
+	ddDate := datadogV1.NewLogsDateRemapperWithDefaults()
+	if tfSources, exists := tfProcessor["sources"].([]string); exists {
+		ddDate.SetSources(tfSources)
+	}
+	if tfName, exists := tfProcessor["name"].(string); exists {
+		ddDate.SetName(tfName)
+	}
+	if tfIsEnabled, exists := tfProcessor["is_enabled"].(bool); exists {
+		ddDate.SetIsEnabled(tfIsEnabled)
+	}
+	return ddDate
+}
+
+func buildDatadogFilter(tfFilter map[string]interface{}) datadogV1.LogsFilter {
+	ddFilter := datadogV1.LogsFilter{}
 	if tfQuery, exists := tfFilter["query"].(string); exists {
 		ddFilter.SetQuery(tfQuery)
 	}


### PR DESCRIPTION
This PR converts the logs custom pipelines resource to utilize datadog go client.

Blockers: Missing `pipelines` schema for log processor types