### PR TITLE
Fix indent in datadog_monitor

### DIFF
--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -188,6 +188,6 @@ resource "datadog_monitor" "bar" {
   type = "composite"
   message = "This is a message"
 
-	query = "${datadog_monitor.foo.id} || ${datadog_synthetics_test.foo.monitor_id}"
+  query = "${datadog_monitor.foo.id} || ${datadog_synthetics_test.foo.monitor_id}"
 }
 ```


### PR DESCRIPTION
Correct indent on the `datadog_monitor` in document.

![image](https://user-images.githubusercontent.com/4465795/84985750-4d579a00-b178-11ea-90e2-2f3923890063.png)
