### PR TITLE
Safely access index field

### DIFF
--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -2533,9 +2533,13 @@ func buildDatadogWidgetFieldSort(terraformWidgetFieldSort map[string]interface{}
 
 func buildTerraformLogStreamDefinition(datadogDefinition datadogV1.LogStreamWidgetDefinition) map[string]interface{} {
 	terraformDefinition := map[string]interface{}{}
-	// Required params
-	terraformDefinition["indexes"] = *datadogDefinition.Indexes
 	// Optional params
+
+	// Indexes is the recommended required field, but we still allow setting logsets instead for backwards compatibility
+	if v, ok := datadogDefinition.GetIndexesOk(); ok {
+		terraformDefinition["indexes"] = *v
+	}
+
 	if v, ok := datadogDefinition.GetLogsetOk(); ok {
 		terraformDefinition["logset"] = *v
 	}


### PR DESCRIPTION
The newly added `indexes` field to the log_stream widget schema was being directly accessed, this PR first checks if it exists, adding a safety layer to prevent panics. 

Fixes #534 

I was able to reproduce this by creating a dashboard with a logstream widget using the provider version 2.7.0 like so:

```resource "datadog_dashboard" "free_dashboard" {
  title         = "Test Log Stream Dashboard"
  description   = "Created using the Datadog provider in Terraform"
  layout_type   = "free"
  is_read_only  = false

  widget {
    log_stream_definition {
      logset = "19"
      query = "error"
      columns = ["core_host", "core_service", "tag_source"]
    }
    layout = {
      height = 36
      width = 32
      x = 5
      y = 51
    }
  }
}
```

which leads to a terraform state not having `indexes` set. Then upgrading to 2.8.0 and running a terraform apply, which was trying to directly access this field and throwing an error on refreshing/reading existing resources. 