### PR TITLE
Deprecate pagerduty integration

### DIFF
--- a/datadog/resource_datadog_integration_pagerduty.go
+++ b/datadog/resource_datadog_integration_pagerduty.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -15,11 +16,12 @@ var integrationPdMutex = sync.Mutex{}
 
 func resourceDatadogIntegrationPagerduty() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDatadogIntegrationPagerdutyCreate,
-		Read:   resourceDatadogIntegrationPagerdutyRead,
-		Exists: resourceDatadogIntegrationPagerdutyExists,
-		Update: resourceDatadogIntegrationPagerdutyUpdate,
-		Delete: resourceDatadogIntegrationPagerdutyDelete,
+		DeprecationMessage: "This resource is deprecated. You can use datadog_integration_pagerduty_service_object resources directly once the integration is activated",
+		Create:             resourceDatadogIntegrationPagerdutyCreate,
+		Read:               resourceDatadogIntegrationPagerdutyRead,
+		Exists:             resourceDatadogIntegrationPagerdutyExists,
+		Update:             resourceDatadogIntegrationPagerdutyUpdate,
+		Delete:             resourceDatadogIntegrationPagerdutyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -206,15 +208,7 @@ func resourceDatadogIntegrationPagerdutyUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceDatadogIntegrationPagerdutyDelete(d *schema.ResourceData, meta interface{}) error {
-	providerConf := meta.(*ProviderConfiguration)
-	client := providerConf.CommunityClient
-
-	integrationPdMutex.Lock()
-	defer integrationPdMutex.Unlock()
-
-	if err := client.DeleteIntegrationPD(); err != nil {
-		return translateClientError(err, "error deleting PagerDuty integration")
-	}
+	log.Printf("Deleting the pagerduty integration isn't safe, please don't use this resource anymore")
 
 	return nil
 }

--- a/website/docs/r/integration_pagerduty.html.markdown
+++ b/website/docs/r/integration_pagerduty.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # datadog_integration_pagerduty
 
-Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration.
+Provides a Datadog - PagerDuty resource. This can be used to create and manage Datadog - PagerDuty integration. This resource is deprecated and should only be used for legacy purposes.
 
 ## Example Usage
 

--- a/website/docs/r/integration_pagerduty_service_object.html.markdown
+++ b/website/docs/r/integration_pagerduty_service_object.html.markdown
@@ -8,31 +8,17 @@ description: |-
 
 # datadog_integration_pagerduty_service_object
 
-Provides access to individual Service Objects of Datadog - PagerDuty integrations. Note that the Datadog - PagerDuty integration must be activated (either manually in the Datadog UI or by using [datadog_integration_pagerduty](/docs/providers/datadog/r/integration_pagerduty.html)) in order for this resource to be usable.
+Provides access to individual Service Objects of Datadog - PagerDuty integrations. Note that the Datadog - PagerDuty integration must be activated in the Datadog UI in order for this resource to be usable.
 
 ## Example Usage
 
 ```
-resource "datadog_integration_pagerduty" "pd" {
-  individual_services = true
-  schedules = [
-    "https://ddog.pagerduty.com/schedules/X123VF",
-    "https://ddog.pagerduty.com/schedules/X321XX"
-    ]
-  subdomain = "ddog"
-  api_token = "38457822378273432587234242874"
-}
-
 resource "datadog_integration_pagerduty_service_object" "testing_foo" {
-  # when creating the integration object for the first time, the service
-  # objects have to be created *after* the integration
-  depends_on = ["datadog_integration_pagerduty.pd"]
   service_name = "testing_foo"
   service_key  = "9876543210123456789"
 }
 
 resource "datadog_integration_pagerduty_service_object" "testing_bar" {
-  depends_on = ["datadog_integration_pagerduty.pd"]
   service_name = "testing_bar"
   service_key  = "54321098765432109876"
 }


### PR DESCRIPTION
The pagerduty integration is a legacy resource used when we didn't use
webhooks. It's a singleton, which means it doesn't fit properly into the
terraform model, each instance overriding the previous one. This
prevents its deletion, and deprecate it.

Closes #564 