### PR TITLE
Add default to deprecated `count` field to avoid sending 0

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2518,6 +2518,7 @@ func getManageStatusDefinitionSchema() map[string]*schema.Schema {
 			Type:       schema.TypeInt,
 			Deprecated: "This parameter may be removed from the dashboard API in the future",
 			Optional:   true,
+			Default:    50,
 		},
 		// The start param is deprecated
 		"start": {


### PR DESCRIPTION
The count field is set to 0 by terraform if not set, which prevents the widget from getting any data.
Since this field is marked as deprecated, it is not expected to be set, so having a default makes sense.