### PR TITLE
Do not set empty structures in request to create aws integration

### DIFF
--- a/datadog/resource_datadog_integration_aws.go
+++ b/datadog/resource_datadog_integration_aws.go
@@ -102,6 +102,7 @@ func resourceDatadogIntegrationAwsPrepareCreateRequest(d *schema.ResourceData, a
 		for _, s := range attr.([]interface{}) {
 			filterTags = append(filterTags, s.(string))
 		}
+		iaws.SetFilterTags(filterTags)
 	}
 
 	var hostTags []string
@@ -110,6 +111,7 @@ func resourceDatadogIntegrationAwsPrepareCreateRequest(d *schema.ResourceData, a
 		for _, s := range attr.([]interface{}) {
 			hostTags = append(hostTags, s.(string))
 		}
+		iaws.SetHostTags(hostTags)
 	}
 
 	accountSpecificNamespaceRules := make(map[string]bool)
@@ -119,10 +121,9 @@ func resourceDatadogIntegrationAwsPrepareCreateRequest(d *schema.ResourceData, a
 		for k, v := range attr.(map[string]interface{}) {
 			accountSpecificNamespaceRules[k] = v.(bool)
 		}
+		iaws.SetAccountSpecificNamespaceRules(accountSpecificNamespaceRules)
 	}
-	iaws.SetFilterTags(filterTags)
-	iaws.SetHostTags(hostTags)
-	iaws.SetAccountSpecificNamespaceRules(accountSpecificNamespaceRules)
+
 	return iaws
 }
 


### PR DESCRIPTION
This PR Fixes #504 by only setting host tags, filter tags and account specific namespace rules on the http request if these values have been set by the user. 

Somehow, setting these structures while they are empty affects the serialisation of the request in such a way that the DataDog API rejects the values as being of the wrong type.