### PR TITLE
Update make task to include new client + update README

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,8 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=datadog
 DIR=~/.terraform.d/plugins
-GO_CLIENT_VERSION=master
+ZORKIAN_VERSION=master
+API_CLIENT_VERSION=master
 
 default: build
 
@@ -71,7 +72,9 @@ endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 update-go-client:
-	go get github.com/zorkian/go-datadog-api@$(GO_CLIENT_VERSION)
+	echo "Updating the Zorkian client to ${ZORKIAN_VERSION} and the API Client to ${API_CLIENT_VERSION}"
+	go get github.com/zorkian/go-datadog-api@$(ZORKIAN_VERSION)
+	go get github.com/DataDog/datadog-api-client-go@${API_CLIENT_VERSION}
 	go mod vendor
 	go mod tidy
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,13 @@ a production Datadog organization.
 ```sh
 $ make testacc
 ```
+
+In order to update the underlying API Clients that are used by this provider to interact with the Datadog API, run:
+
+```sh
+API_CLIENT_VERSION=vx.y.z ZORKIAN_VERSION=vx.y.z make update-go-client
+```
+
+where:
+* `API_CLIENT_VERSION` is the version or commit ref of the https://github.com/DataDog/datadog-api-client-go client.
+* `ZORKIAN_VERSION` is the version or commit ref of the https://github.com/zorkian/go-datadog-api client.


### PR DESCRIPTION
Update the Makefile's `update-go-client` task to include the new client being used. (Changes the existing variable name for the zorkian client as well)

Also documents this briefly in the README.md file..