### PR TITLE
Update api docs links and add lambda arn to docs

### DIFF
--- a/website/datadog.erb
+++ b/website/datadog.erb
@@ -34,6 +34,9 @@
             <li<%= sidebar_current("docs-datadog-resource-integration_aws") %>>
               <a href="/docs/providers/datadog/r/integration_aws.html">datadog_integration_aws</a>
             </li>
+            <li<%= sidebar_current("docs-datadog-resource-integration_aws_lambda_arn") %>>
+              <a href="/docs/providers/datadog/r/integration_aws_lambda_arn.html">datadog_integration_aws_lambda_arn</a>
+            </li>
             <li<%= sidebar_current("docs-datadog-resource-integration_gcp") %>>
               <a href="/docs/providers/datadog/r/integration_gcp.html">datadog_integration_gcp</a>
             </li>

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a Datadog dashboard resource. This can be used to create and manage Datadog dashboards.
 
-~> **Note:** This resource uses the new [Dashboard API](https://docs.datadoghq.com/api/#dashboards) which adds new features like better validation and support for the [Group widget](https://docs.datadoghq.com/graphing/widgets/group/). Additionally, this resource unifies [`datadog_timeboard`](timeboard.html) and [`datadog_screenboard`](screenboard.html) resources to allow you to manage all of your dashboards using a single format.
+~> **Note:** This resource uses the new [Dashboard API](https://docs.datadoghq.com/api/v1/dashboards/) which adds new features like better validation and support for the [Group widget](https://docs.datadoghq.com/graphing/widgets/group/). Additionally, this resource unifies [`datadog_timeboard`](timeboard.html) and [`datadog_screenboard`](screenboard.html) resources to allow you to manage all of your dashboards using a single format.
 
 
 ## Example Usage: Create a new Datadog dashboard - Ordered layout

--- a/website/docs/r/integration_aws.html.markdown
+++ b/website/docs/r/integration_aws.html.markdown
@@ -35,16 +35,16 @@ The following arguments are supported:
 * `account_id` - (Required) Your AWS Account ID without dashes.
 * `role_name` - (Required) Your Datadog role delegation name.
 * `filter_tags` - (Optional) Array of EC2 tags (in the form `key:value`) defines a filter that Datadog use when collecting metrics from EC2. Wildcards, such as `?` (for single characters) and `*` (for multiple characters) can also be used.
-  
+
   Only hosts that match one of the defined tags will be imported into Datadog. The rest will be ignored. Host matching a given tag can also be excluded by adding `!` before the tag.
-  
+
   e.x. `env:production,instance-type:c1.*,!region:us-east-1`
 
 * `host_tags` - (Optional) Array of tags (in the form key:value) to add to all hosts and metrics reporting through this integration.
-* `account_specific_namespace_rules` - (Optional) Enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the [available namespace rules API endpoint](https://docs.datadoghq.com/api/?lang=bash#list-namespace-rules).
+* `account_specific_namespace_rules` - (Optional) Enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the [available namespace rules API endpoint](https://docs.datadoghq.com/api/v1/aws-integration/#list-namespace-rules).
 
 ### See also
-* [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/?lang=bash#aws)
+* [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/v1/aws-integration/)
 
 ## Attributes Reference
 

--- a/website/docs/r/integration_aws_lambda_arn.html.markdown
+++ b/website/docs/r/integration_aws_lambda_arn.html.markdown
@@ -3,13 +3,13 @@ layout: "datadog"
 page_title: "Datadog: datadog_integration_aws_lambda_arn"
 sidebar_current: "docs-datadog-resource-integration_aws_lambda_arn"
 description: |-
-  Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the 
+  Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the
   log collection Lambdas for an account.
 ---
 
 # datadog_integration_aws_lambda_arn
 
-Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the 
+Provides a Datadog - Amazon Web Services integration Lambda ARN resource. This can be used to create and manage the
 log collection Lambdas for an account.
 
 Update operations are currently not supported with datadog API so any change forces a new resource.
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `lambda_arn` - (Required) The ARN of the Datadog forwarder Lambda.
 
 ### See also
-* [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/?lang=bash#aws)
+* [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/v1/aws-integration/)
 * [Datadog log forwarder](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring)
 
 ## Attributes Reference

--- a/website/docs/r/integration_aws_log_collection.html.markdown
+++ b/website/docs/r/integration_aws_log_collection.html.markdown
@@ -3,13 +3,13 @@ layout: "datadog"
 page_title: "Datadog: datadog_integration_aws_log_collection"
 sidebar_current: "docs-datadog-resource-integration_aws_log_collection"
 description: |-
-  Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which 
+  Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which
   AWS services logs are collected from for an account.
 ---
 
 # datadog_integration_aws_log_collection
 
-Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which 
+Provides a Datadog - Amazon Web Services integration log collection resource. This can be used to manage which
 AWS services logs are collected from for an account.
 
 ## Example Usage
@@ -27,12 +27,12 @@ resource "datadog_integration_aws_log_collection" "main" {
 The following arguments are supported:
 
 * `account_id` - (Required) Your AWS Account ID without dashes.
-* `services` - (Required) A list of services to collect logs from. See the 
-[api docs](https://docs.datadoghq.com/api/?lang=bash#get-list-of-aws-log-ready-services) for more details on which 
+* `services` - (Required) A list of services to collect logs from. See the
+[api docs](https://docs.datadoghq.com/api/v1/aws-logs-integration/#get-list-of-aws-log-ready-services) for more details on which
 services are supported.
 
 ### See also
-* [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/?lang=bash#aws)
+* [Datadog API Reference > Integrations > AWS](https://docs.datadoghq.com/api/v1/aws-integration/)
 
 ## Attributes Reference
 

--- a/website/docs/r/integration_gcp.html.markdown
+++ b/website/docs/r/integration_gcp.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 ### See also
 * [Google Cloud > Creating and Managing Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
-* [Datadog API Reference > Integrations > Google Cloud Platform](https://docs.datadoghq.com/api/?lang=bash#google-cloud-platform)
+* [Datadog API Reference > Integrations > Google Cloud Platform](https://docs.datadoghq.com/api/v1/gcp-integration/)
 
 ## Attributes Reference
 

--- a/website/docs/r/integration_pagerduty.html.markdown
+++ b/website/docs/r/integration_pagerduty.html.markdown
@@ -181,4 +181,4 @@ The following arguments are supported:
 
 ### See also
 * [PagerDuty Integration Guide](https://www.pagerduty.com/docs/guides/datadog-integration-guide/)
-* [Datadog API Reference > Integrations > PagerDuty](https://docs.datadoghq.com/api/?lang=bash#pagerduty)
+* [Datadog API Reference > Integrations > PagerDuty](https://docs.datadoghq.com/api/v1/pagerduty-integration/)

--- a/website/docs/r/logs_custom_pipeline.html.markdown
+++ b/website/docs/r/logs_custom_pipeline.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # datadog_logs_custom_pipeline
 
-Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/?lang=python#logs-pipelines) resource, which is used to create and manage Datadog logs custom pipelines.
+Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/) resource, which is used to create and manage Datadog logs custom pipelines.
 
 
 ## Example Usage
@@ -28,7 +28,7 @@ resource "datadog_logs_custom_pipeline" "sample_pipeline" {
             target = "my_arithmetic"
             is_replace_missing = true
             name = "sample arithmetic processor"
-            is_enabled = true            
+            is_enabled = true
         }
     }
     processor {
@@ -187,13 +187,13 @@ The following arguments are supported:
   * `is_enabled` - (Optional, default = false) If the processor is enabled or not.
 * attribute_remapper
   * `sources` - (Required) List of source attributes or tags.
-  * `source_type` - (Required) Defines where the sources are from (log `attribute` or `tag`). 
+  * `source_type` - (Required) Defines where the sources are from (log `attribute` or `tag`).
   * `target` - (Required) Final `attribute` or `tag` name to remap the sources.
   * `target_type` - (Required) Defines if the target is a log `attribute` or `tag`.
   * `preserve_source` - (Optional, default = false) Remove or preserve the remapped source element.
   * `override_on_conflict` - (Optional, default = false) Override the target element if already set.
   * `name` - (Optional) Name of the processor
-  * `is_enabled` - (Optional, default = false) If the processor is enabled or not.  
+  * `is_enabled` - (Optional, default = false) If the processor is enabled or not.
 * category_processor
   * `target` - (Required) Name of the target attribute whose value is defined by the matching category.
   * `category` - (Required) List of filters to match or exclude a log with their corresponding name to assign a custom value to the log.
@@ -201,7 +201,7 @@ The following arguments are supported:
     * `filter`
       * `query` - (Required) Filter criteria of the category.
   * `name` - (Optional) Name of the processor
-  * `is_enabled` - (Optional, default = false) If the processor is enabled or not.  
+  * `is_enabled` - (Optional, default = false) If the processor is enabled or not.
 * date_remapper
   * `sources` - (Required) List of source attributes.
   * `name` - (Optional) Name of the processor.
@@ -255,7 +255,7 @@ The following arguments are supported:
   * `name` - (Optional) Name of the processor
   * `is_enabled` - (Optional, default = false) If the processor is enabled or not.
 * url_parser
-  * `sources` - (Required) List of source attributes. 
+  * `sources` - (Required) List of source attributes.
   * `target` - (Required) Name of the parent attribute that contains all the extracted details from the `sources`.
   * `normalize_ending_slashes` - (Optional, default = false) Normalize the ending slashes or not.
   * `name` - (Optional) Name of the processor
@@ -267,19 +267,19 @@ The following arguments are supported:
   * `name` - (Optional) Name of the processor
   * `is_enabled` - (Optional, default = false) If the processor is enabled or not.
 
-Even though some arguments are optional, we still recommend you to state **all** arguments in the resource to avoid 
+Even though some arguments are optional, we still recommend you to state **all** arguments in the resource to avoid
 unnecessary confusion.
 
 ## Import
 
 For the previously created custom pipelines, you can include them in Terraform with the `import` operation.
-Currently, Terraform requires you to explicitly create resources that match the existing pipelines to 
+Currently, Terraform requires you to explicitly create resources that match the existing pipelines to
 import them. Use ```terraform import <resource.name> <pipelineID>``` for each existing pipeline.
 
 ## Important Notes
 
 Each `datadog_logs_custom_pipeline` resource defines a complete pipeline. The order of the pipelines is maintained in
 a different resource [datadog_logs_pipeline_order](logs_pipeline_order.html#datadog_logs_pipeline_order).
-When creating a new pipeline, you need to **explicitly** add this pipeline to the `datadog_logs_pipeline_order` 
-resource to track the pipeline. Similarly, when a pipeline needs to be destroyed, remove its references from the 
+When creating a new pipeline, you need to **explicitly** add this pipeline to the `datadog_logs_pipeline_order`
+resource to track the pipeline. Similarly, when a pipeline needs to be destroyed, remove its references from the
 `datadog_logs_pipeline_order` resource.

--- a/website/docs/r/logs_index.html.markdown
+++ b/website/docs/r/logs_index.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # datadog_logs_index
 
-Provides a Datadog [Logs Index API](https://docs.datadoghq.com/api/?lang=python#logs-indexes) resource. This can be used to create and manage Datadog logs indexes.
+Provides a Datadog [Logs Index API](https://docs.datadoghq.com/api/v1/logs-indexes/) resource. This can be used to create and manage Datadog logs indexes.
 
 ## Example Usage
 
 A sample Datadog logs index resource definition. Note that at this point, it is not possible to create new logs indexes
-through Terraform, so the `name` field must match a name of an already existing index. If you want to keep the current 
+through Terraform, so the `name` field must match a name of an already existing index. If you want to keep the current
 state of the index, we suggest importing it (see below).
 
 ```hcl
@@ -58,10 +58,10 @@ The following arguments are supported:
 ## Import
 
 The current Datadog Terraform provider version does not support the creation and deletion of indexes.
-To manage the existing indexes, do `terraform import <datadog_logs_index.name> <indexName>` to import them to Terraform. 
+To manage the existing indexes, do `terraform import <datadog_logs_index.name> <indexName>` to import them to Terraform.
 If you create a resource which does not match the name of any existing index, `terraform apply` will throw `Not Found` error
-code. 
+code.
 
 ## Important Notes
 
-The order of indexes is maintained in the separated resource [datadog_logs_index_order](logs_index_order.html#datadog_logs_index_order). 
+The order of indexes is maintained in the separated resource [datadog_logs_index_order](logs_index_order.html#datadog_logs_index_order).

--- a/website/docs/r/logs_index_order.html.markdown
+++ b/website/docs/r/logs_index_order.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # datadog_logs_index_order
 
-Provides a Datadog [Logs Index API](https://docs.datadoghq.com/api/?lang=python#logs-indexes) resource. This can be used to manage the order of Datadog logs indexes.
+Provides a Datadog [Logs Index API](https://docs.datadoghq.com/api/v1/logs-indexes/) resource. This can be used to manage the order of Datadog logs indexes.
 
 ## Example Usage
 
@@ -28,11 +28,11 @@ resource "datadog_logs_index_order" "sample_index_order" {
 
 The following arguments are supported:
 
-* `name` - (Required) The unique name of the index order resource. 
+* `name` - (Required) The unique name of the index order resource.
 * `indexes` - (Required) The index resource list. Logs are tested against the query filter of each index one by one following the order of the list.
 
 ## Import
 
-The current Datadog Terraform provider version does not support the creation and deletion of index orders. 
+The current Datadog Terraform provider version does not support the creation and deletion of index orders.
 Do `terraform import <datadog_logs_index_order.name> <name>` to import index order to Terraform. There must be at
 most one `datadog_logs_index_order` resource.

--- a/website/docs/r/logs_integration_pipeline.html.markdown
+++ b/website/docs/r/logs_integration_pipeline.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # datadog_logs_integration_pipeline
 
-Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/?lang=python#logs-pipelines) resource to manage
+Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/) resource to manage
 the [integrations](https://docs.datadoghq.com/logs/log_collection/?tab=tcpussite).
 
-Integration pipelines are the pipelines that are automatically installed for your organization when sending the logs with 
-specific sources. You don't need to maintain or update these types of pipelines. Keeping them as resources, however, 
-allows you to manage the order of your pipelines by referencing them in your 
+Integration pipelines are the pipelines that are automatically installed for your organization when sending the logs with
+specific sources. You don't need to maintain or update these types of pipelines. Keeping them as resources, however,
+allows you to manage the order of your pipelines by referencing them in your
 [datadog_logs_pipeline_order](logs_pipeline_order.html#datadog_logs_pipeline_order) resource. If you don't need the
 `pipeline_order` feature, this resource declaration can be omitted.
 
@@ -33,4 +33,4 @@ resource "datadog_logs_integration_pipeline" "python" {
 
 ## Import
 
-```terraform import <resource.name> <pipelineID>``` 
+```terraform import <resource.name> <pipelineID>```

--- a/website/docs/r/logs_pipeline_order.html.markdown
+++ b/website/docs/r/logs_pipeline_order.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # datadog_logs_pipeline_order
 
-Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/?lang=python#logs-pipelines) resource, which is used to manage Datadog log pipelines order.
+Provides a Datadog [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/) resource, which is used to manage Datadog log pipelines order.
 
 
 ## Example Usage
@@ -31,20 +31,20 @@ resource "datadog_logs_pipeline_order" "sample_pipeline_order" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name attribute in the resource `datadog_logs_pipeline_order` needs to be unique. It's recommended to use the same value as the resource `NAME`. 
-No related field is available in  [Logs Pipeline API](https://docs.datadoghq.com/api/?lang=python#get-pipeline-order).
+* `name` - (Required) The name attribute in the resource `datadog_logs_pipeline_order` needs to be unique. It's recommended to use the same value as the resource `NAME`.
+No related field is available in  [Logs Pipeline API](https://docs.datadoghq.com/api/v1/logs-pipelines/#get-pipeline-orderr).
 * `pipelines` - (Required) The pipeline IDs list. The order of pipeline IDs in this attribute defines the overall pipeline order for logs.
 
 ## Attributes Reference
 
-* `pipelines` - The `pipelines` list contains the IDs of resources created and imported by the 
-[datadog_logs_custom_pipeline](logs_custom_pipeline.html#datadog_logs_custom_pipeline) and 
+* `pipelines` - The `pipelines` list contains the IDs of resources created and imported by the
+[datadog_logs_custom_pipeline](logs_custom_pipeline.html#datadog_logs_custom_pipeline) and
 [datadog_logs_integration_pipeline](logs_integration_pipeline.html#datadog_logs_integration_pipeline).
 Updating the order of pipelines in this list reflects the application order of the pipelines. You cannot delete or create pipeline by deleting or adding IDs to this list.
 
 ## Import
 
-There must be at most one `datadog_logs_pipeline_order` resource. Pipeline order creation is not supported from logs config API. 
+There must be at most one `datadog_logs_pipeline_order` resource. Pipeline order creation is not supported from logs config API.
 You can import the `datadog_logs_pipeline_order` or create a pipeline order (which is actually doing the update operation).
 
 ```

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -50,7 +50,7 @@ resource "datadog_monitor" "foo" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the monitor. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/?lang=python#create-a-monitor) page. The available options are below. **Note**: The monitor type cannot be changed after a monitor is created.
+* `type` - (Required) The type of the monitor. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor) page. The available options are below. **Note**: The monitor type cannot be changed after a monitor is created.
     * `metric alert`
     * `service check`
     * `event alert`
@@ -59,7 +59,7 @@ The following arguments are supported:
     * `log alert`
 * `name` - (Required) Name of Datadog monitor
 * `query` - (Required) The monitor query to notify on. Note this is not the same query you see in the UI and
-    the syntax is different depending on the monitor `type`, please see the [API Reference](https://docs.datadoghq.com/api/?lang=python#create-a-monitor) for details. **Warning:** `terraform plan` won't perform any validation of the query contents.
+    the syntax is different depending on the monitor `type`, please see the [API Reference](https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor) for details. **Warning:** `terraform plan` won't perform any validation of the query contents.
 * `message` - (Required) A message to include with notifications for this monitor.
     Email notifications can be sent to specific users by using the same '@username' notation as events.
 * `escalation_message` - (Optional) A message to include with a re-notification. Supports the '@username'

--- a/website/docs/r/service_level_objective.html.markdown
+++ b/website/docs/r/service_level_objective.html.markdown
@@ -73,14 +73,14 @@ resource "datadog_service_level_objective" "bar" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the service level objective. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/?lang=python#create-a-service-level-objective) page. Available options to choose from are:
+* `type` - (Required) The type of the service level objective. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/v1/service-level-objectives/#create-a-slo-object) page. Available options to choose from are:
     * `metric`
     * `monitor`
 * `name` - (Required) Name of Datadog service level objective
 * `description` - (Optional) A description of this service level objective.
 * `tags` (Optional) A list of tags to associate with your service level objective. This can help you categorize and filter service level objectives in the service level objectives page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
 * `thresholds` - (Required) - A list of thresholds and targets that define the service level objectives from the provided SLIs.
-    * `timeframe` (Required) - the time frame for the objective. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/?lang=python#create-a-service-level-objective) page. Available options to choose from are:
+    * `timeframe` (Required) - the time frame for the objective. The mapping from these types to the types found in the Datadog Web UI can be found in the Datadog API [documentation](https://docs.datadoghq.com/api/v1/service-level-objectives/#create-a-slo-object) page. Available options to choose from are:
         * `7d`
         * `30d`
         * `90d`


### PR DESCRIPTION
Update the docs to use the latest version of the api documentation links. Most redirected properly, but there were a few, such as the integration ones, that went directly to the API Homepage instead. 

This also removes trailing whitespace for these doc files. 
Also the lambda_arn resource was documented but missing from the sidebar, this adds it in. 