### PR TITLE
Properly setup version.ProviderVersion when using goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X github.com/terraform-providers/terraform-provider-datadog/version.ProviderVersion={{.Version}}'
   goos:
     - freebsd
     - windows


### PR DESCRIPTION
This ensures that `version.ProviderVersion` is properly set even when building with `goreleaser`.